### PR TITLE
Improve DevEx for hot reloading: show errors from hot reloading right away

### DIFF
--- a/mesop/cli/cli.py
+++ b/mesop/cli/cli.py
@@ -49,11 +49,16 @@ def monitor_stdin():
       try:
         reset_runtime()
         execute_main_module()
-        hot_reload_finished()
+
       except Exception as e:
+        runtime().add_loading_error(
+          pb.ServerError(exception=str(e), traceback=format_traceback())
+        )
         logging.log(
           logging.ERROR, "Could not hot reload due to error:", exc_info=e
         )
+      finally:
+        hot_reload_finished()
 
 
 def main(argv: Sequence[str]):


### PR DESCRIPTION
Closes #47 

This fixes two related issues:

- Previously, if you went to page "/" and there was an error hot reloading (i.e. in `execute_main_module`) you would wait for  [wait_for_hot_reload](https://github.com/google/mesop/blob/f176cce48515552914df1a124ced0bc1a183e049/mesop/runtime/runtime.py#L64) before seeing the error. Now, you will see the error message right away.
- Catches error message and displays it in UI ([similar](https://github.com/google/mesop/blob/f176cce48515552914df1a124ced0bc1a183e049/mesop/cli/cli.py#L72) to the first time execute module)