### PR TITLE
Create optimized / prod-Angular app for prod mode

### DIFF
--- a/build_defs/app_bundle/BUILD
+++ b/build_defs/app_bundle/BUILD
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "terser_config.json",
+    "esbuild.config-tmpl.mjs",
+])
+
+# Make source files available for distribution via pkg_npm
+filegroup(
+    name = "files",
+    srcs = glob(["*"]),
+)

--- a/build_defs/app_bundle/README.md
+++ b/build_defs/app_bundle/README.md
@@ -1,0 +1,1 @@
+Forked from https://github.com/angular/dev-infra/tree/301473cb5fbcd6cca8b70a6369dcdf3dc2d12e08/bazel/app-bundling

--- a/build_defs/app_bundle/esbuild.config-tmpl.mjs
+++ b/build_defs/app_bundle/esbuild.config-tmpl.mjs
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright Google LLC
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ *
+ * Forked from: https://github.com/angular/dev-infra/blob/f82e2c46f5285375dd1944f29beae19849492f9a/bazel/app-bundling/esbuild.config-tmpl.mjs#L4
+ */
+
+import {createEsbuildAngularOptimizePlugin} from '@angular/build-tooling/shared-scripts/angular-optimization/esbuild-plugin.mjs';
+import {GLOBAL_DEFS_FOR_TERSER_WITH_AOT} from '@angular/compiler-cli/private/tooling';
+import * as path from 'path';
+
+///////////////////////////////////
+// Mesop-specific configurations
+///////////////////////////////////
+function resolveMesop(resolveDir, path) {
+  const binIndex = resolveDir.indexOf('/bin/');
+  if (binIndex === -1) {
+    throw new Error('Expected to find /bin/ in ' + resolveDir);
+  }
+
+  // Extract the part of the string up to and including "/bin/"
+  const upUntilBin = resolveDir.substring(0, binIndex + '/bin/'.length);
+
+  const result =
+    upUntilBin +
+    // "mesop/" is our workspace name (and not an actual file directory)
+    // so we remove it as a prefix.
+    path.substring('mesop/'.length) +
+    // Generated protos are ".js" files
+    '.js';
+
+  return result;
+}
+
+// Handles imports to generated proto files.
+let mesopProtoOnResolvePlugin = {
+  name: 'mesop-proto',
+  setup(build) {
+    build.onResolve({filter: /^mesop\//}, (args) => {
+      return {path: resolveMesop(args.resolveDir, args.path)};
+    });
+  },
+};
+
+///////////////////////////////////
+// End of Mesop-specific configurations
+///////////////////////////////////
+
+/** Root path pointing to the app bundle source entry-point file. */
+const entryPointSourceRootPath = path.normalize(`TMPL_ENTRY_POINT_ROOTPATH`);
+
+/**
+ * Root path to the bundle entry-point without extension.
+ *
+ * The extension of the bundle entry-point file is not known because the ESBuild
+ * rule strips the source extension (like `.ts`) and resolves the file based on
+ * the resolved inputs.
+ */
+const entryPointBasepath = entryPointSourceRootPath.replace(/\.[^.]+$/, '');
+
+/** Whether the given file is considered side-effect free. */
+function isFileSideEffectFree(filePath) {
+  // This returns false because proto-generated JS files which uses
+  // the legacy closure module system get incorrectly optimized.
+  return false;
+}
+
+export default {
+  // Note: We prefer `.mjs` here as this is the extension used by Angular APF
+  // packages.
+  resolveExtensions: ['.mjs', '.js'],
+  // Based on the CLI configuration:
+  // https://github.com/angular/angular-cli/blame/8089c9388056b3caaf56f981848aca94f022da73/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts#L51.
+  conditions: ['es2022', 'es2020', 'es2015', 'module'],
+  // Note: ES2015 main condition is needed for `rxjs@v6`.
+  mainFields: ['fesm2022', 'es2022', 'es2020', 'es2015', 'module', 'main'],
+  // The majority of these options match with the ones the CLI sets:
+  // https://github.com/angular/angular-cli/blob/0d76bf04bca6e083865972b5398a32bbe9396e14/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-worker.ts#L133.
+  treeShaking: true,
+  pure: ['forwardRef'],
+  legalComments: 'none',
+  supported: {
+    // We always downlevel `async/await` when bundling apps. The Angular CLI does the
+    // same with its ESBuild experimental builder, and with the non-esbuild pipeline
+    // Babel is used to downlevel async/await. See:
+    // https://github.com/angular/angular-cli/blob/afe9feaa45913cbebe7f22c678d693d96f38584a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts#L111
+    // https://github.com/angular/angular-cli/blob/afe9feaa45913/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts#L313-L318.
+    'async-await': false,
+  },
+  // ESBuild requires the `define` option to take a string-based dictionary.
+  define: convertObjectToStringDictionary(GLOBAL_DEFS_FOR_TERSER_WITH_AOT),
+  plugins: [
+    mesopProtoOnResolvePlugin,
+    await createEsbuildAngularOptimizePlugin({
+      optimize: {
+        isSideEffectFree: isFileSideEffectFree,
+      },
+      downlevelAsyncGeneratorsIfPresent: true,
+      enableLinker: {
+        ensureNoPartialDeclaration: false,
+        linkerOptions: {
+          linkerJitMode: false,
+        },
+      },
+    }),
+  ],
+};
+
+/** Converts an object to a string dictionary. */
+function convertObjectToStringDictionary(value) {
+  return Object.entries(value).reduce((result, [propName, value]) => {
+    result[propName] = String(value);
+    return result;
+  }, {});
+}

