### PR TITLE
Allow `flex-shrink` to be set to 0.

### DIFF
--- a/mesop/component_helpers/style.py
+++ b/mesop/component_helpers/style.py
@@ -279,7 +279,7 @@ def to_style_proto(s: Style) -> pb.Style:
     flex_basis=s.flex_basis,
     flex_direction=s.flex_direction,
     flex_grow=s.flex_grow,
-    flex_shrink=s.flex_shrink,
+    flex_shrink=str(s.flex_shrink),
     flex_wrap=s.flex_wrap,
     font_family=s.font_family,
     font_size=_px_str(s.font_size),

--- a/mesop/protos/ui.proto
+++ b/mesop/protos/ui.proto
@@ -234,7 +234,7 @@ message Style {
     optional string flex_basis = 7;
     optional string flex_direction = 8;
     optional int32 flex_grow = 9;
-    optional int32 flex_shrink = 10;
+    optional string flex_shrink = 10;
     optional string flex_wrap = 11;
     optional string font_family = 45;
     optional string font_size = 12;


### PR DESCRIPTION
The `flex-shrink` css property could not be set to 0 since Mesop will ignore styles that are "empty".

Normally this is fine, but `flex-shrink` defaults to 1, which means the "empty" state will make `flex-shrink` equal to 1. This means that 0 cannot be set for `flex-shrink`.

To resolve this, we can change the date type to a string in the UI proto.

Example:

```
import mesop as me

@me.page(path="/flex_shrink")
def main():
  with me.box(style=me.Style(display="flex", flex_shrink="0")):
    me.text("Testing flex shrink")
```

Also here's a screenshot to check that the property is being set correctly:

<img width="1309" alt="Screenshot 2024-03-20 at 8 26 01 PM" src="https://github.com/google/mesop/assets/539889/7efc28a4-5c5b-405e-a275-24414a9c3734">

Fixes #69 
