### PR TITLE
Deflakes chat_test.ts

### DIFF
--- a/mesop/examples/e2e/chat_test.ts
+++ b/mesop/examples/e2e/chat_test.ts
@@ -4,16 +4,13 @@ test('Chat UI can send messages and display responses', async ({page}) => {
   // Increase the default time out since this test is slow and has multiple steps.
   test.setTimeout(30000);
 
-  await page.goto('/chat');
+  await page.goto('/testing/minimal_chat');
 
   // Test that we can send a message.
   await page.locator('//input').fill('Lorem ipsum');
   // Need to wait for the input state to be saved before clicking.
   await page.waitForTimeout(2000);
   await page.getByRole('button', {name: 'Send prompt'}).click();
-  await expect(
-    page.getByRole('button', {name: 'Processing prompt...'}),
-  ).toBeAttached({timeout: 5000});
   await expect(page.locator('//input')).toHaveValue('');
   expect(page.locator('//div[text()="Lorem ipsum"]')).toHaveCount(1);
   await expect(page.locator('//div[text()="Lorem Ipsum Bot"]')).toHaveCount(1);
@@ -31,9 +28,6 @@ test('Chat UI can send messages and display responses', async ({page}) => {
   // Need to wait for the input state to be saved before clicking.
   await page.waitForTimeout(2000);
   await page.getByRole('button', {name: 'Send prompt'}).click();
-  await expect(
-    page.getByRole('button', {name: 'Processing prompt...'}),
-  ).toBeAttached({timeout: 3000});
   await expect(page.locator('//input')).toHaveValue('');
   await expect(page.locator('//div[text()="Dolor sit amet"]')).toHaveCount(1);
   await expect(page.locator('//div[text()="Lorem Ipsum Bot"]')).toHaveCount(2);

--- a/mesop/examples/testing/__init__.py
+++ b/mesop/examples/testing/__init__.py
@@ -1,3 +1,6 @@
 from mesop.examples.testing import (
   conditional_event_handler as conditional_event_handler,
 )
+from mesop.examples.testing import (
+  minimal_chat as minimal_chat,
+)

--- a/mesop/examples/testing/minimal_chat.py
+++ b/mesop/examples/testing/minimal_chat.py
@@ -1,0 +1,12 @@
+import mesop as me
+import mesop.labs as mel
+
+
+@me.page(path="/testing/minimal_chat", title="Lorem Ipsum Chat")
+def page():
+  mel.chat(transform, title="Lorem Ipsum Chat", bot_user="Lorem Ipsum Bot")
+
+
+def transform(input: str, history: list[mel.ChatMessage]):
+  yield "Echo: "
+  yield input


### PR DESCRIPTION
Changes:

- Creates a minimal chat app with no sleep to speed up the test
- Skips assertions on the in-progress state 'Processing prompt...' - this seems inherently flaky because it's possible to miss it (if it happens too quickly now that there's no sleep)

This test isn't quite as high fidelity as before (but still covers most of the functionality) but it greatly alleviates the flakiness.

Checked (passed 10/10 times):

```sh
$ yarn playwright test  mesop/examples/e2e/chat_test.ts --repeat-each=10
```