### PR TITLE
Add on table cell click event

### DIFF
--- a/mesop/__init__.py
+++ b/mesop/__init__.py
@@ -100,6 +100,9 @@ from mesop.components.slider.slider import (
 from mesop.components.slider.slider import (
   slider as slider,
 )
+from mesop.components.table.table import (
+  TableClickEvent as TableClickEvent,
+)
 from mesop.components.table.table import table as table
 from mesop.components.text.text import text as text
 from mesop.components.tooltip.tooltip import tooltip as tooltip

--- a/mesop/components/table/e2e/table_app.py
+++ b/mesop/components/table/e2e/table_app.py
@@ -6,25 +6,48 @@ import pandas as pd
 import mesop as me
 
 
+@me.stateclass
+class State:
+  selected_cell: str = "No cell selected."
+
+
+df = pd.DataFrame(
+  data={
+    "NA": [pd.NA, pd.NA, pd.NA],
+    "Index": [3, 2, 1],
+    "Bools": [True, False, np.bool_(True)],
+    "Ints": [101, 90, np.int64(-55)],
+    "Floats": [2.3, 4.5, np.float64(-3.000000003)],
+    "Strings": ["Hello", "World", "!"],
+    "Date Times": [
+      pd.Timestamp("20180310"),
+      pd.Timestamp("20230310"),
+      datetime(2023, 1, 1, 12, 12, 1),
+    ],
+  }
+)
+
+
 @me.page(path="/components/table/e2e/table_app")
 def app():
+  state = me.state(State)
+
+  with me.box(style=me.Style(padding=me.Padding.all(10), width=500)):
+    me.table(df, on_click=on_click)
+
   with me.box(
     style=me.Style(
-      padding=me.Padding(top=10, right=10, left=10, bottom=10), width=500
+      background="#ececec",
+      margin=me.Margin.all(10),
+      padding=me.Padding.all(10),
     )
   ):
-    df = pd.DataFrame(
-      data={
-        "NA": [pd.NA, pd.NA, pd.NA],
-        "Bools": [True, False, np.bool_(True)],
-        "Ints": [101, 90, np.int64(-55)],
-        "Floats": [2.3, 4.5, np.float64(-3.000000003)],
-        "Strings": ["Hello", "World", "!"],
-        "DateTimes": [
-          pd.Timestamp("20180310"),
-          pd.Timestamp("20230310"),
-          datetime(2023, 1, 1, 12, 12, 1),
-        ],
-      }
-    )
-    me.table(df)
+    me.text(state.selected_cell)
+
+
+def on_click(e: me.TableClickEvent):
+  state = me.state(State)
+  state.selected_cell = (
+    f"Selected cell at col {e.col_index} and row {e.row_index} "
+    f"with value {str(df.iat[e.row_index, e.col_index])}"
+  )

--- a/mesop/components/table/e2e/table_test.ts
+++ b/mesop/components/table/e2e/table_test.ts
@@ -1,10 +1,11 @@
 import {test, expect} from '@playwright/test';
 
-test('test', async ({page}) => {
+test('renders table', async ({page}) => {
   await page.goto('/components/table/e2e/table_app');
 
   // Check headers rendered.
   await expect(page.locator(`//th[contains(text(), "NA")]`)).toBeAttached();
+  await expect(page.locator(`//th[contains(text(), "Index")]`)).toBeAttached();
   await expect(page.locator(`//th[contains(text(), "Bools")]`)).toBeAttached();
   await expect(page.locator(`//th[contains(text(), "Ints")]`)).toBeAttached();
   await expect(page.locator(`//th[contains(text(), "Floats")]`)).toBeAttached();
@@ -12,7 +13,7 @@ test('test', async ({page}) => {
     page.locator(`//th[contains(text(), "Strings")]`),
   ).toBeAttached();
   await expect(
-    page.locator(`//th[contains(text(), "DateTimes")]`),
+    page.locator(`//th[contains(text(), "Date Times")]`),
   ).toBeAttached();
 
   // Spot check that expected table values are rendered.
@@ -21,6 +22,11 @@ test('test', async ({page}) => {
       `//td[contains(@class, "mat-column-NA") and contains(text(), "<NA>")]`,
     ),
   ).toHaveCount(3);
+  await expect(
+    page.locator(
+      `//td[contains(@class, "mat-column-Index") and contains(text(), "2")]`,
+    ),
+  ).toBeAttached();
   await expect(
     page.locator(
       `//td[contains(@class, "mat-column-Bools") and contains(text(), "False")]`,
@@ -43,13 +49,16 @@ test('test', async ({page}) => {
   ).toBeAttached();
   await expect(
     page.locator(
-      `//td[contains(@class, "mat-column-DateTimes") and contains(text(), "2018-03-10 00:00:00")]`,
+      `//td[contains(@class, "mat-column-Date-Times") and contains(text(), "2018-03-10 00:00:00")]`,
     ),
   ).toBeAttached();
 
   // Check expected number of rows rendered.
   await expect(
     page.locator(`//td[contains(@class, "mat-column-NA")]`),
+  ).toHaveCount(3);
+  await expect(
+    page.locator(`//td[contains(@class, "mat-column-Index")]`),
   ).toHaveCount(3);
   await expect(
     page.locator(`//td[contains(@class, "mat-column-Bools")]`),
@@ -64,6 +73,18 @@ test('test', async ({page}) => {
     page.locator(`//td[contains(@class, "mat-column-Strings")]`),
   ).toHaveCount(3);
   await expect(
-    page.locator(`//td[contains(@class, "mat-column-DateTimes")]`),
+    page.locator(`//td[contains(@class, "mat-column-Date-Times")]`),
   ).toHaveCount(3);
+});
+
+test('table cell click event triggered', async ({page}) => {
+  await page.goto('/components/table/e2e/table_app');
+  await page
+    .locator(
+      `//td[contains(@class, "mat-column-Ints") and contains(text(), "90")]`,
+    )
+    .click();
+  await expect(
+    page.getByText('Selected cell at col 3 and row 1 with value 90'),
+  ).toBeAttached();
 });

--- a/mesop/components/table/table.ng.html
+++ b/mesop/components/table/table.ng.html
@@ -9,8 +9,12 @@
     <th mat-header-cell *matHeaderCellDef>
       {{ config().getDisplayedColumnsList()[index] }}
     </th>
-    <td mat-cell *matCellDef="let element">
-      {{ element.getRowMap().get(config().getDisplayedColumnsList()[index]) }}
+    <td
+      mat-cell
+      (click)="onClickCell(element, index)"
+      *matCellDef="let element"
+    >
+      {{ element.getCellValuesList()[index] }}
     </td>
   </ng-container>
   }

--- a/mesop/components/table/table.proto
+++ b/mesop/components/table/table.proto
@@ -2,11 +2,27 @@ syntax = "proto2";
 
 package mesop.components.table;
 
+message TableClickEvent {
+    optional int64 row_index = 1;
+    optional int64 col_index = 2;
+}
+
 message TableRow {
-    map<string, string> row = 1;
+    // Pandas Index.
+    optional int64 index = 1;
+    // Column values are stored as a list corresponding to the `displayed_columns`
+    // field.
+    //
+    // This is done because the Pandas may change the column name in certain situations
+    // such as:
+    //
+    // - Naming a column `Index` which conflicts with the special Pandas `Index` column.
+    // - Naming a column with spaces, such as "Date Time"
+    repeated string cell_values = 2;
 }
 
 message TableType {
     repeated string displayed_columns = 1;
     repeated TableRow data_source = 2;
+    optional string on_table_click_event_handler_id = 3;
 }

--- a/mesop/components/table/table.py
+++ b/mesop/components/table/table.py
@@ -1,24 +1,66 @@
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Callable
 
 import mesop.components.table.table_pb2 as table_pb
-from mesop.component_helpers import insert_component, register_native_component
+from mesop.component_helpers import (
+  insert_component,
+  register_event_handler,
+  register_event_mapper,
+  register_native_component,
+)
+from mesop.events import MesopEvent
+
+
+@dataclass(kw_only=True)
+class TableClickEvent(MesopEvent):
+  """Event representing a click on the table component cell.
+
+  Attributes:
+      row_index: DataFrame row index of the clicked cell in the table.
+      col_index: DataFrame col index of the clicked cell in the table.
+      key (str): key of the component that emitted this event.
+  """
+
+  row_index: int
+  col_index: int
+
+
+def map_table_click_event(event, key):
+  click_event = table_pb.TableClickEvent()
+  click_event.ParseFromString(event.bytes_value)
+  return TableClickEvent(
+    key=key.key,
+    row_index=click_event.row_index,
+    col_index=click_event.col_index,
+  )
+
+
+register_event_mapper(TableClickEvent, map_table_click_event)
 
 
 # Don't include type hint since Pydantic can't properly type check the Pandas data
 # frame. In addition, we don't want to include Pandas as a dependency into Mesop.
 @register_native_component
-def table(data_frame: Any):
+def table(
+  data_frame: Any, *, on_click: Callable[[TableClickEvent], Any] | None = None
+):
   """
   This function creates a table from Pandas data frame
 
   Args:
       data_frame: Pandas data frame.
+      on_click: Triggered when a table cell is clicked. The [click event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click_event) is a native browser event.
   """
   insert_component(
     type_name="table",
     proto=table_pb.TableType(
       displayed_columns=list(data_frame.columns),
       data_source=_to_data_source(data_frame),
+      on_table_click_event_handler_id=register_event_handler(
+        on_click, event=TableClickEvent
+      )
+      if on_click
+      else "",
     ),
   )
 
@@ -27,13 +69,16 @@ def _to_data_source(data_frame) -> list[table_pb.TableRow]:
   """Convert Pandas data frame for display as a table.
 
   All values will be converted to strings for display purposes on the frontend.
+
+  The special Pandas `Index` column is included automatically, so we can refer back to
+  same cell on the server to handle user events.
   """
-  columns = list(data_frame.columns)
   data = []
-  for df_row in data_frame.itertuples():
+  for df_row in data_frame.itertuples(name=None):
     data.append(
       table_pb.TableRow(
-        row={col_name: str(getattr(df_row, col_name)) for col_name in columns}
+        index=df_row[0],
+        cell_values=[str(row) for row in df_row[1:]],
       )
     )
   return data

--- a/mesop/components/table/table.ts
+++ b/mesop/components/table/table.ts
@@ -1,8 +1,13 @@
 import {MatTableModule} from '@angular/material/table';
 import {Component, Input} from '@angular/core';
-import {TableType} from 'mesop/mesop/components/table/table_jspb_proto_pb/mesop/components/table/table_pb';
+import {
+  TableType,
+  TableRow,
+  TableClickEvent,
+} from 'mesop/mesop/components/table/table_jspb_proto_pb/mesop/components/table/table_pb';
 import {Channel} from '../../web/src/services/channel';
 import {
+  UserEvent,
   Key,
   Type,
 } from 'mesop/mesop/protos/ui_jspb_proto_pb/mesop/protos/ui_pb';
@@ -27,5 +32,20 @@ export class TableComponent {
 
   config(): TableType {
     return this._config;
+  }
+
+  onClickCell(row: TableRow, index: number): void {
+    // On cell click events, return the column and row indexes so we can refer back
+    // to the same cell on the server.
+    const userEvent = new UserEvent();
+    userEvent.setHandlerId(this.config().getOnTableClickEventHandlerId()!);
+    userEvent.setKey(this.key);
+    const clickEvent = new TableClickEvent();
+    clickEvent.setColIndex(index);
+    // Need to cast to number since the index field is optional, but it should never
+    // be null when this event is triggered.
+    clickEvent.setRowIndex(row.getIndex() as number);
+    userEvent.setBytesValue(clickEvent.serializeBinary());
+    this.channel.dispatch(userEvent);
   }
 }

--- a/mesop/protos/ui.proto
+++ b/mesop/protos/ui.proto
@@ -31,6 +31,7 @@ message UserEvent {
         double double_value = 7;
         int32 int_value = 8;
         NavigationEvent navigation = 6;
+        bytes bytes_value = 9;
     }
 }
 


### PR DESCRIPTION
The table cell click event will return the column name and row Index which will allow us to refer back to the same row or column in the Pandas data frame.

<img width="551" alt="Screenshot 2024-04-20 at 3 16 13 PM" src="https://github.com/google/mesop/assets/539889/ae0c59c3-b3a3-4822-a776-b08374f80b3f">

Ref: #118