### PR TITLE
Fix angular material colors for M3

### DIFF
--- a/mesop/examples/buttons.py
+++ b/mesop/examples/buttons.py
@@ -23,6 +23,20 @@ def main():
     disabled=False,
   )
   me.button(
+    "accent color button",
+    on_click=button_click,
+    type="flat",
+    color="accent",
+    disabled=False,
+  )
+  me.button(
+    "warn color button",
+    on_click=button_click,
+    type="flat",
+    color="warn",
+    disabled=False,
+  )
+  me.button(
     "not rounded",
     type="flat",
     on_click=button_click,

--- a/mesop/web/src/app/styles.scss
+++ b/mesop/web/src/app/styles.scss
@@ -11,29 +11,18 @@
 @include mat.all-component-typographies();
 @include mat.core();
 
-$m3-dark-theme: matx.define-theme(
-  (
-    color: (
-      theme-type: dark,
-      primary: matx.$m3-azure-palette,
-    ),
-  )
-);
-
 $m3-light-theme: matx.define-theme(
   (
     color: (
       primary: matx.$m3-azure-palette,
+      tertiary: matx.$m3-chartreuse-palette,
     ),
   )
 );
 
 body {
   @include mat.all-component-themes($m3-light-theme);
-}
-
-.dark-theme {
-  @include mat.all-component-colors($m3-dark-theme);
+  @include matx.color-variants-back-compat($m3-light-theme);
 }
 
 html,


### PR DESCRIPTION
Docs: https://material.angular.io/guide/material-3#optional-add-backwards-compatibility-styles-for-color-variants

I missed this earlier so color variants like `me.button("hi", color="warn")` were not working.

- Drive-by: remove dark theme which is unused right now.

Fixes #149 