### PR TITLE
Allow columns CSS property to accept int/str vals.

### DIFF
--- a/mesop/component_helpers/style.py
+++ b/mesop/component_helpers/style.py
@@ -173,7 +173,7 @@ class Style:
   box_sizing: str | None = None
   color: str | None = None
   column_gap: int | str | None = None
-  columns: int | None = None
+  columns: int | str | None = None
   cursor: str | None = None
   display: Literal[
     # precomposed values
@@ -273,7 +273,7 @@ def to_style_proto(s: Style) -> pb.Style:
     box_sizing=s.box_sizing,
     color=s.color,
     column_gap=_px_str(s.column_gap),
-    columns=s.columns,
+    columns=str(s.columns),
     cursor=s.cursor,
     display=s.display,
     flex_basis=s.flex_basis,

--- a/mesop/protos/ui.proto
+++ b/mesop/protos/ui.proto
@@ -228,7 +228,7 @@ message Style {
     optional string box_sizing = 47;
     optional string color = 4;
     optional string column_gap = 33;
-    optional int32 columns = 5;
+    optional string columns = 5;
     optional string cursor = 46;
     optional string display = 6;
     optional string flex_basis = 7;


### PR DESCRIPTION
The columns property allows int/strs according to
https://developer.mozilla.org/en-US/docs/Web/CSS/columns

# Example code

To test this change, I tested out the following code.

```
import mesop as me

@me.page(path="/columns")
def main():
  with me.box(style=me.Style(columns="150px 3")):
    me.text("first_column")
    me.text("second_column")

  with me.box(style=me.Style(columns=2)):
    me.text("first_column")
    me.text("second_column")
```

# Example of columns defined using strings

<img width="1312" alt="Screenshot 2024-03-27 at 3 55 24 PM" src="https://github.com/google/mesop/assets/539889/db87f3b0-7c5d-4b43-a986-42eb612389de">

# Example of columns defined using ints

<img width="1311" alt="Screenshot 2024-03-27 at 3 55 47 PM" src="https://github.com/google/mesop/assets/539889/03f534ec-11d7-4ca5-a0f4-0f350423ce0b">

# Note

I also tried to update the columns component in labs.layout.py, but ran into an issue there trying to change the field definition to int | str. So for now, just left it as int.

This led to this error: `Mesop Internal Error: ('Unhandled param type', int | str, 'field_name', 'columns')`

Which leads to: mesop/mesop/editor/component_configs.py

It's probably related to the logic around here. Seems like we handle the int | str | None case, but not int | str.

```
    elif param_type is str or (
      # special case, for int|str|None (used for styles, e.g. pixel value), use str
      args
      and len(args) == 3
      and args[0] is int
      and args[1] is str
      and args[2] is NoneType
    ):
```

Fixes #79