### PR TITLE
Fix setup_proto_py_modules.sh

### DIFF
--- a/scripts/setup_proto_py_modules.sh
+++ b/scripts/setup_proto_py_modules.sh
@@ -2,7 +2,9 @@
 bazel_bin_path=$(bazel info bazel-bin)
 
 touch "${bazel_bin_path}/mesop/__init__.py" && \
-touch "${bazel_bin_path}/generator/__init__.py" && \
 touch "${bazel_bin_path}/mesop/protos/__init__.py" && \
-touch "${bazel_bin_path}/mesop/components/__init__.py" &&
-find "${bazel_bin_path}/mesop/components/" -type d -exec touch {}/__init__.py \;
+touch "${bazel_bin_path}/mesop/components/__init__.py" && \
+find "${bazel_bin_path}/mesop/components/" -type d -exec touch {}/__init__.py \; && \
+# Purposefully have generator at the end since it's not always built and might error out
+# which isn't a big deal because VS Code can still type-check the rest of the codebase.
+touch "${bazel_bin_path}/generator/__init__.py";


### PR DESCRIPTION
@richard-to not sure if you've setup VS Code type-checking - there's [some instructions here](https://google.github.io/mesop/internal/development/#venv), but I just recently fixed it with this PR and this earlier docs fix: https://github.com/google/mesop/commit/11c8d36d98dbe2477c09224cd41ee22e2082ab15