### PR TITLE
Fix bug with hot reload and component diffs

### DIFF
--- a/mesop/runtime/context.py
+++ b/mesop/runtime/context.py
@@ -91,10 +91,6 @@ class Context:
     if FLAGS.enable_component_tree_diffs:
       self._previous_node = self._current_node
 
-  def reset_nodes(self) -> None:
-    self.set_previous_node_from_current_node()
-    self.reset_current_node()
-
   def reset_current_node(self) -> None:
     self._current_node = pb.Component()
 


### PR DESCRIPTION
Hot reloading was not working with component diffs since the diffs were returning no changes.

This is because the render loop does not have access to the old tree before hot reloading. Since that tree does get sent with the event, it's possible we could update the code to use the old tree, but for development, it seems ok to just perform a full diff.

There is also the use case of pressing the back button, which triggers a UI event. This event does not provid a handler ID so it will now a skip diffing.

Also the `reset_nodes` method was removed. With this change, the naming became a bit confusing. So ended up just explicitly calling each method.