### PR TITLE
Add component diffing on event responses.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,14 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
-
+      - name: Run playwright test with component tree diffs enabled
+        run: ENABLE_COMPONENT_TREE_DIFFS=1 yarn playwright test
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        if: always()
+        with:
+          name: playwright-report-with-component-diffs-enabled
+          path: playwright-report-with-component-diffs-enabled/
+          retention-days: 30
   # Deploy docs
   deploy-docs:
     # Only deploy docs if we're pushing to main (see on.push.branches)

--- a/mesop/component_helpers/BUILD
+++ b/mesop/component_helpers/BUILD
@@ -1,4 +1,4 @@
-load("//build_defs:defaults.bzl", "py_library")
+load("//build_defs:defaults.bzl", "THIRD_PARTY_PY_ABSL_PY", "THIRD_PARTY_PY_PYTEST", "py_library", "py_test")
 
 package(
     default_visibility = ["//build_defs:mesop_internal"],
@@ -8,8 +8,15 @@ py_library(
     name = "component_helpers",
     srcs = glob(["*.py"]),
     deps = [
+        "//mesop/events",
         "//mesop/protos:ui_py_pb2",
         "//mesop/runtime",
         "//mesop/utils",
-    ],
+    ] + THIRD_PARTY_PY_ABSL_PY,
+)
+
+py_test(
+    name = "diff_component_test",
+    srcs = ["diff_component_test.py"],
+    deps = [":component_helpers"] + THIRD_PARTY_PY_PYTEST,
 )

