### PR TITLE
Make it so wide code examples do not overflow.

### DIFF
--- a/mesop/web/src/app/styles.scss
+++ b/mesop/web/src/app/styles.scss
@@ -98,3 +98,8 @@ body {
     width: 0;
   }
 }
+
+// Make it so wide code examples do not overflow. Instead show a horizontal scrollbar.
+mesop-markdown pre {
+  overflow-x: scroll;
+}


### PR DESCRIPTION
Instead show a horizontal scrollbar to remain within the boundaries of the box.

The scroll bar appears, so that is an improvement, but it kind of looks like the text gets cut off since the code mark up gets rendered on a white background, so there's no delineation of where the code block actually ends width wize.

Some example screen shots:

<img width="374" alt="Screenshot 2024-04-20 at 3 26 59 PM" src="https://github.com/google/mesop/assets/539889/4846c30f-67d5-49f2-8774-e3841df448a2">

<img width="374" alt="Screenshot 2024-04-20 at 3 26 36 PM" src="https://github.com/google/mesop/assets/539889/b0ac3103-7aa8-4c3c-b044-b283c031da7c">
