### PR TITLE
Make MesopException the parent class of more specific mesop exceptions & expose as public API

### DIFF
--- a/mesop/__init__.py
+++ b/mesop/__init__.py
@@ -111,6 +111,18 @@ from mesop.events import (
 from mesop.events import (
   InputEvent as InputEvent,
 )
+from mesop.exceptions import (
+  MesopDeveloperException as MesopDeveloperException,
+)
+from mesop.exceptions import (
+  MesopException as MesopException,
+)
+from mesop.exceptions import (
+  MesopInternalException as MesopInternalException,
+)
+from mesop.exceptions import (
+  MesopUserException as MesopUserException,
+)
 from mesop.features import page as page
 from mesop.key import Key as Key
 from mesop.runtime import runtime

--- a/mesop/exceptions/__init__.py
+++ b/mesop/exceptions/__init__.py
@@ -5,16 +5,16 @@ class MesopException(Exception):
   pass
 
 
-class MesopUserException(Exception):
+class MesopUserException(MesopException):
   def __str__(self):
     return f"**User Error:** {super().__str__()}"
 
 
-class MesopInternalException(Exception):
+class MesopInternalException(MesopException):
   def __str__(self):
     return f"**Mesop Internal Error:** {super().__str__()}"
 
 
-class MesopDeveloperException(Exception):
+class MesopDeveloperException(MesopException):
   def __str__(self):
     return f"**Mesop Developer Error:** {super().__str__()}"


### PR DESCRIPTION
Closes #111.

This makes it possible for Mesop app developers to catch Mesop exceptions and having them all subclass from a single Mesop exception class also makes it more convenient to catch any kind of Mesop exception.