### PR TITLE
Add __version__ attribute so Mesop users can easily tell which version of Mesop they're using

### DIFF
--- a/docs/internal/publishing.md
+++ b/docs/internal/publishing.md
@@ -4,7 +4,7 @@ Follow these instructions for releasing a new version of Mesop publicly via PyPI
 
 ## Bump the version
 
-Update `mesop/pip_package/setup.py` version field to the next version.
+Update `mesop/version.py` by incrementing the version number. We follow semver.
 
 ## Install locally
 

--- a/mesop/BUILD
+++ b/mesop/BUILD
@@ -17,6 +17,7 @@ py_library(
     ],
     visibility = ["//build_defs:mesop_users"],
     deps = [
+        "//mesop/pip_package:version",
         # REF(//scripts/scaffold_component.py):insert_component_import
         "//mesop/components/table:py",
         "//mesop/components/sidenav:py",

--- a/mesop/__init__.py
+++ b/mesop/__init__.py
@@ -113,9 +113,12 @@ from mesop.events import (
 )
 from mesop.features import page as page
 from mesop.key import Key as Key
+from mesop.pip_package.version import VERSION
 from mesop.runtime import runtime
 from mesop.server.colab_run import colab_run as colab_run
 from mesop.server.wsgi_app import wsgi_app
+
+__version__ = VERSION
 
 
 class _WsgiAppModule(types.ModuleType):

--- a/mesop/pip_package/BUILD
+++ b/mesop/pip_package/BUILD
@@ -9,6 +9,12 @@ package(
 
 licenses(["notice"])
 
+py_library(
+    name = "version",
+    srcs = ["version.py"],
+    visibility = ["//build_defs:mesop_internal"],
+)
+
 sh_binary(
     name = "build_pip_package",
     srcs = ["build_pip_package.sh"],
@@ -19,6 +25,7 @@ sh_binary(
         "requirements.txt",
         "setup.cfg",
         "setup.py",
+        "version.py",
         ":deterministic_tar_gz",
         "//mesop",  # Main Mesop target
         "//mesop/bin",  # CLI binary

--- a/mesop/pip_package/build_pip_package.sh
+++ b/mesop/pip_package/build_pip_package.sh
@@ -79,6 +79,7 @@ build() (
   mv -f "mesop/pip_package/requirements.txt" .
   mv -f "mesop/pip_package/setup.cfg" .
   mv -f "mesop/pip_package/setup.py" .
+  mv -f "mesop/pip_package/version.py" .
   rm -rf "mesop/pip_package"
 
   rm -f mesop/mesop  # bazel py_binary sh wrapper

--- a/mesop/pip_package/setup.py
+++ b/mesop/pip_package/setup.py
@@ -13,8 +13,13 @@
 # limitations under the License.
 # ==============================================================================
 
-
 from setuptools import find_packages, setup
+
+# Intentionally do not import "from mesop.pip_package.version"
+# because this will drag in other modules through mesop/__init__.py
+# incl. third-party packages like Flask which don't exist
+# in this script environment.
+from version import VERSION
 
 
 def get_required_packages():
@@ -35,7 +40,7 @@ CONSOLE_SCRIPTS = [
 
 setup(
   name="mesop",
-  version="0.4.1",
+  version=VERSION,
   description="Build UIs in Python",
   long_description=get_readme(),
   url="https://github.com/google/mesop",

--- a/mesop/pip_package/version.py
+++ b/mesop/pip_package/version.py
@@ -1,0 +1,6 @@
+"""Contains the version string."""
+
+VERSION = "0.4.1"
+
+if __name__ == "__main__":
+  print(VERSION)


### PR DESCRIPTION
Fixes #104 

pip_package is a bit strangely organized (it was modeled after https://github.com/tensorflow/tensorboard/tree/master/tensorboard/pip_package)