### PR TITLE
Update default UI for radio component

### DIFF
--- a/mesop/components/defs.bzl
+++ b/mesop/components/defs.bzl
@@ -4,13 +4,14 @@ Bazel macro for defining an Mesop component, which includes the Python, client-s
 
 load("//build_defs:defaults.bzl", "ANGULAR_CORE_DEPS", "ANGULAR_MATERIAL_TS_DEPS", "jspb_proto_library", "ng_module", "proto_library", "py_library", "py_proto_library")
 
-def mesop_component(name, ng_deps = [], py_deps = []):
+def mesop_component(name, ng_deps = [], assets = [], py_deps = []):
     """
     Defines a new Mesop component which includes Python, client-side (TypeScript) and proto targets.
 
     Args:
         name (str): The name of the component. Must be in snake_case.
         ng_deps (list, optional): List of Angular dependencies for the component. Defaults to an empty list.
+        assets (list, optional): List of assets for the component. Defaults to an empty list.
         py_deps (list, optional): List of Python dependencies for the component. Defaults to an empty list.
     """
     jspb_proto_target = name + "_jspb_proto"
@@ -22,7 +23,7 @@ def mesop_component(name, ng_deps = [], py_deps = []):
         ]),
         assets = native.glob([
             "*.ng.html",
-        ]),
+        ]) + assets,
         deps = [
             ":" + jspb_proto_target,
             "//mesop/protos:ui_jspb_proto",

--- a/mesop/components/radio/BUILD
+++ b/mesop/components/radio/BUILD
@@ -1,4 +1,5 @@
 load("//mesop/components:defs.bzl", "mesop_component")
+load("//build_defs:defaults.bzl", "sass_binary")
 
 package(
     default_visibility = ["//build_defs:mesop_internal"],
@@ -6,4 +7,11 @@ package(
 
 mesop_component(
     name = "radio",
+    assets = [":radio.css"],
+)
+
+sass_binary(
+    name = "styles",
+    src = "radio.scss",
+    sourcemap = False,
 )

--- a/mesop/components/radio/radio.py
+++ b/mesop/components/radio/radio.py
@@ -47,7 +47,7 @@ def radio(
   options: Iterable[RadioOption] = (),
   on_change: Callable[[RadioChangeEvent], Any] | None = None,
   color: Literal["primary", "accent", "warn"] | None = None,
-  label_position: Literal["before", "after"] = "before",
+  label_position: Literal["before", "after"] = "after",
   value: str = "",
   disabled: bool = False,
   key: str | None = None,

--- a/mesop/components/radio/radio.scss
+++ b/mesop/components/radio/radio.scss
@@ -1,0 +1,3 @@
+mat-radio-group {
+  display: block;
+}

--- a/mesop/components/radio/radio.ts
+++ b/mesop/components/radio/radio.ts
@@ -10,6 +10,7 @@ import {Channel} from '../../web/src/services/channel';
 
 @Component({
   templateUrl: 'radio.ng.html',
+  styleUrl: 'radio.css',
   standalone: true,
   imports: [MatRadioModule],
 })

--- a/mesop/examples/__init__.py
+++ b/mesop/examples/__init__.py
@@ -1,5 +1,6 @@
 from mesop.examples import buttons as buttons
 from mesop.examples import chat as chat
+from mesop.examples import checkbox_and_radio as checkbox_and_radio
 from mesop.examples import columns as columns
 from mesop.examples import composite as composite
 from mesop.examples import docs as docs

--- a/mesop/examples/checkbox_and_radio.py
+++ b/mesop/examples/checkbox_and_radio.py
@@ -1,0 +1,15 @@
+import mesop as me
+
+
+@me.page(path="/checkbox_and_radio")
+def page():
+  me.text("Checkbox and radio")
+  me.radio(
+    options=[
+      me.RadioOption(label="Option 1"),
+      me.RadioOption(label="Option 2"),
+    ]
+  )
+  me.checkbox("Checkbox 1")
+  me.checkbox("Checkbox 2")
+  me.text("More text")


### PR DESCRIPTION
- Changes default label position to "after" which is what [Angular Material defaults](https://github.com/angular/components/blob/4719da2c34bee87095a2368334715e415f18a4c3/src/material/radio/radio.ts#L121) to and what checkbox currently defaults to.
- Sets the display type to `block` as this is the most common behavior.

I will open a separate PR so that radio (& other components) can be styled, so Mesop app developers can override this.