### PR TITLE
Fix state serialization bug with pandas.DataFrame.

### DIFF
--- a/mesop/dataclass_utils/BUILD
+++ b/mesop/dataclass_utils/BUILD
@@ -1,4 +1,4 @@
-load("//build_defs:defaults.bzl", "THIRD_PARTY_PY_PYTEST", "py_library", "py_test")
+load("//build_defs:defaults.bzl", "THIRD_PARTY_PY_PANDAS", "THIRD_PARTY_PY_PYTEST", "py_library", "py_test")
 
 package(
     default_visibility = ["//build_defs:mesop_internal"],
@@ -16,5 +16,5 @@ py_library(
 py_test(
     name = "dataclass_utils_test",
     srcs = ["dataclass_utils_test.py"],
-    deps = [":dataclass_utils"] + THIRD_PARTY_PY_PYTEST,
+    deps = [":dataclass_utils"] + THIRD_PARTY_PY_PYTEST + THIRD_PARTY_PY_PANDAS,
 )

--- a/mesop/dataclass_utils/dataclass_utils_test.py
+++ b/mesop/dataclass_utils/dataclass_utils_test.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from mesop.dataclass_utils.dataclass_utils import (
@@ -24,6 +26,11 @@ class A:
   b: B = field(default_factory=B)
   list_b: list[B] = field(default_factory=list)
   strs: list[str] = field(default_factory=list)
+
+
+@dataclass
+class WithPandasDataFrame:
+  val: pd.DataFrame | None = None
 
 
 JSON_STR = """{"b": {"c": {"val": "<init>"}},
@@ -93,6 +100,33 @@ def test_serialize_dataclass():
   assert val == """{"b": {"c": {"val": "<init>"}}, "list_b": [], "strs": []}"""
 
 
+def test_serialize_pandas_dataframe():
+  df = pd.DataFrame(
+    data={
+      "NA": [pd.NA, pd.NA],
+      "Bools": [True, np.bool_(False)],
+      "Ints": [101, np.int64(-55)],
+      "Floats": [2.3, np.float64(-3.000000003)],
+      "Strings": ["Hello", "World"],
+      "DateTimes": [
+        pd.Timestamp("20180310"),
+        pd.Timestamp("20230310"),
+      ],
+    }
+  )
+
+  serialized_dataclass = serialize_dataclass(WithPandasDataFrame(val=df))
+
+  json_data = df.to_json(orient="table")
+  assert json_data is not None
+  assert (
+    serialized_dataclass
+    == '{"val": {"__pandas.DataFrame__": "'
+    + json_data.replace('"', '\\"')
+    + '"}}'
+  )
+
+
 def test_update_dataclass_from_json_nested_dataclass():
   b = B()
   update_dataclass_from_json(b, """{"c": {"val": "<init>"}}""")
@@ -111,6 +145,49 @@ def test_update_dataclass_from_json_list_nested_dataclass():
     B(c=C(val="2")),
   ]
   assert a.strs == ["a", "b"]
+
+
+def test_update_dataclass_with_pandas_dataframe():
+  serialized_dataclass = serialize_dataclass(
+    WithPandasDataFrame(
+      val=pd.DataFrame(
+        data={
+          "NA": [pd.NA, pd.NA],
+          "Bools": [True, np.bool_(False)],
+          "Ints": [101, np.int64(-55)],
+          "Floats": [2.3, np.float64(-3.000000003)],
+          "Strings": ["Hello", "World"],
+          "DateTimes": [
+            pd.Timestamp("20180310"),
+            pd.Timestamp("20230310"),
+          ],
+        }
+      )
+    )
+  )
+  pandas_dataframe_state = WithPandasDataFrame()
+
+  update_dataclass_from_json(pandas_dataframe_state, serialized_dataclass)
+
+  assert pandas_dataframe_state.val is not None
+  assert pandas_dataframe_state.val.equals(
+    pd.DataFrame(
+      data={
+        "NA": [
+          np.nan,
+          np.nan,
+        ],  # Note that these became np.nan instead of pd.NA.
+        "Bools": [True, np.bool_(False)],
+        "Ints": [101, np.int64(-55)],
+        "Floats": [2.3, np.float64(-3.000000003)],
+        "Strings": ["Hello", "World"],
+        "DateTimes": [
+          pd.Timestamp("20180310"),
+          pd.Timestamp("20230310"),
+        ],
+      }
+    )
+  )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To fix this issue we add custom JSON encoding and decoding logic.

For most accurate serialization/deserialization, we use Pandas's built in JSON serialization (via to_json) with the "table" strategy. This is more verbose, but provides enough metadata to deserialize as close as possible to the original DataFrame.

To deserialize we use `pandas.read_json` with `orient="table"`.

One difference I've noticed so far is that pandas.NA becomes np.nan.

Ref: #117