### PR TITLE
Switch to ipv6 host

### DIFF
--- a/mesop/cli/cli.py
+++ b/mesop/cli/cli.py
@@ -102,7 +102,7 @@ def main(argv: Sequence[str]):
     log_startup(port=port())
     logging.getLogger("werkzeug").setLevel(logging.WARN)
 
-  flask_app.run(host="0.0.0.0", port=port(), use_reloader=False)
+  flask_app.run(host="::", port=port(), use_reloader=False)
 
 
 if __name__ == "__main__":

--- a/mesop/cli/dev_cli.py
+++ b/mesop/cli/dev_cli.py
@@ -40,7 +40,7 @@ def main(argv: Sequence[str]):
   print("Starting dev server...")
   dev_server.configure_dev_server(flask_app)
   flask_app.debug = True
-  flask_app.run(host="0.0.0.0", port=port(), use_reloader=False)
+  flask_app.run(host="::", port=port(), use_reloader=False)
 
 
 if __name__ == "__main__":

--- a/mesop/server/colab_run.py
+++ b/mesop/server/colab_run.py
@@ -31,7 +31,7 @@ def colab_run(*, port: int = 32123, prod_mode: bool = False):
   log_startup(port=port)
 
   def run_flask_app():
-    flask_app.run(host="0.0.0.0", port=port, use_reloader=False)
+    flask_app.run(host="::", port=port, use_reloader=False)
 
   # Launch Flask in background thread so we don't hog up the main thread
   # for regular Colab usage.

--- a/mesop/server/wsgi_app.py
+++ b/mesop/server/wsgi_app.py
@@ -18,7 +18,7 @@ class App:
 
   def run(self):
     log_startup(port=port())
-    self._flask_app.run(host="0.0.0.0", port=port(), use_reloader=False)
+    self._flask_app.run(host="::", port=port(), use_reloader=False)
 
 
 def create_app(


### PR DESCRIPTION
Why? Running Colab (internally) requires IPv6, which isn't currently supported when using "0.0.0.0"

Using `::` ensures that this will work for for both IPv6 and IPv4 environments, according to:
- https://stackoverflow.com/a/21689979

Background:
- https://superuser.com/questions/515379/what-is-the-difference-between-and-0-0-0-0-from-the-netstat-an-output
- https://en.wikipedia.org/wiki/0.0.0.0?useskin=vector

Closes https://github.com/google/mesop/issues/102