### PR TITLE
Use watchdog for a more robust file watching for mesop/bin

### DIFF
--- a/mesop/cli/cli.py
+++ b/mesop/cli/cli.py
@@ -8,6 +8,7 @@ from absl import app, flags
 
 import mesop.protos.ui_pb2 as pb
 from mesop.cli.execute_module import (
+  clear_app_modules,
   execute_module,
   get_module_name_from_runfile_path,
 )
@@ -35,9 +36,11 @@ flags.DEFINE_bool("verbose", False, "set to true for verbose logging.")
 
 
 def execute_main_module():
+  module_name = get_module_name_from_runfile_path(FLAGS.path)
+  clear_app_modules(module_name=module_name)
   execute_module(
     module_path=get_runfile_location(FLAGS.path),
-    module_name=get_module_name_from_runfile_path(FLAGS.path),
+    module_name=module_name,
   )
 
 

--- a/mesop/cli/dev_cli.py
+++ b/mesop/cli/dev_cli.py
@@ -4,6 +4,7 @@ from absl import app, flags
 
 import mesop.protos.ui_pb2 as pb
 from mesop.cli.execute_module import (
+  clear_app_modules,
   execute_module,
   get_module_name_from_runfile_path,
 )
@@ -27,9 +28,11 @@ def main(argv: Sequence[str]):
   enable_debug_mode()
 
   try:
+    module_name = get_module_name_from_runfile_path(FLAGS.path)
+    clear_app_modules(module_name=module_name)
     execute_module(
       module_path=get_runfile_location(FLAGS.path),
-      module_name=get_module_name_from_runfile_path(FLAGS.path),
+      module_name=module_name,
     )
   except Exception as e:
     runtime().add_loading_error(

--- a/mesop/cli/execute_module.py
+++ b/mesop/cli/execute_module.py
@@ -5,10 +5,6 @@ from types import ModuleType
 
 
 def execute_module(*, module_path: str, module_name: str) -> ModuleType:
-  # Delete all app modules so we reload them.
-  for submodule in get_app_modules(module_name, set(sys.modules.keys())):
-    del sys.modules[submodule]
-
   spec = importlib.util.spec_from_file_location(module_name, module_path)
   assert spec
   module = importlib.util.module_from_spec(spec)
@@ -16,6 +12,12 @@ def execute_module(*, module_path: str, module_name: str) -> ModuleType:
   spec.loader.exec_module(module)
 
   return module
+
+
+def clear_app_modules(module_name: str) -> None:
+  # Delete all app modules so we reload them.
+  for submodule in get_app_modules(module_name, set(sys.modules.keys())):
+    del sys.modules[submodule]
 
 
 def get_module_name_from_runfile_path(runfile_path: str) -> str:

--- a/mesop/pip_package/requirements.txt
+++ b/mesop/pip_package/requirements.txt
@@ -3,3 +3,4 @@ absl-py
 pydantic==1.10 # --no-binary pydantic
 libcst==1.1.0
 protobuf
+watchdog # used by mesop CLI for hot reloading


### PR DESCRIPTION
Closes #150.

Note: this doesn't work with Python relative imports which seems relatively less popular than Python absolute imports.