--- a/mesop/component_helpers/__init__.py
+++ b/mesop/component_helpers/__init__.py
@@ -2,6 +2,9 @@ from .helper import (
   component as component,
 )
 from .helper import (
+  diff_component as diff_component,
+)
+from .helper import (
   get_qualified_fn_name as get_qualified_fn_name,
 )
 from .helper import (

--- a/mesop/component_helpers/diff_component_test.py
+++ b/mesop/component_helpers/diff_component_test.py
@@ -1,0 +1,431 @@
+import pytest
+
+import mesop.protos.ui_pb2 as pb
+from mesop.component_helpers.helper import diff_component
+
+
+def create_default_single_component():
+  return pb.Component(
+    key=pb.Key(key="key"),
+    style=pb.Style(color="red", columns="1"),
+    style_debug_json="debug json string",
+    type=pb.Type(
+      name=pb.ComponentName(core_module=True, fn_name="test"), value=b"value"
+    ),
+    source_code_location=pb.SourceCodeLocation(module="x", line=1, col=2),
+  )
+
+
+def test_single_component_no_diff():
+  c1 = create_default_single_component()
+
+  assert diff_component(c1, c1) == pb.ComponentDiff()
+
+
+def test_single_component_key_diff():
+  c1 = create_default_single_component()
+  c2 = create_default_single_component()
+  c2.key.CopyFrom(pb.Key(key="key2"))
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    update_strategy_key=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    key=pb.Key(key="key2"),
+  )
+
+
+def test_single_component_source_code_location_diff():
+  c1 = create_default_single_component()
+  c2 = create_default_single_component()
+  c2.source_code_location.CopyFrom(
+    pb.SourceCodeLocation(module="y", line=10, col=20)
+  )
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    update_strategy_source_code_location=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    source_code_location=pb.SourceCodeLocation(module="y", line=10, col=20),
+  )
+
+
+def test_single_component_style_diff():
+  c1 = create_default_single_component()
+  c2 = create_default_single_component()
+  c2.style.CopyFrom(pb.Style(width="100px"))
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    update_strategy_style=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    style=pb.Style(width="100px"),
+  )
+
+
+def test_single_component_style_debug_json_diff():
+  c1 = create_default_single_component()
+  c2 = create_default_single_component()
+  c2.style_debug_json = "updated json"
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    update_strategy_style_debug_json=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    style_debug_json="updated json",
+  )
+
+
+def test_single_component_type_diff():
+  c1 = create_default_single_component()
+  c2 = create_default_single_component()
+  c2.type.CopyFrom(
+    pb.Type(
+      name=pb.ComponentName(core_module=True, fn_name="test-diff"),
+      value=b"value2",
+    )
+  )
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    update_strategy_type=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    type=pb.Type(
+      name=pb.ComponentName(core_module=True, fn_name="test-diff"),
+      value=b"value2",
+    ),
+  )
+
+
+def test_single_component_multiple_diffs():
+  c1 = create_default_single_component()
+  c2 = create_default_single_component()
+  c2.key.CopyFrom(pb.Key(key="key2"))
+  c2.style.CopyFrom(pb.Style(width="100px"))
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    update_strategy_key=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    key=pb.Key(key="key2"),
+    update_strategy_style=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    style=pb.Style(width="100px"),
+  )
+
+
+def test_add_child_component():
+  c1 = create_default_single_component()
+  c2 = create_default_single_component()
+  c2_c1 = create_default_single_component()
+  c2.children.append(c2_c1)
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_ADD,
+        component=create_default_single_component(),
+      )
+    ],
+  )
+
+
+def test_add_multiple_child_components():
+  c1 = create_default_single_component()
+  c2 = create_default_single_component()
+  c2_c1 = create_default_single_component()
+  c2_c2 = create_default_single_component()
+  c2.children.append(c2_c1)
+  c2.children.append(c2_c2)
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_ADD,
+        component=c2_c1,
+      ),
+      pb.ComponentDiff(
+        index=1,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_ADD,
+        component=c2_c2,
+      ),
+    ],
+  )
+
+
+def test_add_child_component_sub_tree():
+  c1 = create_default_single_component()
+  c2 = create_default_single_component()
+  c2_c1 = create_default_single_component()
+  c2_c1_c1 = create_default_single_component()
+  c2_c1.children.append(c2_c1_c1)
+  c2.children.append(c2_c1)
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_ADD,
+        component=c2_c1,
+      ),
+    ],
+  )
+
+
+def test_add_child_child_component():
+  c1 = create_default_single_component()
+  c1_c1 = create_default_single_component()
+  c1.children.append(c1_c1)
+  c2 = create_default_single_component()
+  c2_c1 = create_default_single_component()
+  c2_c1_c1 = create_default_single_component()
+  c2_c1.children.append(c2_c1_c1)
+  c2.children.append(c2_c1)
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+        children=[
+          pb.ComponentDiff(
+            index=0,
+            diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_ADD,
+            component=c2_c1_c1,
+          ),
+        ],
+      )
+    ],
+  )
+
+
+def test_delete_child_component():
+  c1 = create_default_single_component()
+  c1_c1 = create_default_single_component()
+  c1.children.append(c1_c1)
+  c2 = create_default_single_component()
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_DELETE,
+      )
+    ],
+  )
+
+
+def test_delete_multiple_child_components():
+  c1 = create_default_single_component()
+  c1_c1 = create_default_single_component()
+  c1_c2 = create_default_single_component()
+  c1.children.append(c1_c1)
+  c1.children.append(c1_c2)
+  c2 = create_default_single_component()
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_DELETE,
+      ),
+      pb.ComponentDiff(
+        index=1,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_DELETE,
+      ),
+    ],
+  )
+
+
+def test_delete_child_component_sub_tree():
+  c1 = create_default_single_component()
+  c1_c1 = create_default_single_component()
+  c1_c1_c1 = create_default_single_component()
+  c1_c1.children.append(c1_c1_c1)
+  c1.children.append(c1_c1)
+
+  c2 = create_default_single_component()
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_DELETE,
+      ),
+    ],
+  )
+
+
+def test_delete_child_child_component():
+  c1 = create_default_single_component()
+  c1_c1 = create_default_single_component()
+  c1_c1_c1 = create_default_single_component()
+  c1_c1.children.append(c1_c1_c1)
+  c1.children.append(c1_c1)
+  c2 = create_default_single_component()
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_DELETE,
+      ),
+    ],
+  )
+
+
+def test_update_child_component():
+  c1 = create_default_single_component()
+  c1_c1 = create_default_single_component()
+  c1.children.append(c1_c1)
+  c2 = create_default_single_component()
+  c2_c1 = create_default_single_component()
+  c2_c1.key.CopyFrom(pb.Key(key="key2"))
+  c2.children.append(c2_c1)
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+        update_strategy_key=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+        key=pb.Key(key="key2"),
+      )
+    ],
+  )
+
+
+def test_update_multiple_child_components():
+  c1 = create_default_single_component()
+  c1_c1 = create_default_single_component()
+  c1_c2 = create_default_single_component()
+  c1.children.append(c1_c1)
+  c1.children.append(c1_c2)
+  c2 = create_default_single_component()
+  c2_c1 = create_default_single_component()
+  c2_c1.key.CopyFrom(pb.Key(key="key2"))
+  c2_c2 = create_default_single_component()
+  c2_c2.key.CopyFrom(pb.Key(key="key3"))
+  c2.children.append(c2_c1)
+  c2.children.append(c2_c2)
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+        update_strategy_key=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+        key=pb.Key(key="key2"),
+      ),
+      pb.ComponentDiff(
+        index=1,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+        update_strategy_key=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+        key=pb.Key(key="key3"),
+      ),
+    ],
+  )
+
+
+def test_update_child_child_component():
+  c1 = create_default_single_component()
+  c1_c1 = create_default_single_component()
+  c1_c1_c1 = create_default_single_component()
+  c1_c1.children.append(c1_c1_c1)
+  c1.children.append(c1_c1)
+  c2 = create_default_single_component()
+  c2_c1 = create_default_single_component()
+  c2_c1_c1 = create_default_single_component()
+  c2_c1_c1.key.CopyFrom(pb.Key(key="key3"))
+  c2_c1.children.append(c2_c1_c1)
+  c2.children.append(c2_c1)
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+        children=[
+          pb.ComponentDiff(
+            index=0,
+            diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+            update_strategy_key=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+            key=pb.Key(key="key3"),
+          )
+        ],
+      ),
+    ],
+  )
+
+
+def test_swapped_child_components_will_update_fields():
+  c1 = create_default_single_component()
+  c1_c1 = create_default_single_component()
+  c1_c1.key.CopyFrom(pb.Key(key="key2"))
+  c1_c2 = create_default_single_component()
+  c1.children.append(c1_c1)
+  c1.children.append(c1_c2)
+  c2 = create_default_single_component()
+  c2_c1 = create_default_single_component()
+  c2_c2 = create_default_single_component()
+  c2_c2.key.CopyFrom(pb.Key(key="key2"))
+  c2.children.append(c2_c1)
+  c2.children.append(c2_c2)
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+        update_strategy_key=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+        key=pb.Key(key="key"),
+      ),
+      pb.ComponentDiff(
+        index=1,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+        update_strategy_key=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+        key=pb.Key(key="key2"),
+      ),
+    ],
+  )
+
+
+def test_displaced_child_component_will_update_and_add_component():
+  c1 = create_default_single_component()
+  c1_c1 = create_default_single_component()
+  c1_c1.key.CopyFrom(pb.Key(key="key2"))
+  c1.children.append(c1_c1)
+  c2 = create_default_single_component()
+  c2_c1 = create_default_single_component()
+  c2_c2 = create_default_single_component()
+  c2_c2.key.CopyFrom(pb.Key(key="key2"))
+  c2.children.append(c2_c1)
+  c2.children.append(c2_c2)
+
+  assert diff_component(c1, c2) == pb.ComponentDiff(
+    diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+    children=[
+      pb.ComponentDiff(
+        index=0,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_UPDATE,
+        update_strategy_key=pb.ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+        key=pb.Key(key="key"),
+      ),
+      pb.ComponentDiff(
+        index=1,
+        diff_type=pb.ComponentDiff.DiffType.DIFF_TYPE_ADD,
+        component=c2_c2,
+      ),
+    ],
+  )
+
+
+if __name__ == "__main__":
+  raise SystemExit(pytest.main([__file__]))

