### PR TITLE
Don't send component configs in prod mode

### DIFF
--- a/mesop/cli/cli.py
+++ b/mesop/cli/cli.py
@@ -65,7 +65,7 @@ def monitor_stdin():
 
 
 def main(argv: Sequence[str]):
-  flask_app = configure_flask_app()
+  flask_app = configure_flask_app(prod_mode=FLAGS.prod)
   if len(FLAGS.path) < 1:
     raise Exception("Required flag 'path'. Received: " + FLAGS.path)
 

--- a/mesop/cli/dev_cli.py
+++ b/mesop/cli/dev_cli.py
@@ -21,7 +21,7 @@ flags.DEFINE_string("path", "", "path to main python module of Mesop app.")
 
 
 def main(argv: Sequence[str]):
-  flask_app = configure_flask_app()
+  flask_app = configure_flask_app(prod_mode=False)
   if len(FLAGS.path) < 1:
     raise Exception("Required flag 'path'. Received: " + FLAGS.path)
 

--- a/mesop/server/colab_run.py
+++ b/mesop/server/colab_run.py
@@ -17,7 +17,7 @@ def colab_run(*, port: int = 32123, prod_mode: bool = False):
   if not colab_utils.is_running_in_colab():
     print("Not running Colab: `colab_run` is a no-op")
     return
-  flask_app = configure_flask_app()
+  flask_app = configure_flask_app(prod_mode=prod_mode)
   if not prod_mode:
     enable_debug_mode()
 

--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -26,7 +26,7 @@ _requests_in_flight = 0
 
 
 def configure_flask_app(
-  *, exceptions_to_propagate: Sequence[type] = ()
+  *, prod_mode: bool = True, exceptions_to_propagate: Sequence[type] = ()
 ) -> Flask:
   flask_app = Flask(__name__)
 
@@ -51,7 +51,7 @@ def configure_flask_app(
           component_diff=component_diff,
           states=runtime().context().serialize_state(),
           commands=runtime().context().commands(),
-          component_configs=get_component_configs(),
+          component_configs=None if prod_mode else get_component_configs(),
           title=title,
         )
       )

--- a/mesop/server/wsgi_app.py
+++ b/mesop/server/wsgi_app.py
@@ -25,7 +25,7 @@ def create_app(
   prod_mode: bool,
   run_block: Callable[..., None] | None = None,
 ) -> App:
-  flask_app = configure_flask_app()
+  flask_app = configure_flask_app(prod_mode=prod_mode)
 
   if not prod_mode:
     enable_debug_mode()


### PR DESCRIPTION
Closes #175 

Component configs is only needed for editor mode.