### PR TITLE
Add simple chat widget function.

### DIFF
--- a/docs/components/chat.md
+++ b/docs/components/chat.md
@@ -1,0 +1,13 @@
+## Overview
+
+Chat component is a quick way to create a simple chat interface. Chat is part of [Mesop Labs](../guides/labs.md).
+
+## Examples
+
+```python
+--8<-- "mesop/examples/chat.py"
+```
+
+## API
+
+::: mesop.labs.chat.chat

--- a/mesop/examples/__init__.py
+++ b/mesop/examples/__init__.py
@@ -1,4 +1,5 @@
 from mesop.examples import buttons as buttons
+from mesop.examples import chat as chat
 from mesop.examples import columns as columns
 from mesop.examples import composite as composite
 from mesop.examples import docs as docs

--- a/mesop/examples/chat.py
+++ b/mesop/examples/chat.py
@@ -1,0 +1,40 @@
+import random
+import time
+
+import mesop as me
+import mesop.labs as mel
+
+
+@me.page(path="/chat", title="Lorem Ipsum Chat")
+def page():
+  mel.chat(
+    lorem_ipsum_chat, title="Lorem Ipsum Chat", bot_user="Lorem Ipsum Bot"
+  )
+
+
+def lorem_ipsum_chat(input: str, history: list[mel.ChatMessage]):
+  lines = [
+    (
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, "
+      "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+    ),
+    "Laoreet sit amet cursus sit amet dictum sit amet.",
+    "At lectus urna duis convallis.",
+    "A pellentesque sit amet porttitor eget.",
+    "Mauris nunc congue nisi vitae suscipit tellus mauris a diam.",
+    "Aliquet lectus proin nibh nisl condimentum id.",
+    "Integer malesuada nunc vel risus commodo viverra maecenas accumsan.",
+    "Tempor id eu nisl nunc mi.",
+    "Id consectetur purus ut faucibus pulvinar.",
+    "Mauris pharetra et ultrices neque ornare.",
+    "Facilisis magna etiam tempor orci.",
+    "Mauris pharetra et ultrices neque.",
+    "Sit amet facilisis magna etiam tempor orci.",
+    "Amet consectetur adipiscing elit pellentesque habitant morbi tristique.",
+    "Egestas erat imperdiet sed euismod.",
+    "Tincidunt praesent semper feugiat nibh sed pulvinar proin gravida.",
+    "Habitant morbi tristique senectus et netus et malesuada.",
+  ]
+  for line in random.sample(lines, random.randint(3, len(lines) - 1)):
+    time.sleep(0.3)
+    yield line + " "

--- a/mesop/examples/e2e/chat_test.ts
+++ b/mesop/examples/e2e/chat_test.ts
@@ -1,0 +1,45 @@
+import {test, expect} from '@playwright/test';
+
+test('Chat UI can send messages and display responses', async ({page}) => {
+  // Increase the default time out since this test is slow and has multiple steps.
+  test.setTimeout(30000);
+
+  await page.goto('/chat');
+
+  // Test that we can send a message.
+  await page.locator('//input').fill('Lorem ipsum');
+  // Need to wait for the input state to be saved before clicking.
+  await page.waitForTimeout(2000);
+  await page.getByRole('button', {name: 'Send prompt'}).click();
+  await expect(
+    page.getByRole('button', {name: 'Processing prompt...'}),
+  ).toBeAttached({timeout: 3000});
+  await expect(page.locator('//input')).toHaveValue('');
+  expect(page.locator('//div[text()="Lorem ipsum"]')).toHaveCount(1);
+  await expect(page.locator('//div[text()="Lorem Ipsum Bot"]')).toHaveCount(1);
+  // Since the text is random, we just check that some text is displayed.
+  await expect(page.locator('//mesop-markdown')).toContainText(/[\w]+/);
+
+  // The chat example's transform function has a fake delay per line. The number of
+  // lines are also randomly. So we need a longer delay.
+  await expect(page.getByRole('button', {name: 'Send prompt'})).toBeAttached({
+    timeout: 10000,
+  });
+
+  // Test that we can send more than one message.
+  await page.locator('//input').fill('Dolor sit amet');
+  // Need to wait for the input state to be saved before clicking.
+  await page.waitForTimeout(2000);
+  await page.getByRole('button', {name: 'Send prompt'}).click();
+  await expect(
+    page.getByRole('button', {name: 'Processing prompt...'}),
+  ).toBeAttached({timeout: 3000});
+  await expect(page.locator('//input')).toHaveValue('');
+  await expect(page.locator('//div[text()="Dolor sit amet"]')).toHaveCount(1);
+  await expect(page.locator('//div[text()="Lorem Ipsum Bot"]')).toHaveCount(2);
+  // Since the text is random, we just check that some text is displayed.
+  await expect(page.locator('//mesop-markdown')).toContainText([
+    /[\w]+/,
+    /[\w]+/,
+  ]);
+});

--- a/mesop/labs/__init__.py
+++ b/mesop/labs/__init__.py
@@ -1,2 +1,4 @@
+from mesop.labs.chat import ChatMessage as ChatMessage
+from mesop.labs.chat import chat as chat
 from mesop.labs.io import text_io as text_io
 from mesop.labs.text_to_image import text_to_image as text_to_image

--- a/mesop/labs/chat.py
+++ b/mesop/labs/chat.py
@@ -1,0 +1,227 @@
+import time
+from dataclasses import dataclass
+from typing import Callable, Generator, Literal
+
+import mesop as me
+
+Role = Literal["user", "assistant"]
+
+_ROLE_USER = "user"
+_ROLE_ASSISTANT = "assistant"
+
+_BOT_USER_DEFAULT = "mesop-bot"
+
+_COLOR_BACKGROUND = "#f0f4f8"
+_COLOR_CHAT_BUBBLE_YOU = "#f2f2f2"
+_COLOR_CHAT_BUBBLE_BOT = "#ebf3ff"
+
+_DEFAULT_PADDING = me.Padding(top=20, left=20, right=20, bottom=20)
+_DEFAULT_BORDER_SIDE = me.BorderSide(
+  width="1px", style="solid", color="#ececec"
+)
+
+_LABEL_BUTTON = "Send prompt"
+_LABEL_BUTTON_IN_PROGRESS = "Processing prompt..."
+_LABEL_INPUT = "Enter your prompt"
+
+_STYLE_APP_CONTAINER = me.Style(
+  background=_COLOR_BACKGROUND,
+  display="grid",
+  height="100vh",
+  grid_template_columns="repeat(1, 1fr)",
+)
+_STYLE_TITLE = me.Style(padding=me.Padding(left=10))
+_STYLE_CHAT_BOX = me.Style(
+  height="100%",
+  overflow_y="scroll",
+  padding=_DEFAULT_PADDING,
+  margin=me.Margin(bottom=20),
+  border_radius="10px",
+  border=me.Border(
+    left=_DEFAULT_BORDER_SIDE,
+    right=_DEFAULT_BORDER_SIDE,
+    top=_DEFAULT_BORDER_SIDE,
+    bottom=_DEFAULT_BORDER_SIDE,
+  ),
+)
+_STYLE_CHAT_INPUT = me.Style(width="100%")
+_STYLE_CHAT_INPUT_BOX = me.Style(padding=me.Padding(top=30))
+_STYLE_CHAT_BUBBLE_NAME = me.Style(
+  font_weight="bold",
+  font_size="12px",
+  padding=me.Padding(left=15, right=15, bottom=5),
+)
+_STYLE_CHAT_BUBBLE_PLAINTEXT = me.Style(margin=me.Margin(top=15, bottom=15))
+
+
+def _make_style_chat_ui_container(has_title: bool) -> me.Style:
+  """Generates styles for chat UI container depending on if there is a title or not.
+
+  Args:
+    has_title: Whether the Chat UI is display a title or not.
+  """
+  return me.Style(
+    display="grid",
+    grid_template_columns="repeat(1, 1fr)",
+    grid_template_rows="1fr 14fr 1fr" if has_title else "5fr 1fr",
+    margin=me.Margin(top=0, bottom=0, left="auto", right="auto"),
+    width="min(1024px, 100%)",
+    height="100vh",
+    background="#fff",
+    box_shadow=(
+      "0 3px 1px -2px #0003, 0 2px 2px #00000024, 0 1px 5px #0000001f"
+    ),
+    padding=_DEFAULT_PADDING,
+  )
+
+
+def _make_style_chat_bubble_wrapper(role: Role) -> me.Style:
+  """Generates styles for chat bubble position.
+
+  Args:
+    role: Chat bubble alignment depends on the role
+  """
+  align_items = "end" if role == _ROLE_USER else "start"
+  return me.Style(
+    display="flex",
+    flex_direction="column",
+    align_items=align_items,
+  )
+
+
+def _make_chat_bubble_style(role: Role) -> me.Style:
+  """Generates styles for chat bubble.
+
+  Args:
+    role: Chat bubble background color depends on the role
+  """
+  background = (
+    _COLOR_CHAT_BUBBLE_YOU if role == _ROLE_USER else _COLOR_CHAT_BUBBLE_BOT
+  )
+  return me.Style(
+    width="80%",
+    font_size="13px",
+    background=background,
+    border_radius="15px",
+    padding=me.Padding(right=15, left=15, bottom=3),
+    margin=me.Margin(bottom=10),
+    border=me.Border(
+      left=_DEFAULT_BORDER_SIDE,
+      right=_DEFAULT_BORDER_SIDE,
+      top=_DEFAULT_BORDER_SIDE,
+      bottom=_DEFAULT_BORDER_SIDE,
+    ),
+  )
+
+
+@dataclass(kw_only=True)
+class ChatMessage:
+  """Chat message metadata."""
+
+  role: Role = "user"
+  content: str = ""
+
+
+@me.stateclass
+class State:
+  input: str
+  output: list[ChatMessage]
+  in_progress: bool = False
+
+
+def on_input_update(State):
+  """Generic on text input handler that saves input to State using the given key.
+
+  This helper only works if you have one state instance. If use multiple state classes
+  with this helper, then only the last event handler will be stored. For more info, see
+  https://google.github.io/mesop/guides/troubleshooting/#avoid-using-closure-variables-in-event-handler.
+  """
+
+  def _on_update(e: me.InputEvent):
+    state = me.state(State)
+    setattr(state, e.key.split("-", 1)[0], e.value)
+
+  return _on_update
+
+
+def chat(
+  transform: Callable[
+    [str, list[ChatMessage]], Generator[str, None, None] | str
+  ],
+  *,
+  title: str | None = None,
+  bot_user: str = _BOT_USER_DEFAULT,
+):
+  """Creates a simple chat UI which takes in a prompt and chat history and returns a
+  response to the prompt.
+
+  This function creates event handlers for text input and output operations
+  using the provided function `transform` to process the input and generate the output.
+
+  Args:
+    transform: Function that takes in a prompt and chat history and returns a response to the prompt.
+    title: Headline text to display at the top of the UI.
+    bot_user: Name of your bot / assistant.
+  """
+  state = me.state(State)
+
+  def on_click(e: me.ClickEvent):
+    state = me.state(State)
+    if state.in_progress or not state.input:
+      return
+    input = state.input
+    state.input = ""
+    yield
+
+    output = state.output
+    if output is None:
+      output = []
+    output.append(ChatMessage(role=_ROLE_USER, content=input))
+    state.in_progress = True
+    yield
+
+    start_time = time.time()
+    output_message = transform(input, state.output)
+    assistant_message = ChatMessage(role=_ROLE_ASSISTANT)
+    output.append(assistant_message)
+    state.output = output
+    for content in output_message:
+      assistant_message.content += content
+      # TODO: 0.25 is an abitrary choice. In the future, consider making this adjustable.
+      if (time.time() - start_time) >= 0.25:
+        start_time = time.time()
+        yield
+    state.in_progress = False
+    yield
+
+  with me.box(style=_STYLE_APP_CONTAINER):
+    with me.box(style=_make_style_chat_ui_container(bool(title))):
+      if title:
+        me.text(title, type="headline-5", style=_STYLE_TITLE)
+      with me.box(style=_STYLE_CHAT_BOX):
+        for msg in state.output:
+          with me.box(style=_make_style_chat_bubble_wrapper(msg.role)):
+            if msg.role == _ROLE_ASSISTANT:
+              me.text(bot_user, style=_STYLE_CHAT_BUBBLE_NAME)
+            with me.box(style=_make_chat_bubble_style(msg.role)):
+              if msg.role == _ROLE_USER:
+                me.text(msg.content, style=_STYLE_CHAT_BUBBLE_PLAINTEXT)
+              else:
+                me.markdown(msg.content)
+
+      with me.box(style=_STYLE_CHAT_INPUT_BOX):
+        me.input(
+          label=_LABEL_INPUT,
+          # Workaround: update key to clear input.
+          key=f"input-{len(state.output)}",
+          on_input=on_input_update(State),
+          style=_STYLE_CHAT_INPUT,
+        )
+        with me.box():
+          me.button(
+            _LABEL_BUTTON_IN_PROGRESS if state.in_progress else _LABEL_BUTTON,
+            color="primary",
+            type="flat",
+            disabled=state.in_progress,
+            on_click=on_click,
+          )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - I/O:
           - Text I/O: components/text_io.md
           - Text To Image: components/text_to_image.md
+          - Chat: components/chat.md
       - Layout:
           - Box: components/box.md
           - Sidenav: components/sidenav.md

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 8,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
Also adds an example usage of the chat widget.

## Functionality

- Provide title
- Provide a bot name
- Can stream chat response
- When generating a response, new prompts cannot
- be sent
- Relatively responsive to device width

## Minor issues

- Chat window does not scroll along with new text being added.
- Text input does not clear when pressing entering a prompt.

## Screenshots

### Desktop

<img width="1312" alt="Screenshot 2024-04-04 at 3 10 10 PM" src="https://github.com/google/mesop/assets/539889/c53e813d-6a52-40de-830f-20a2e6861820">

### Mobile

<img width="399" alt="Screenshot 2024-04-04 at 3 10 29 PM" src="https://github.com/google/mesop/assets/539889/34076d07-de9d-4a2b-87c5-59f1d6f75c70">

### Tablet

<img width="776" alt="Screenshot 2024-04-04 at 3 10 56 PM" src="https://github.com/google/mesop/assets/539889/1c2229a9-22f6-4b2b-bbc3-09fad239561b">