--- a/build_defs/app_bundle/index.bzl
+++ b/build_defs/app_bundle/index.bzl
@@ -1,0 +1,118 @@
+# Copyright Google LLC
+#
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file at https://angular.io/license
+#
+# Forked from: https://github.com/angular/dev-infra/blob/f82e2c46f5285375dd1944f29beae19849492f9a/bazel/app-bundling/index.bzl
+
+load("@npm//@angular/build-tooling/bazel:expand_template.bzl", "expand_template")
+load("@npm//@angular/build-tooling/bazel:filter_outputs.bzl", "filter_outputs")
+load("@npm//@angular/build-tooling/bazel/esbuild:index.bzl", "esbuild", "esbuild_config")
+load("@npm//@bazel/terser:index.bzl", "terser_minified")
+load("@npm//prettier:index.bzl", "prettier")
+
+def _create_esbuild_minify_options(debug = False):
+    # The minify options match with the configuration used by the CLI. The whitespace
+    # minification is left to Terser. More details can be found here:
+    # https://github.com/angular/angular-cli/blob/0d76bf04bca6e083865972b5398a32bbe9396e14/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-worker.ts#L133.
+    return {
+        "minifyIdentifiers": not debug,
+        "minifySyntax": True,
+        "minifyWhitespace": False,
+    }
+
+def app_bundle(
+        name,
+        entry_point,
+        visibility = None,
+        testonly = False,
+        platform = "browser",
+        target = "es2020",
+        format = "iife",
+        **kwargs):
+    """
+      Bundles an Angular applications in an optimized way that closely matches
+      the compilation pipeline as within the Angular CLI.
+
+      The rule produces a number of output bundles.
+
+        JS                               : "%{name}.js"
+        JS minified                      : "%{name}.min.js"
+        ----
+        JS debug                         : "%{name}.debug.js"
+        JS debug minified                : "%{name}.debug.min.js"
+        JS debug minified (beautified)   : "%{name}.debug.min.beautified.js"
+    """
+
+    common_base_attributes = {
+        "testonly": testonly,
+        "visibility": visibility,
+    }
+
+    expand_template(
+        name = "%s_config_file" % name,
+        output_name = "%s_config.mjs" % name,
+        template = "//build_defs/app_bundle:esbuild.config-tmpl.mjs",
+        substitutions = {
+            "TMPL_ENTRY_POINT_ROOTPATH": "$(rootpath %s)" % entry_point,
+        },
+        data = [entry_point],
+        **common_base_attributes
+    )
+
+    esbuild_config(
+        name = "%s_esbuild_config" % name,
+        config_file = ":%s_config_file" % name,
+        deps = [
+            "@npm//@angular/compiler-cli",
+            "@npm//@angular/build-tooling/shared-scripts/angular-optimization:js_lib",
+        ],
+        **common_base_attributes
+    )
+
+    common_esbuild_options = dict({
+        "config": "%s_esbuild_config" % name,
+        "entry_point": entry_point,
+        "target": target,
+        "platform": platform,
+        "format": format,
+        "sourcemap": "external",
+    }, **common_base_attributes)
+
+    common_terser_options = dict({
+        "config_file": "//build_defs/app_bundle:terser_config.json",
+        "sourcemap": True,
+    }, **common_base_attributes)
+
+    esbuild(
+        name = name,
+        args = _create_esbuild_minify_options(False),
+        **dict(kwargs, **common_esbuild_options)
+    )
+
+    esbuild(
+        name = "%s.debug" % name,
+        args = _create_esbuild_minify_options(True),
+        **dict(kwargs, tags = ["manual"], **common_esbuild_options)
+    )
+
+    terser_minified(name = name + ".min", src = ":%s" % name, **common_terser_options)
+    filter_outputs(name = name + ".min.js", target = ":%s.min" % name, filters = ["%s.min.js" % name], **common_base_attributes)
+    filter_outputs(name = name + ".min.js.map", target = ":%s.min" % name, filters = ["%s.min.js.map" % name], **common_base_attributes)
+
+    terser_minified(name = name + ".debug.min", src = ":%s.debug" % name, debug = True, tags = ["manual"], **common_terser_options)
+    filter_outputs(name = name + ".debug.min.js", target = ":%s.debug.min" % name, filters = ["%s.debug.min.js" % name], **common_base_attributes)
+    filter_outputs(name = name + ".debug.min.js.map", target = ":%s.debug.min" % name, filters = ["%s.debug.min.js.map" % name], **common_base_attributes)
+
+    # For better debugging, we also run prettier on the minified debug bundle. This is
+    # necessary as Terser no longer has beautify/formatting functionality.
+    prettier(
+        name = name + ".debug.min.beautified",
+        args = ["$(execpath %s)" % (name + ".debug.min")],
+        # The `outs` attribute needs to be set when `stdout` is captured as an output.
+        outs = [],
+        stdout = name + ".debug.min.beautified.js",
+        data = [name + ".debug.min"],
+        tags = ["manual"],
+        **common_base_attributes
+    )

