### PR TITLE
Add basic table with Pandas support

### DIFF
--- a/build_defs/defaults.bzl
+++ b/build_defs/defaults.bzl
@@ -96,3 +96,7 @@ THIRD_PARTY_PY_PYTEST = [
 THIRD_PARTY_PY_MYPY_PROTOBUF = [
     requirement("mypy-protobuf"),
 ]
+
+THIRD_PARTY_PY_PANDAS = [
+    requirement("pandas"),
+]

--- a/build_defs/requirements.txt
+++ b/build_defs/requirements.txt
@@ -9,3 +9,4 @@ pydantic==1.10 --no-binary pydantic
 libcst==1.1.0
 
 matplotlib # only used for example
+pandas  # only used for example

--- a/build_defs/requirements_lock.txt
+++ b/build_defs/requirements_lock.txt
@@ -581,6 +581,7 @@ numpy==1.26.3 \
     # via
     #   contourpy
     #   matplotlib
+    #   pandas
 packaging==23.2 \
     --hash=sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5 \
     --hash=sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
@@ -591,6 +592,37 @@ packaging==23.2 \
 paginate==0.5.6 \
     --hash=sha256:5e6007b6a9398177a7e1648d04fdd9f8c9766a1a945bceac82f1929e8c78af2d
     # via mkdocs-material
+pandas==2.2.1 \
+    --hash=sha256:04f6ec3baec203c13e3f8b139fb0f9f86cd8c0b94603ae3ae8ce9a422e9f5bee \
+    --hash=sha256:06cf591dbaefb6da9de8472535b185cba556d0ce2e6ed28e21d919704fef1a9e \
+    --hash=sha256:0ab90f87093c13f3e8fa45b48ba9f39181046e8f3317d3aadb2fffbb1b978572 \
+    --hash=sha256:0f573ab277252ed9aaf38240f3b54cfc90fff8e5cab70411ee1d03f5d51f3944 \
+    --hash=sha256:101d0eb9c5361aa0146f500773395a03839a5e6ecde4d4b6ced88b7e5a1a6403 \
+    --hash=sha256:11940e9e3056576ac3244baef2fedade891977bcc1cb7e5cc8f8cc7d603edc89 \
+    --hash=sha256:1ba21b1d5c0e43416218db63037dbe1a01fc101dc6e6024bcad08123e48004ab \
+    --hash=sha256:4aa1d8707812a658debf03824016bf5ea0d516afdea29b7dc14cf687bc4d4ec6 \
+    --hash=sha256:4acf681325ee1c7f950d058b05a820441075b0dd9a2adf5c4835b9bc056bf4fb \
+    --hash=sha256:53680dc9b2519cbf609c62db3ed7c0b499077c7fefda564e330286e619ff0dd9 \
+    --hash=sha256:739cc70eaf17d57608639e74d63387b0d8594ce02f69e7a0b046f117974b3019 \
+    --hash=sha256:76f27a809cda87e07f192f001d11adc2b930e93a2b0c4a236fde5429527423be \
+    --hash=sha256:7d2ed41c319c9fb4fd454fe25372028dfa417aacb9790f68171b2e3f06eae8cd \
+    --hash=sha256:88ecb5c01bb9ca927ebc4098136038519aa5d66b44671861ffab754cae75102c \
+    --hash=sha256:8df8612be9cd1c7797c93e1c5df861b2ddda0b48b08f2c3eaa0702cf88fb5f88 \
+    --hash=sha256:94e714a1cca63e4f5939cdce5f29ba8d415d85166be3441165edd427dc9f6bc0 \
+    --hash=sha256:9bd8a40f47080825af4317d0340c656744f2bfdb6819f818e6ba3cd24c0e1397 \
+    --hash=sha256:9d1265545f579edf3f8f0cb6f89f234f5e44ba725a34d86535b1a1d38decbccc \
+    --hash=sha256:a935a90a76c44fe170d01e90a3594beef9e9a6220021acfb26053d01426f7dc2 \
+    --hash=sha256:af5d3c00557d657c8773ef9ee702c61dd13b9d7426794c9dfeb1dc4a0bf0ebc7 \
+    --hash=sha256:c2ce852e1cf2509a69e98358e8458775f89599566ac3775e70419b98615f4b06 \
+    --hash=sha256:c38ce92cb22a4bea4e3929429aa1067a454dcc9c335799af93ba9be21b6beb51 \
+    --hash=sha256:c391f594aae2fd9f679d419e9a4d5ba4bce5bb13f6a989195656e7dc4b95c8f0 \
+    --hash=sha256:c70e00c2d894cb230e5c15e4b1e1e6b2b478e09cf27cc593a11ef955b9ecc81a \
+    --hash=sha256:df0c37ebd19e11d089ceba66eba59a168242fc6b7155cba4ffffa6eccdfb8f16 \
+    --hash=sha256:e97fbb5387c69209f134893abc788a6486dbf2f9e511070ca05eed4b930b1b02 \
+    --hash=sha256:f02a3a6c83df4026e55b63c1f06476c9aa3ed6af3d89b4f04ea656ccdaaaa359 \
+    --hash=sha256:f821213d48f4ab353d20ebc24e4faf94ba40d76680642fb7ce2ea31a3ad94f9b \
+    --hash=sha256:f9d3558d263073ed95e46f4650becff0c5e1ffe0fc3a015de3c79283dfbdb3df
+    # via -r build_defs/requirements.txt
 pathspec==0.11.2 \
     --hash=sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20 \
     --hash=sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3
@@ -685,7 +717,9 @@ protobuf==4.25.0 \
     --hash=sha256:c40ff8f00aa737938c5378d461637d15c442a12275a81019cc2fef06d81c9419 \
     --hash=sha256:cf21faba64cd2c9a3ed92b7a67f226296b10159dbb8fbc5e854fc90657d908e4 \
     --hash=sha256:d94a33db8b7ddbd0af7c467475fb9fde0c705fb315a8433c0e2020942b863a1f
-    # via mypy-protobuf
+    # via
+    #   -r build_defs/requirements.txt
+    #   mypy-protobuf
 pydantic==1.10.0 \
     --hash=sha256:026427be4e251f876e7519a63af37ae5ebb8b593ca8b02180bdc6becd1ea4ef4 \
     --hash=sha256:134b4fd805737496ce4efd24ce2f8da0e08c66dcfc054fee1a19673eec780f2c \
@@ -748,6 +782,11 @@ python-dateutil==2.8.2 \
     # via
     #   ghp-import
     #   matplotlib
+    #   pandas
+pytz==2024.1 \
+    --hash=sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812 \
+    --hash=sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319
+    # via pandas
 pyyaml==6.0.1 \
     --hash=sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5 \
     --hash=sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc \
@@ -925,6 +964,10 @@ typing-inspect==0.9.0 \
     --hash=sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f \
     --hash=sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78
     # via libcst
+tzdata==2024.1 \
+    --hash=sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd \
+    --hash=sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252
+    # via pandas
 urllib3==2.0.7 \
     --hash=sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84 \
     --hash=sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -1,0 +1,13 @@
+## Overview
+
+Table allows the user to render an [Angular Material table component](https://material.angular.io/components/table/overview) from a Pandas data frame.
+
+## Examples
+
+```python
+--8<-- "mesop/components/table/e2e/table_app.py"
+```
+
+## API
+
+::: mesop.components.table.table.table

--- a/mesop/BUILD
+++ b/mesop/BUILD
@@ -18,6 +18,7 @@ py_library(
     visibility = ["//build_defs:mesop_users"],
     deps = [
         # REF(//scripts/scaffold_component.py):insert_component_import
+        "//mesop/components/table:py",
         "//mesop/components/sidenav:py",
         "//mesop/components/video:py",
         "//mesop/components/audio:py",

--- a/mesop/__init__.py
+++ b/mesop/__init__.py
@@ -100,6 +100,7 @@ from mesop.components.slider.slider import (
 from mesop.components.slider.slider import (
   slider as slider,
 )
+from mesop.components.table.table import table as table
 from mesop.components.text.text import text as text
 from mesop.components.tooltip.tooltip import tooltip as tooltip
 from mesop.components.video.video import video as video

--- a/mesop/cli/BUILD
+++ b/mesop/cli/BUILD
@@ -1,4 +1,4 @@
-load("//build_defs:defaults.bzl", "THIRD_PARTY_PY_ABSL_PY", "THIRD_PARTY_PY_MATPLOTLIB", "THIRD_PARTY_PY_PYTEST", "py_binary", "py_library", "py_test")
+load("//build_defs:defaults.bzl", "THIRD_PARTY_PY_ABSL_PY", "THIRD_PARTY_PY_MATPLOTLIB", "THIRD_PARTY_PY_PANDAS", "THIRD_PARTY_PY_PYTEST", "py_binary", "py_library", "py_test")
 
 package(
     default_visibility = ["//build_defs:mesop_internal"],
@@ -13,7 +13,7 @@ COMMON_DEPS = [
     "//mesop",  # Keep dep to ensure the entire Mesop library is loaded.
     "//mesop/exceptions",
     "//mesop/runtime",
-] + THIRD_PARTY_PY_ABSL_PY + THIRD_PARTY_PY_MATPLOTLIB  # Used for /examples
+] + THIRD_PARTY_PY_ABSL_PY + THIRD_PARTY_PY_MATPLOTLIB + THIRD_PARTY_PY_PANDAS  # Used for /examples
 
 exports_files(["cli.py"])
 

--- a/mesop/components/table/BUILD
+++ b/mesop/components/table/BUILD
@@ -1,0 +1,9 @@
+load("//mesop/components:defs.bzl", "mesop_component")
+
+package(
+    default_visibility = ["//build_defs:mesop_internal"],
+)
+
+mesop_component(
+    name = "table",
+)

--- a/mesop/components/table/e2e/BUILD
+++ b/mesop/components/table/e2e/BUILD
@@ -1,0 +1,13 @@
+load("//build_defs:defaults.bzl", "py_library")
+
+package(
+    default_visibility = ["//build_defs:mesop_examples"],
+)
+
+py_library(
+    name = "e2e",
+    srcs = glob(["*.py"]),
+    deps = [
+        "//mesop",
+    ],
+)

--- a/mesop/components/table/e2e/__init__.py
+++ b/mesop/components/table/e2e/__init__.py
@@ -1,0 +1,1 @@
+from . import table_app as table_app

--- a/mesop/components/table/e2e/table_app.py
+++ b/mesop/components/table/e2e/table_app.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+
+import mesop as me
+
+
+@me.page(path="/components/table/e2e/table_app")
+def app():
+  with me.box(
+    style=me.Style(
+      padding=me.Padding(top=10, right=10, left=10, bottom=10), width=500
+    )
+  ):
+    df = pd.DataFrame(
+      data={
+        "NA": [pd.NA, pd.NA, pd.NA],
+        "Bools": [True, False, np.bool_(True)],
+        "Ints": [101, 90, np.int64(-55)],
+        "Floats": [2.3, 4.5, np.float64(-3.000000003)],
+        "Strings": ["Hello", "World", "!"],
+        "DateTimes": [
+          pd.Timestamp("20180310"),
+          pd.Timestamp("20230310"),
+          datetime(2023, 1, 1, 12, 12, 1),
+        ],
+      }
+    )
+    me.table(df)

--- a/mesop/components/table/e2e/table_test.ts
+++ b/mesop/components/table/e2e/table_test.ts
@@ -1,0 +1,69 @@
+import {test, expect} from '@playwright/test';
+
+test('test', async ({page}) => {
+  await page.goto('/components/table/e2e/table_app');
+
+  // Check headers rendered.
+  await expect(page.locator(`//th[contains(text(), "NA")]`)).toBeAttached();
+  await expect(page.locator(`//th[contains(text(), "Bools")]`)).toBeAttached();
+  await expect(page.locator(`//th[contains(text(), "Ints")]`)).toBeAttached();
+  await expect(page.locator(`//th[contains(text(), "Floats")]`)).toBeAttached();
+  await expect(
+    page.locator(`//th[contains(text(), "Strings")]`),
+  ).toBeAttached();
+  await expect(
+    page.locator(`//th[contains(text(), "DateTimes")]`),
+  ).toBeAttached();
+
+  // Spot check that expected table values are rendered.
+  await expect(
+    page.locator(
+      `//td[contains(@class, "mat-column-NA") and contains(text(), "<NA>")]`,
+    ),
+  ).toHaveCount(3);
+  await expect(
+    page.locator(
+      `//td[contains(@class, "mat-column-Bools") and contains(text(), "False")]`,
+    ),
+  ).toBeAttached();
+  await expect(
+    page.locator(
+      `//td[contains(@class, "mat-column-Ints") and contains(text(), "-55")]`,
+    ),
+  ).toBeAttached();
+  await expect(
+    page.locator(
+      `//td[contains(@class, "mat-column-Floats") and contains(text(), "4.5")]`,
+    ),
+  ).toBeAttached();
+  await expect(
+    page.locator(
+      `//td[contains(@class, "mat-column-Strings") and contains(text(), "World")]`,
+    ),
+  ).toBeAttached();
+  await expect(
+    page.locator(
+      `//td[contains(@class, "mat-column-DateTimes") and contains(text(), "2018-03-10 00:00:00")]`,
+    ),
+  ).toBeAttached();
+
+  // Check expected number of rows rendered.
+  await expect(
+    page.locator(`//td[contains(@class, "mat-column-NA")]`),
+  ).toHaveCount(3);
+  await expect(
+    page.locator(`//td[contains(@class, "mat-column-Bools")]`),
+  ).toHaveCount(3);
+  await expect(
+    page.locator(`//td[contains(@class, "mat-column-Ints")]`),
+  ).toHaveCount(3);
+  await expect(
+    page.locator(`//td[contains(@class, "mat-column-Floats")]`),
+  ).toHaveCount(3);
+  await expect(
+    page.locator(`//td[contains(@class, "mat-column-Strings")]`),
+  ).toHaveCount(3);
+  await expect(
+    page.locator(`//td[contains(@class, "mat-column-DateTimes")]`),
+  ).toHaveCount(3);
+});

--- a/mesop/components/table/table.ng.html
+++ b/mesop/components/table/table.ng.html
@@ -1,0 +1,23 @@
+<table
+  mat-table
+  [dataSource]="config().getDataSourceList()"
+  class="mat-elevation-z8"
+>
+  @for(colummn of config().getDisplayedColumnsList(); track index; let index =
+  $index) {
+  <ng-container matColumnDef="{{ config().getDisplayedColumnsList()[index] }}">
+    <th mat-header-cell *matHeaderCellDef>
+      {{ config().getDisplayedColumnsList()[index] }}
+    </th>
+    <td mat-cell *matCellDef="let element">
+      {{ element.getRowMap().get(config().getDisplayedColumnsList()[index]) }}
+    </td>
+  </ng-container>
+  }
+
+  <tr mat-header-row *matHeaderRowDef="config().getDisplayedColumnsList()"></tr>
+  <tr
+    mat-row
+    *matRowDef="let row; columns: config().getDisplayedColumnsList();"
+  ></tr>
+</table>

--- a/mesop/components/table/table.proto
+++ b/mesop/components/table/table.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+package mesop.components.table;
+
+message TableRow {
+    map<string, string> row = 1;
+}
+
+message TableType {
+    repeated string displayed_columns = 1;
+    repeated TableRow data_source = 2;
+}

--- a/mesop/components/table/table.py
+++ b/mesop/components/table/table.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+import mesop.components.table.table_pb2 as table_pb
+from mesop.component_helpers import insert_component, register_native_component
+
+
+# Don't include type hint since Pydantic can't properly type check the Pandas data
+# frame. In addition, we don't want to include Pandas as a dependency into Mesop.
+@register_native_component
+def table(data_frame: Any):
+  """
+  This function creates a table from Pandas data frame
+
+  Args:
+      data_frame: Pandas data frame.
+  """
+  insert_component(
+    type_name="table",
+    proto=table_pb.TableType(
+      displayed_columns=list(data_frame.columns),
+      data_source=_to_data_source(data_frame),
+    ),
+  )
+
+
+def _to_data_source(data_frame) -> list[table_pb.TableRow]:
+  """Convert Pandas data frame for display as a table.
+
+  All values will be converted to strings for display purposes on the frontend.
+  """
+  columns = list(data_frame.columns)
+  data = []
+  for df_row in data_frame.itertuples():
+    data.append(
+      table_pb.TableRow(
+        row={col_name: str(getattr(df_row, col_name)) for col_name in columns}
+      )
+    )
+  return data

--- a/mesop/components/table/table.ts
+++ b/mesop/components/table/table.ts
@@ -1,0 +1,31 @@
+import {MatTableModule} from '@angular/material/table';
+import {Component, Input} from '@angular/core';
+import {TableType} from 'mesop/mesop/components/table/table_jspb_proto_pb/mesop/components/table/table_pb';
+import {Channel} from '../../web/src/services/channel';
+import {
+  Key,
+  Type,
+} from 'mesop/mesop/protos/ui_jspb_proto_pb/mesop/protos/ui_pb';
+
+@Component({
+  selector: 'mesop-table',
+  templateUrl: 'table.ng.html',
+  standalone: true,
+  imports: [MatTableModule],
+})
+export class TableComponent {
+  @Input({required: true}) type!: Type;
+  @Input() key!: Key;
+  private _config!: TableType;
+  constructor(private readonly channel: Channel) {}
+
+  ngOnChanges() {
+    this._config = TableType.deserializeBinary(
+      this.type.getValue() as unknown as Uint8Array,
+    );
+  }
+
+  config(): TableType {
+    return this._config;
+  }
+}

--- a/mesop/example_index.py
+++ b/mesop/example_index.py
@@ -25,4 +25,5 @@ import mesop.components.image.e2e as image_e2e
 import mesop.components.audio.e2e as audio_e2e
 import mesop.components.video.e2e as video_e2e
 import mesop.components.sidenav.e2e as sidenav_e2e
+import mesop.components.table.e2e as table_e2e
 # REF(//scripts/scaffold_component.py):insert_component_e2e_import_export

--- a/mesop/examples/BUILD
+++ b/mesop/examples/BUILD
@@ -14,6 +14,7 @@ py_library(
     srcs = glob(["*.py"]),
     deps = [
         # REF(//scripts/scaffold_component.py):insert_component_e2e_import
+        "//mesop/components/table/e2e",
         "//mesop/components/sidenav/e2e",
         "//mesop/components/video/e2e",
         "//mesop/components/audio/e2e",

--- a/mesop/web/src/component_renderer/BUILD
+++ b/mesop/web/src/component_renderer/BUILD
@@ -14,6 +14,7 @@ ng_module(
     ]) + ["component_renderer.css"],
     deps = [
         # REF(//scripts/scaffold_component.py):insert_component_import
+        "//mesop/components/table:ng",
         "//mesop/components/sidenav:ng",
         "//mesop/components/video:ng",
         "//mesop/components/audio:ng",

--- a/mesop/web/src/component_renderer/type_to_component.ts
+++ b/mesop/web/src/component_renderer/type_to_component.ts
@@ -1,3 +1,4 @@
+import {TableComponent} from '../../../components/table/table';
 import {SidenavComponent} from '../../../components/sidenav/sidenav';
 import {VideoComponent} from '../../../components/video/video';
 import {AudioComponent} from '../../../components/audio/audio';
@@ -50,6 +51,7 @@ export class UserDefinedComponent implements BaseComponent {
 }
 
 export const typeToComponent = {
+  'table': TableComponent,
   'sidenav': SidenavComponent,
   'video': VideoComponent,
   'audio': AudioComponent,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
           - Icon: components/icon.md
           - Progress bar: components/progress_bar.md
           - Progress spinner: components/progress_spinner.md
+          - Table: components/table.md
           - Tooltip: components/tooltip.md
       - Styling:
           - Style: components/style.md

--- a/packages.bzl
+++ b/packages.bzl
@@ -45,6 +45,7 @@ _MATERIAL_ENTRY_POINTS = [
     "divider",
     "radio",
     "slider",
+    "table",
 ]
 
 # Forked from: https://github.com/angular/components/blob/ff67a416d19e9237607605bec0d7cc372025387f/packages.bzl
@@ -124,6 +125,7 @@ MDC_PACKAGES = [
     "@material/tab-indicator",
     "@material/tab-scroller",
     "@material/textfield",
+    "@material/table",
     "@material/theme",
     "@material/tooltip",
     "@material/top-app-bar",


### PR DESCRIPTION
This change adds a barebones Angular table that can take a Pandas DataFrame as input.

Current issues:

- Table headers not bold
- Style support (haven't looked into this yet)

Example usage:

```
import pandas
import mesop as me

@me.page(path="/components/table/e2e/table_app")
def app():
  with me.box(
    style=me.Style(
      padding=me.Padding(top=10, right=10, left=10, bottom=10), width=500
    )
  ):
    d = {
      "Bools": [True, False],
      "Ints": [3, 4],
      "Floats": [2.3, 4.5],
      "Strings": ["Hello", "World"],
    }
    df = pandas.DataFrame(data=d)
    me.table(me.TableDataSourcePandasDataFrame(df=df))
```

<img width="579" alt="Screenshot 2024-04-04 at 6 13 26 PM" src="https://github.com/google/mesop/assets/539889/f711ddbb-29a6-4e43-95b1-83d3020f6129">


Issue Reference: #75