--- a/mesop/examples/testing/__init__.py
+++ b/mesop/examples/testing/__init__.py
@@ -1,4 +1,7 @@
 from mesop.examples.testing import (
+  complex_layout as complex_layout,
+)
+from mesop.examples.testing import (
   conditional_event_handler as conditional_event_handler,
 )
 from mesop.examples.testing import (

--- a/mesop/examples/testing/complex_layout.py
+++ b/mesop/examples/testing/complex_layout.py
@@ -1,0 +1,147 @@
+"""Page for smoke testing component diffing."""
+import mesop as me
+
+
+@me.stateclass
+class State:
+  color1: str = "red"
+  color2: str = "orange"
+  color3: str = "yellow"
+  color4: str = "green"
+  color5: str = "blue"
+  color6: str = "indigo"
+  color7: str = "violet"
+  random_inputs: bool = False
+  other_random_inputs: bool = False
+
+
+@me.page(path="/testing/complex_layout")
+def app():
+  state = me.state(State)
+
+  # Test general diff updates
+  me.button("Reverse colors", on_click=update_colors)
+  # Test diff propagation
+  me.button("Update last color", on_click=update_last_color)
+  # Test adding components to differents parts of tree
+  me.button("Show random inputs", on_click=show_random_inputs)
+  # Test replacement of components to differenet components
+  me.button("Show other random inputs", on_click=show_other_random_inputs)
+  # Test deletion of components
+  me.button("Hide random inputs", on_click=hide_random_inputs)
+
+  with me.box(
+    key="box1",
+    style=me.Style(background=state.color1, padding=me.Padding.all(10)),
+  ):
+    me.text("Label " + state.color1)
+    with me.box(
+      style=me.Style(background=state.color2, padding=me.Padding.all(10))
+    ):
+      me.text("Label " + state.color2)
+      with me.box(
+        style=me.Style(background=state.color3, padding=me.Padding.all(10))
+      ):
+        me.text("Label " + state.color3)
+        if state.random_inputs:
+          with me.box(
+            style=me.Style(border=me.Border.all(me.BorderSide(width=1)))
+          ):
+            me.checkbox(state.color3)
+            me.input(label=state.color3)
+            me.radio(
+              options=[
+                me.RadioOption(label="Radio 1"),
+                me.RadioOption(label="Radio 2"),
+              ]
+            )
+            me.slider()
+        if state.other_random_inputs:
+          with me.box(
+            style=me.Style(border=me.Border.all(me.BorderSide(width=1)))
+          ):
+            me.checkbox(state.color3)
+            me.radio(
+              options=[
+                me.RadioOption(label="Radio 1"),
+                me.RadioOption(label="Radio 2"),
+              ]
+            )
+            me.input(label=state.color3)
+        with me.box(
+          style=me.Style(background=state.color4, padding=me.Padding.all(10))
+        ):
+          me.text("Label " + state.color4)
+          with me.box(
+            style=me.Style(background=state.color5, padding=me.Padding.all(10))
+          ):
+            me.text("Label " + state.color5)
+            with me.box(
+              style=me.Style(
+                background=state.color6, padding=me.Padding.all(10)
+              )
+            ):
+              me.text("Label " + state.color6)
+              with me.box(
+                style=me.Style(
+                  background=state.color7, padding=me.Padding.all(10)
+                )
+              ):
+                me.text("Label " + state.color7)
+                if state.random_inputs:
+                  me.input(label=state.color7)
+                  me.checkbox(state.color7)
+                  me.slider()
+                  me.radio(
+                    options=[
+                      me.RadioOption(label="Radio 1"),
+                      me.RadioOption(label="Radio 2"),
+                    ]
+                  )
+                if state.other_random_inputs:
+                  me.checkbox(state.color7)
+                  me.input(label=state.color7)
+                  me.radio(options=[me.RadioOption(label="Radio 2")])
+
+
+def update_colors(e: me.ClickEvent):
+  state = me.state(State)
+  if state.color7 == "red":
+    state.color1 = "red"
+    state.color2 = "orange"
+    state.color3 = "yellow"
+    state.color4 = "green"
+    state.color5 = "blue"
+    state.color6 = "indigo"
+    state.color7 = "violet"
+  else:
+    state.color7 = "red"
+    state.color6 = "orange"
+    state.color5 = "yellow"
+    state.color4 = "green"
+    state.color3 = "blue"
+    state.color2 = "indigo"
+    state.color1 = "violet"
+
+
+def update_last_color(e: me.ClickEvent):
+  state = me.state(State)
+  state.color7 = "white"
+
+
+def show_random_inputs(e: me.ClickEvent):
+  state = me.state(State)
+  state.random_inputs = True
+  state.other_random_inputs = False
+
+
+def show_other_random_inputs(e: me.ClickEvent):
+  state = me.state(State)
+  state.other_random_inputs = True
+  state.random_inputs = False
+
+
+def hide_random_inputs(e: me.ClickEvent):
+  state = me.state(State)
+  state.random_inputs = False
+  state.other_random_inputs = False

--- a/mesop/protos/ui.proto
+++ b/mesop/protos/ui.proto
@@ -145,6 +145,7 @@ message ContextLine {
 
 message RenderEvent {
     optional Component root_component = 1;
+    optional ComponentDiff component_diff = 6;
     optional string title = 5;
     optional States states = 2;
     repeated Command commands = 3;
@@ -175,6 +176,15 @@ message State {
 }
 
 // Represents an instance of a component.
+//
+// When adding new fields to the Component proto, make sure to update
+// the ComponentDiff proto.
+//
+// The new field should be added with the same name to the ComponentDiff proto. In
+// addition you will need to update the following functions:
+//
+// - `diff_component` in mesop/component_helpers/helpers.py
+// - `applyComponentDiff` in mesop/web/src/utils/diff.ts
 message Component {
     optional Key key = 3;
     optional Style style = 5;
@@ -187,6 +197,52 @@ message Component {
 
     // Only sent in editor mode.
     optional SourceCodeLocation source_code_location = 4;
+}
+
+// Used for tracking differences between two components.
+//
+// Next ID: 15
+message ComponentDiff {
+    optional int32 index = 1;
+
+    optional Key key = 2;
+    optional SourceCodeLocation source_code_location = 3;
+    optional Style style = 4;
+    optional string style_debug_json = 5;
+    optional Type type = 6;
+
+    repeated ComponentDiff children = 7;
+
+    // Used for cases when a component subtree is determined to be completely new.
+    optional Component component = 8;
+
+    // If there is a diff on a component's field, determine the strategy to use for
+    // updating the target field.
+    enum UpdateStrategy {
+        UPDATE_STRATEGY_NOOP = 0;
+        // Replace field completely. In most cases this is the desired behavior.
+        UPDATE_STRATEGY_REPLACE = 1;
+        // Some components can contain a lot of text. Usually text is added to the
+        // existing text. So instead of a full replacement, we can append new text
+        // rather than replacing the entire field.
+        //
+        // This strategy has not implemented yet.
+        UPDATE_STRATEGY_APPEND = 2;
+    }
+    optional UpdateStrategy update_strategy_key = 9;
+    optional UpdateStrategy update_strategy_source_code_location = 10;
+    optional UpdateStrategy update_strategy_style = 11;
+    optional UpdateStrategy update_strategy_style_debug_json = 12;
+    optional UpdateStrategy update_strategy_type = 13;
+
+    // Determines the type of diff for the component.
+    enum DiffType {
+        DIFF_TYPE_NONE = 0;
+        DIFF_TYPE_ADD = 1;
+        DIFF_TYPE_DELETE = 2;
+        DIFF_TYPE_UPDATE = 3;
+    }
+    optional DiffType diff_type = 14;
 }
 
 message SourceCodeLocation {

--- a/mesop/server/BUILD
+++ b/mesop/server/BUILD
@@ -8,6 +8,7 @@ py_library(
     name = "server",
     srcs = glob(["*.py"]),
     deps = [
+        "//mesop/component_helpers",
         "//mesop/editor",
         "//mesop/events",
         "//mesop/protos:ui_py_pb2",

--- a/mesop/tests/e2e/diff_test.ts
+++ b/mesop/tests/e2e/diff_test.ts
@@ -1,0 +1,68 @@
+import {test, expect} from '@playwright/test';
+
+test('test component diffing', async ({page}) => {
+  await page.goto('/testing/complex_layout');
+
+  // Spot check initial page render.
+  let locator = await page.locator('div:has-text("Label")');
+  await expect(locator).toHaveCount(7);
+  await expect(locator.first()).toHaveText('Label red');
+  await expect(locator.nth(4)).toHaveText('Label blue');
+  await expect(locator.last()).toHaveText('Label violet');
+  await expect(page.locator('//input')).toHaveCount(0);
+
+  // Test general diff updates updates
+  await page.getByRole('button', {name: 'Reverse colors'}).click();
+  locator = await page.locator('div:has-text("Label")');
+  await expect(locator).toHaveCount(7);
+  await expect(locator.first()).toHaveText('Label violet');
+  await expect(locator.nth(4)).toHaveText('Label yellow');
+  await expect(locator.last()).toHaveText('Label red');
+
+  // Test diff propagation
+  await page.getByRole('button', {name: 'Update last color'}).click();
+  locator = await page.locator('div:has-text("Label")');
+  await expect(locator).toHaveCount(7);
+  await expect(locator.first()).toHaveText('Label violet');
+  await expect(locator.nth(4)).toHaveText('Label yellow');
+  await expect(locator.last()).toHaveText('Label white');
+
+  // Test adding components to differents parts of tree
+  await page.getByRole('button', {name: 'Show random inputs'}).click();
+  locator = await page.locator(
+    '//component-renderer[contains(@style, "border")]//input',
+  );
+  await expect(locator.first()).toHaveAttribute('type', 'checkbox');
+  await expect(locator.nth(1)).toHaveAttribute('type', 'text');
+  await expect(locator.nth(2)).toHaveAttribute('type', 'radio');
+  await expect(locator.nth(3)).toHaveAttribute('type', 'radio');
+  await expect(locator.last()).toHaveAttribute('type', 'range');
+  locator = await page.locator(
+    '//component-renderer[contains(@style, "white")]//input',
+  );
+  await expect(locator.first()).toHaveAttribute('type', 'text');
+  await expect(locator.nth(1)).toHaveAttribute('type', 'checkbox');
+  await expect(locator.nth(2)).toHaveAttribute('type', 'range');
+  await expect(locator.nth(3)).toHaveAttribute('type', 'radio');
+  await expect(locator.nth(4)).toHaveAttribute('type', 'radio');
+
+  // Test replacement of components to differenet components
+  await page.getByRole('button', {name: 'Show other random inputs'}).click();
+  locator = await page.locator(
+    '//component-renderer[contains(@style, "border")]//input',
+  );
+  await expect(locator.first()).toHaveAttribute('type', 'checkbox');
+  await expect(locator.nth(1)).toHaveAttribute('type', 'radio');
+  await expect(locator.nth(2)).toHaveAttribute('type', 'radio');
+  await expect(locator.last()).toHaveAttribute('type', 'text');
+  locator = await page.locator(
+    '//component-renderer[contains(@style, "white")]//input',
+  );
+  await expect(locator.first()).toHaveAttribute('type', 'checkbox');
+  await expect(locator.nth(1)).toHaveAttribute('type', 'text');
+  await expect(locator.last()).toHaveAttribute('type', 'radio');
+
+  // Test deletion of components
+  await page.getByRole('button', {name: 'Hide random inputs'}).click();
+  await expect(page.locator('//input')).toHaveCount(0);
+});

--- a/mesop/web/src/utils/BUILD
+++ b/mesop/web/src/utils/BUILD
@@ -1,4 +1,4 @@
-load("//build_defs:defaults.bzl", "ts_library")
+load("//build_defs:defaults.bzl", "ng_test_library", "ng_web_test_suite", "ts_library")
 
 package(
     default_visibility = ["//build_defs:mesop_internal"],
@@ -6,6 +6,25 @@ package(
 
 ts_library(
     name = "utils",
-    srcs = glob(["*.ts"]),
+    srcs = glob(
+        ["*.ts"],
+        exclude = ["*_spec.ts"],
+    ),
     deps = ["//mesop/protos:ui_jspb_proto"],
+)
+
+ng_test_library(
+    name = "utils_test_lib",
+    srcs = glob(["*_spec.ts"]),
+    deps = [
+        ":utils",
+        "//mesop/protos:ui_jspb_proto",
+    ],
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    deps = [
+        ":utils_test_lib",
+    ],
 )

--- a/mesop/web/src/utils/diff.ts
+++ b/mesop/web/src/utils/diff.ts
@@ -1,0 +1,76 @@
+import {
+  Component,
+  ComponentDiff,
+} from 'mesop/mesop/protos/ui_jspb_proto_pb/mesop/protos/ui_pb';
+
+/** Updates the given component in place with the provided diffs. */
+export function applyComponentDiff(component: Component, diff: ComponentDiff) {
+  if (
+    diff.getUpdateStrategyKey() ===
+    ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE
+  ) {
+    component.setKey(diff.getKey());
+  }
+  if (
+    diff.getUpdateStrategySourceCodeLocation() ===
+    ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE
+  ) {
+    component.setSourceCodeLocation(diff.getSourceCodeLocation());
+  }
+  if (
+    diff.getUpdateStrategyStyle() ===
+    ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE
+  ) {
+    component.setStyle(diff.getStyle());
+  }
+  if (
+    diff.getUpdateStrategyStyleDebugJson() ===
+    ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE
+  ) {
+    component.setStyleDebugJson(diff.getStyleDebugJson() as string);
+  }
+  if (
+    diff.getUpdateStrategyType() ===
+    ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE
+  ) {
+    component.setType(diff.getType());
+  }
+
+  let deleteIndex = -1;
+  for (const childDiff of diff.getChildrenList()) {
+    if (childDiff.getDiffType() === ComponentDiff.DiffType.DIFF_TYPE_UPDATE) {
+      applyComponentDiff(
+        component.getChildrenList()[childDiff.getIndex() as number],
+        childDiff,
+      );
+    } else if (
+      // We do not care about adding the node to a specific index since we expect
+      // additions to be added in order after all updates.
+      //
+      // Once deletions are applied, the additions should be at the expected location
+      // in the component tree.
+      childDiff.getDiffType() === ComponentDiff.DiffType.DIFF_TYPE_ADD
+    ) {
+      component.addChildren(childDiff.getComponent());
+    } else if (
+      childDiff.getDiffType() === ComponentDiff.DiffType.DIFF_TYPE_DELETE &&
+      (deleteIndex === -1 || (childDiff.getIndex() as number) < deleteIndex)
+    ) {
+      // Only track the smallest `deleteIndex` if there are deletions. See comment
+      // below.
+      deleteIndex = childDiff.getIndex() as number;
+    }
+  }
+
+  // If deleteIndex is set to a non-negative number, this means that we have child nodes
+  // to delete.
+  //
+  // Due to the way deletes are determined, we know that deletes will always occur
+  // sequentially to the end of the list. This allows us to delete all nodes after the
+  // lowest `deleteIndex` found.
+  if (deleteIndex !== -1) {
+    component.setChildrenList(
+      component.getChildrenList().slice(0, deleteIndex),
+    );
+  }
+}

--- a/mesop/web/src/utils/diff_spec.ts
+++ b/mesop/web/src/utils/diff_spec.ts
@@ -1,0 +1,414 @@
+import {
+  Component,
+  ComponentDiff,
+  ComponentName,
+  Key,
+  SourceCodeLocation,
+  Style,
+  Type,
+} from 'mesop/mesop/protos/ui_jspb_proto_pb/mesop/protos/ui_pb';
+import {applyComponentDiff} from 'mesop/mesop/web/src/utils/diff';
+
+function createKey(name: string) {
+  const key = new Key();
+  key.setKey(name);
+  return key;
+}
+
+function createStyle(color: string, columns: string) {
+  const style = new Style();
+  style.setColor(color);
+  style.setColumns(columns);
+  return style;
+}
+
+function createType(fnName: string) {
+  const componentName = new ComponentName();
+  componentName.setCoreModule(true);
+  componentName.setFnName(fnName);
+  const type = new Type();
+  type.setName(componentName);
+  type.setValue('value');
+  return type;
+}
+
+function createSourceCodeLocation(module: string) {
+  const sourceCodeLocation = new SourceCodeLocation();
+  sourceCodeLocation.setModule(module);
+  sourceCodeLocation.setLine(1);
+  sourceCodeLocation.setCol(2);
+  return sourceCodeLocation;
+}
+
+function createDefaultComponent() {
+  const c = new Component();
+  c.setKey(createKey('key'));
+  c.setStyle(createStyle('red', '1'));
+  c.setStyleDebugJson('debug json string');
+  c.setType(createType('test'));
+  c.setSourceCodeLocation(createSourceCodeLocation('x'));
+  return c;
+}
+
+describe('applyComponenDiff functionality', () => {
+  it('applies no diffs when there are no diffs', () => {
+    const c = createDefaultComponent();
+    const diff = new ComponentDiff();
+
+    applyComponentDiff(c, diff);
+
+    expect(c).toBe(c);
+  });
+
+  it('applies diffs on key field', () => {
+    // Starting component
+    const c = createDefaultComponent();
+    // Diff
+    const diff = new ComponentDiff();
+    diff.setKey(createKey('key2'));
+    diff.setUpdateStrategyKey(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    // Expected updates
+    const expectedC = createDefaultComponent();
+    expectedC.setKey(createKey('key2'));
+
+    applyComponentDiff(c, diff);
+
+    expect(c).toEqual(expectedC);
+  });
+
+  it('applies diffs on style field', () => {
+    // Starting component
+    const c = createDefaultComponent();
+    // Diff
+    const diff = new ComponentDiff();
+    diff.setStyle(createStyle('blue', '100px'));
+    diff.setUpdateStrategyStyle(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    // Expected updates
+    const expectedC = createDefaultComponent();
+    expectedC.setStyle(createStyle('blue', '100px'));
+
+    applyComponentDiff(c, diff);
+
+    expect(c).toEqual(expectedC);
+  });
+
+  it('applies diffs on styleDebugJson field', () => {
+    // Starting component
+    const c = createDefaultComponent();
+    // Diff
+    const diff = new ComponentDiff();
+    diff.setStyleDebugJson('updated debug json');
+    diff.setUpdateStrategyStyleDebugJson(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    // Expected updates
+    const expectedC = createDefaultComponent();
+    expectedC.setStyleDebugJson('updated debug json');
+
+    applyComponentDiff(c, diff);
+
+    expect(c).toEqual(expectedC);
+  });
+
+  it('applies diffs on type field', () => {
+    // Starting component
+    const c = createDefaultComponent();
+    // Diff
+    const diff = new ComponentDiff();
+    diff.setType(createType('updated'));
+    diff.setUpdateStrategyType(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    // Expected updates
+    const expectedC = createDefaultComponent();
+    expectedC.setType(createType('updated'));
+
+    applyComponentDiff(c, diff);
+
+    expect(c).toEqual(expectedC);
+  });
+
+  it('applies diffs on sourceCodeLocation field', () => {
+    // Starting component
+    const c = createDefaultComponent();
+    // Diff
+    const diff = new ComponentDiff();
+    diff.setSourceCodeLocation(createSourceCodeLocation('y'));
+    diff.setUpdateStrategySourceCodeLocation(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    // Expected updates
+    const expectedC = createDefaultComponent();
+    expectedC.setSourceCodeLocation(createSourceCodeLocation('y'));
+
+    applyComponentDiff(c, diff);
+
+    expect(c).toEqual(expectedC);
+  });
+
+  it('applies multiple diffs', () => {
+    // Starting component
+    const c = createDefaultComponent();
+    // Diff
+    const diff = new ComponentDiff();
+    diff.setKey(createKey('key2'));
+    diff.setUpdateStrategyKey(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    diff.setSourceCodeLocation(createSourceCodeLocation('y'));
+    diff.setUpdateStrategySourceCodeLocation(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    // Expected updates
+    const expectedC = createDefaultComponent();
+    expectedC.setKey(createKey('key2'));
+    expectedC.setSourceCodeLocation(createSourceCodeLocation('y'));
+
+    applyComponentDiff(c, diff);
+
+    expect(c).toEqual(expectedC);
+  });
+
+  it('applies update diffs on child components', () => {
+    // Starting component
+    const c1 = createDefaultComponent();
+    const c1c1 = createDefaultComponent();
+    c1.addChildren(c1c1);
+    // Diff
+    const diffC1 = new ComponentDiff();
+    const diffC1C1 = new ComponentDiff();
+    diffC1C1.setKey(createKey('key2'));
+    diffC1C1.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_UPDATE);
+    diffC1C1.setUpdateStrategyKey(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    diffC1.addChildren(diffC1C1);
+    // Expected updates
+    const expectedC1 = createDefaultComponent();
+    const expectedC1C1 = createDefaultComponent();
+    expectedC1C1.setKey(createKey('key2'));
+    expectedC1.addChildren(expectedC1C1);
+
+    applyComponentDiff(c1, diffC1);
+
+    expect(c1).toEqual(expectedC1);
+  });
+
+  it('applies update diffs on multiple child components', () => {
+    // Starting component
+    const c1 = createDefaultComponent();
+    const c1c1 = createDefaultComponent();
+    const c1c2 = createDefaultComponent();
+    c1.addChildren(c1c1);
+    c1.addChildren(c1c2);
+    // Diff
+    const diffC1 = new ComponentDiff();
+    const diffC1C1 = new ComponentDiff();
+    diffC1C1.setKey(createKey('key1 - update'));
+    diffC1C1.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_UPDATE);
+    diffC1C1.setUpdateStrategyKey(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    diffC1.addChildren(diffC1C1);
+    const diffC1C2 = new ComponentDiff();
+    diffC1C2.setIndex(1);
+    diffC1C2.setKey(createKey('key2 - update'));
+    diffC1C2.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_UPDATE);
+    diffC1C2.setUpdateStrategyKey(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    diffC1.addChildren(diffC1C2);
+    // Expected updates
+    const expectedC1 = createDefaultComponent();
+    const expectedC1C1 = createDefaultComponent();
+    expectedC1C1.setKey(createKey('key1 - update'));
+    expectedC1.addChildren(expectedC1C1);
+    const expectedC1C2 = createDefaultComponent();
+    expectedC1C2.setKey(createKey('key2 - update'));
+    expectedC1.addChildren(expectedC1C2);
+
+    applyComponentDiff(c1, diffC1);
+
+    expect(c1).toEqual(expectedC1);
+  });
+
+  it('applies add diffs', () => {
+    // Starting component
+    const c1 = createDefaultComponent();
+    const c1c1 = createDefaultComponent();
+    c1.addChildren(c1c1);
+    // Diff
+    const diffC1 = new ComponentDiff();
+    const diffC1C1 = new ComponentDiff();
+    diffC1C1.setIndex(1);
+    const addC = createDefaultComponent();
+    addC.setKey(createKey('key 2'));
+    diffC1C1.setComponent(addC);
+    diffC1C1.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_ADD);
+    diffC1.addChildren(diffC1C1);
+    // Expected updates
+    const expectedC1 = createDefaultComponent();
+    const expectedC1C1 = createDefaultComponent();
+    expectedC1.addChildren(expectedC1C1);
+    const expectedC1C2 = createDefaultComponent();
+    expectedC1C2.setKey(createKey('key 2'));
+    expectedC1.addChildren(expectedC1C2);
+
+    applyComponentDiff(c1, diffC1);
+
+    expect(c1).toEqual(expectedC1);
+  });
+
+  it('applies delete diffs', () => {
+    // Starting component
+    const c1 = createDefaultComponent();
+    const c1c1 = createDefaultComponent();
+    c1.addChildren(c1c1);
+    const c1c2 = createDefaultComponent();
+    c1.addChildren(c1c2);
+    // Diff
+    const diffC1 = new ComponentDiff();
+    const diffC1C2 = new ComponentDiff();
+    diffC1C2.setIndex(1);
+    diffC1C2.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_DELETE);
+    diffC1.addChildren(diffC1C2);
+    // Expected updates
+    const expectedC1 = createDefaultComponent();
+    const expectedC11 = createDefaultComponent();
+    expectedC1.addChildren(expectedC11);
+
+    applyComponentDiff(c1, diffC1);
+
+    expect(c1).toEqual(expectedC1);
+  });
+
+  it('applies mutliple delete diffs', () => {
+    // Starting component
+    const c1 = createDefaultComponent();
+    const c1c1 = createDefaultComponent();
+    c1.addChildren(c1c1);
+    const c1c2 = createDefaultComponent();
+    c1.addChildren(c1c2);
+    const c1c3 = createDefaultComponent();
+    c1.addChildren(c1c3);
+    // Diff
+    const diffC1 = new ComponentDiff();
+    const diffC1C2 = new ComponentDiff();
+    diffC1C2.setIndex(1);
+    diffC1C2.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_DELETE);
+    diffC1.addChildren(diffC1C2);
+    const diffC1C3 = new ComponentDiff();
+    diffC1C3.setIndex(2);
+    diffC1C3.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_DELETE);
+    diffC1.addChildren(diffC1C3);
+    // Expected updates
+    const expectedC1 = createDefaultComponent();
+    const expectedC1C1 = createDefaultComponent();
+    expectedC1.addChildren(expectedC1C1);
+
+    applyComponentDiff(c1, diffC1);
+
+    expect(c1).toEqual(expectedC1);
+  });
+
+  it('applies update / delete diffs on child components', () => {
+    // Starting component
+    const c1 = createDefaultComponent();
+    const c1c1 = createDefaultComponent();
+    c1.addChildren(c1c1);
+    const c1c2 = createDefaultComponent();
+    c1.addChildren(c1c2);
+    // Diff
+    const diffC1 = new ComponentDiff();
+    const diffC1C1 = new ComponentDiff();
+    diffC1C1.setKey(createKey('key2'));
+    diffC1C1.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_UPDATE);
+    diffC1C1.setUpdateStrategyKey(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    diffC1.addChildren(diffC1C1);
+    const diffC1C2 = new ComponentDiff();
+    diffC1C2.setIndex(1);
+    diffC1C2.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_DELETE);
+    diffC1.addChildren(diffC1C2);
+    // Expected updates
+    const expectedC1 = createDefaultComponent();
+    const expectedC1C2 = createDefaultComponent();
+    expectedC1C2.setKey(createKey('key2'));
+    expectedC1.addChildren(expectedC1C2);
+
+    applyComponentDiff(c1, diffC1);
+
+    expect(c1).toEqual(expectedC1);
+  });
+
+  it('applies update / add diffs on child components', () => {
+    // Starting component
+    const c1 = createDefaultComponent();
+    const c1c1 = createDefaultComponent();
+    c1.addChildren(c1c1);
+    // Diff
+    const diffC1 = new ComponentDiff();
+    const diffC1C1 = new ComponentDiff();
+    diffC1C1.setKey(createKey('key2'));
+    diffC1C1.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_UPDATE);
+    diffC1C1.setUpdateStrategyKey(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    diffC1.addChildren(diffC1C1);
+    const diffC1C2 = new ComponentDiff();
+    diffC1C2.setIndex(1);
+    diffC1C2.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_ADD);
+    const addC = createDefaultComponent();
+    diffC1C2.setComponent(addC);
+    diffC1.addChildren(diffC1C2);
+    // Expected updates
+    const expectedC1 = createDefaultComponent();
+    const expectedC1C1 = createDefaultComponent();
+    expectedC1C1.setKey(createKey('key2'));
+    expectedC1.addChildren(expectedC1C1);
+    const expectedC1C2 = createDefaultComponent();
+    expectedC1.addChildren(expectedC1C2);
+
+    applyComponentDiff(c1, diffC1);
+
+    expect(c1).toEqual(expectedC1);
+  });
+
+  it('applies diffs on child child components', () => {
+    // Starting component
+    const c1 = createDefaultComponent();
+    const c1c1 = createDefaultComponent();
+    const c1c1c1 = createDefaultComponent();
+    c1c1.addChildren(c1c1c1);
+    c1.addChildren(c1c1);
+    // Diff
+    const diffC1 = new ComponentDiff();
+    diffC1.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_UPDATE);
+    const diffC1C1 = new ComponentDiff();
+    diffC1C1.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_UPDATE);
+    const diffC1C1C1 = new ComponentDiff();
+    diffC1C1C1.setKey(createKey('key1 - update'));
+    diffC1C1C1.setDiffType(ComponentDiff.DiffType.DIFF_TYPE_UPDATE);
+    diffC1C1C1.setUpdateStrategyKey(
+      ComponentDiff.UpdateStrategy.UPDATE_STRATEGY_REPLACE,
+    );
+    diffC1C1.addChildren(diffC1C1C1);
+    diffC1.addChildren(diffC1C1);
+    // Expected updates
+    const expectedC1 = createDefaultComponent();
+    const expectedC1C1 = createDefaultComponent();
+    const expectedC1C1C1 = createDefaultComponent();
+    expectedC1C1C1.setKey(createKey('key1 - update'));
+    expectedC1C1.addChildren(expectedC1C1C1);
+    expectedC1.addChildren(expectedC1C1);
+
+    applyComponentDiff(c1, diffC1);
+
+    expect(c1).toEqual(expectedC1);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,12 @@ import {defineConfig, devices} from '@playwright/test';
  */
 // require('dotenv').config();
 
+// We need to run all tests with component tree diffs enabled and disabled.
+// We use this flag to toggle between the two modes.
+const enableComponentTreeDiffs = process.env.ENABLE_COMPONENT_TREE_DIFFS
+  ? '--enable_component_tree_diffs'
+  : '--noenable_component_tree_diffs';
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -45,8 +51,7 @@ export default defineConfig({
 
   /* Run your local server before starting the tests */
   webServer: {
-    command:
-      'bazel run //mesop/cli -- --path=mesop/mesop/example_index.py --prod',
+    command: `bazel run //mesop/cli -- --path=mesop/mesop/example_index.py --prod ${enableComponentTreeDiffs}`,
     url: 'http://127.0.0.1:32123/',
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
This change is gated by a flag called `enable_component_tree_diffs`. When enabled, the full component tree will not be returned in event responses. Instead only the changed component fields will be returned to the frontend. The frontend will then apply the diff to update its copy of the component tree.

A few notes:

- Wasn't sure how to add unit tests for typescript. Is there a framework we're using?
- I'd like to run the playwright tests with the diff flag enabled and without it enabled (right now it's enabled by default in the test). Haven't looked into this too much yet. Seems like there's a way to do it 
  - Passing in a different config but that would lead to a lot of duplication (so probably rule this out)
  - Seems like we could pass in some environment variable to enable/disable the flag. Then we'd need to update the CI to run the tests twice.

Ref #62, #84