--- a/build_defs/app_bundle/terser_config.json
+++ b/build_defs/app_bundle/terser_config.json
@@ -1,0 +1,12 @@
+{
+  "ecma": "es2020",
+  "compress": {
+    "passes": 2,
+    "pure_getters": true
+  },
+  "format": {
+    "ascii_only": true,
+    "wrap_func_args": false
+  },
+  "mangle": false
+}

--- a/build_defs/defaults.bzl
+++ b/build_defs/defaults.bzl
@@ -6,7 +6,7 @@ load("@build_bazel_rules_nodejs//:index.bzl", _nodejs_binary = "nodejs_binary", 
 load("@my_deps//:requirements.bzl", "requirement")
 load("@rules_proto//proto:defs.bzl", _proto_library = "proto_library")
 load("//build_defs:jspb_proto_library.bzl", _jspb_proto_library = "jspb_proto_library")
-load("//build_defs:ng_js_binary.bzl", _ng_js_binary = "ng_js_binary")
+load("//build_defs:ng_js_binary.bzl", _ng_js_binary = "ng_js_binary", _ng_js_binary_prod = "ng_js_binary_prod")
 load("//build_defs:py_proto_library.bzl", _py_proto_library = "py_proto_library")
 load("//build_defs:sass_external_binary.bzl", _sass_external_binary = "sass_external_binary")
 load("//tools:defaults.bzl", _devmode_esbuild = "devmode_esbuild", _esbuild = "esbuild", _esbuild_config = "esbuild_config", _http_server = "http_server", _karma_web_test_suite = "karma_web_test_suite", _ng_module = "ng_module", _ng_test_library = "ng_test_library", _ng_web_test_suite = "ng_web_test_suite", _sass_binary = "sass_binary", _sass_library = "sass_library", _ts_library = "ts_library")
@@ -20,6 +20,7 @@ karma_web_test_suite = _karma_web_test_suite
 http_server = _http_server
 jspb_proto_library = _jspb_proto_library
 ng_js_binary = _ng_js_binary
+ng_js_binary_prod = _ng_js_binary_prod
 ng_module = _ng_module
 ng_test_library = _ng_test_library
 ng_web_test_suite = _ng_web_test_suite

--- a/build_defs/ng_js_binary.bzl
+++ b/build_defs/ng_js_binary.bzl
@@ -1,8 +1,10 @@
 """Wrapper for building a js binary.
 """
 
-load("//tools/angular:index.bzl", "LINKER_PROCESSED_FW_PACKAGES")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("//build_defs/app_bundle:index.bzl", "app_bundle")
 load("//tools:defaults.bzl", "esbuild")
+load("//tools/angular:index.bzl", "LINKER_PROCESSED_FW_PACKAGES")
 
 def ng_js_binary(name, deps = [], entry_points = [], **kwargs):
     esbuild(
@@ -16,4 +18,43 @@ def ng_js_binary(name, deps = [], entry_points = [], **kwargs):
         target = "es2016",
         deps = LINKER_PROCESSED_FW_PACKAGES + deps,
         **kwargs
+    )
+
+# This rule was based on what tensorboard did:
+# https://github.com/tensorflow/tensorboard/blob/4023658707d54976622c3b3a32f5a4a215689da7/tensorboard/defs/defs.bzl#L93
+def ng_js_binary_prod(
+        name,
+        **kwargs):
+    """Rule for creating a prod-optimized JavaScript bundle for an Angular app.
+    This uses the Angular team's internal toolchain for creating these bundles:
+    app_bundle(). This toolchain is not officially supported. We use it at our
+    own risk.
+    The bundles allow for Angular AOT compilation and are further optimized to
+    reduce size. However, the bundle times are significantly slower than those
+    for ng_js_binary().
+    Args:
+        name: Name of the target.
+        **kwargs: Other keyword arguments to app_bundle() and esbuild(). Typically
+          used for entry_point and deps. Please refer to
+          https://esbuild.github.io/api/ for more details.
+    """
+
+    app_bundle_name = "%s_app_bundle" % name
+    app_bundle(
+        config = "//mesop/web/src/app:esbuild_config",
+        name = app_bundle_name,
+        **kwargs
+    )
+
+    # app_bundle() generates several outputs. We copy the one that has gone
+    # through a terser pass to be the output of this rule.
+    copy_file(
+        name = name + "_copy",
+        src = "%s.min.js" % app_bundle_name,
+        out = "%s.js" % name,
+    )
+
+    native.filegroup(
+        name = name,
+        srcs = ["%s.js" % name, "%s.min.js.map" % app_bundle_name],
     )

--- a/mesop/web/src/app/BUILD
+++ b/mesop/web/src/app/BUILD
@@ -7,6 +7,10 @@ package(
 esbuild_config(
     name = "esbuild_config",
     config_file = "esbuild.config.mjs",
+    deps = [
+        "@npm//@angular/build-tooling/shared-scripts/angular-optimization:js_lib",
+        "@npm//@angular/compiler-cli",
+    ],
 )
 
 sass_library(

--- a/mesop/web/src/app/prod/BUILD
+++ b/mesop/web/src/app/prod/BUILD
@@ -1,4 +1,4 @@
-load("//build_defs:defaults.bzl", "ANGULAR_CORE_DEPS", "JS_STATIC_FILES", "ng_js_binary", "ng_module", "pkg_web")
+load("//build_defs:defaults.bzl", "ANGULAR_CORE_DEPS", "JS_STATIC_FILES", "ng_js_binary_prod", "ng_module", "pkg_web")
 
 package(
     default_visibility = ["//build_defs:mesop_internal"],
@@ -14,9 +14,9 @@ ng_module(
     ] + ANGULAR_CORE_DEPS,
 )
 
-ng_js_binary(
+ng_js_binary_prod(
     name = "prod_bundle",
-    entry_points = [":bundle.ts"],
+    entry_point = "bundle.ts",
     visibility = ["//build_defs:mesop_users"],
     deps = [
         ":main",

--- a/mesop/web/src/app/prod/index.html
+++ b/mesop/web/src/app/prod/index.html
@@ -28,6 +28,6 @@
     <mesop-app>Loading...</mesop-app>
     <!-- Inject script (if needed) -->
     <script src="zone.js/dist/zone.js"></script>
-    <script src="prod_bundle/bundle.js" type="module"></script>
+    <script src="prod_bundle.js" type="module"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "send": "^0.17.2",
     "shelljs": "^0.8.5",
     "stylelint": "^14.14.0",
-    "terser": "^5.10.0",
+    "terser": "5.28.1",
     "ts-node": "^10.9.1",
     "ts-protoc-gen": "0.15.0",
     "tsec": "0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4872,7 +4872,7 @@ acorn@^8.4.1, acorn@^8.7.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
-acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.2:
+acorn@^8.7.1, acorn@^8.8.2:
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
@@ -15414,7 +15414,7 @@ source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.7.3, source-map@~0.7.2:
+source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -16052,14 +16052,14 @@ terser@5.27.0:
     commander "^2.20.0"
     source-map-support "~0.5.20"
 
-terser@^5.10.0:
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.12.1.tgz#4cf2ebed1f5bceef5c83b9f60104ac4a78b49e9c"
-  integrity sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==
+terser@5.28.1:
+  version "5.28.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.28.1.tgz#bf00f7537fd3a798c352c2d67d67d65c915d1b28"
+  integrity sha512-wM+bZp54v/E9eRRGXb5ZFDvinrJIOaTapx3WUokyVGZu5ucVCK55zEgGd5Dl2fSr3jUo5sDiERErUWLY6QPFyA==
   dependencies:
-    acorn "^8.5.0"
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
     commander "^2.20.0"
-    source-map "~0.7.2"
     source-map-support "~0.5.20"
 
 terser@^5.26.0:


### PR DESCRIPTION
Fixes #61.

TLDR: compiling Angular app with Bazel is painful, especially with protos.

Previously, even in prod mode, the Mesop app was compiled in Angular dev mode, which is not ideal, particularly for performance reasons (Angular prod mode is AOT compiled instead of dev mode which is JIT compiled).

Because there isn't a well-lit path for compiling Angular apps in Bazel, we end up copying what tensorboard has done: https://github.com/tensorflow/tensorboard/blob/4023658707d54976622c3b3a32f5a4a215689da7/tensorboard/defs/defs.bzl#L93 which is essentially to use Angular internal build toolchain for OSS.

However, we couldn't use Angular's internal `app_bundle` Bazel def directly because Mesop needs a custom esbuild plugin to resolve the generated JS paths for protos, so we ended up forking Angular's app_bundle Bazel def: https://github.com/angular/dev-infra/tree/301473cb5fbcd6cca8b70a6369dcdf3dc2d12e08/bazel/app-bundling

Note: this will require some downstream changes: 1) needs a `ng_js_binary_prod` shim in build_defs/ and 2) update the copybara script for mesop/web/src/app/prod/index.html because "prod_bundle/bundle.js" is now "prod_bundle.js" (to be fair, the previous path was kind of funky).