### PR TITLE
Remove columns from mesop.labs.layout

### DIFF
--- a/mesop/editor/component_configs_test.py
+++ b/mesop/editor/component_configs_test.py
@@ -8,7 +8,7 @@ from mesop.editor.component_configs import (
   generate_component_config,
   get_component_configs,
 )
-from mesop.labs.layout import columns
+from mesop.labs import chat
 
 
 def test_generate_component_config_button():
@@ -72,11 +72,11 @@ def test_generate_component_config_radio():
   )
 
 
-def test_generate_component_config_labs_column():
-  proto = generate_component_config(columns)
+def test_generate_component_config_labs_chat():
+  proto = generate_component_config(chat)
   assert proto.component_name.HasField("core_module") is False
-  assert proto.component_name.module_path == "mesop.labs.layout"
-  assert proto.component_name.fn_name == "columns"
+  assert proto.component_name.module_path == "mesop.labs.chat"
+  assert proto.component_name.fn_name == "chat"
 
 
 def test_get_component_configs():

--- a/mesop/editor/editor_codemod_test.py
+++ b/mesop/editor/editor_codemod_test.py
@@ -39,14 +39,6 @@ class TestDeleteComponentCodemod(CodemodTest):
       ),
     )
 
-  def test_delete_custom_component(self) -> None:
-    self.assertEditorUpdate(
-      "delete_custom_component",
-      pb.EditorDeleteComponent(
-        source_code_location=pb.SourceCodeLocation(line=6),
-      ),
-    )
-
   def assertEditorUpdate(
     self, test_case_name: str, input: pb.EditorDeleteComponent
   ):
@@ -65,18 +57,6 @@ class TestNewComponentCodemod(CodemodTest):
       "new_component",
       pb.EditorNewComponent(
         component_name=me_name("divider"),
-        source_code_location=pb.SourceCodeLocation(line=5),
-        mode=pb.EditorNewComponent.Mode.MODE_APPEND_SIBLING,
-      ),
-    )
-
-  def test_new_custom_component(self) -> None:
-    self.assertEditorUpdate(
-      "new_custom_component",
-      pb.EditorNewComponent(
-        component_name=pb.ComponentName(
-          fn_name="columns", module_path="mesop.labs.layout"
-        ),
         source_code_location=pb.SourceCodeLocation(line=5),
         mode=pb.EditorNewComponent.Mode.MODE_APPEND_SIBLING,
       ),
@@ -450,23 +430,6 @@ class TestUpdateCallsiteCodemod(CodemodTest):
           )
         ),
         source_code_location=pb.SourceCodeLocation(line=5),
-      ),
-    )
-
-  def test_update_columns(self) -> None:
-    self.assertEditorUpdate(
-      "update_columns",
-      pb.EditorUpdateCallsite(
-        component_name=pb.ComponentName(
-          fn_name="columns", module_path="mesop.labs.layout"
-        ),
-        arg_path=pb.ArgPath(
-          segments=[pb.ArgPathSegment(keyword_argument="columns")]
-        ),
-        replacement=pb.CodeReplacement(
-          new_code=pb.CodeValue(int_value=1),
-        ),
-        source_code_location=pb.SourceCodeLocation(line=6),
       ),
     )
 

--- a/mesop/editor/testdata/delete_custom_component/after.py
+++ b/mesop/editor/testdata/delete_custom_component/after.py
@@ -1,5 +1,0 @@
-import mesop as me
-from mesop.labs.layout import columns
-
-def app():
-    me.text()

--- a/mesop/editor/testdata/delete_custom_component/before.py
+++ b/mesop/editor/testdata/delete_custom_component/before.py
@@ -1,6 +1,0 @@
-import mesop as me
-from mesop.labs.layout import columns
-
-def app():
-    me.text()
-    columns(columns=2)

--- a/mesop/editor/testdata/new_custom_component/after.py
+++ b/mesop/editor/testdata/new_custom_component/after.py
@@ -1,8 +1,0 @@
-import mesop as me
-from mesop.labs.layout import columns
-
-
-def app():
-  me.text("before")
-  columns()
-  me.text("after")

--- a/mesop/editor/testdata/new_custom_component/before.py
+++ b/mesop/editor/testdata/new_custom_component/before.py
@@ -1,6 +1,0 @@
-import mesop as me
-
-
-def app():
-  me.text("before")
-  me.text("after")

--- a/mesop/editor/testdata/update_columns/after.py
+++ b/mesop/editor/testdata/update_columns/after.py
@@ -1,6 +1,0 @@
-import mesop as me
-from mesop.labs.layout import columns
-
-def app():
-    me.text()
-    columns(columns=1)

--- a/mesop/editor/testdata/update_columns/before.py
+++ b/mesop/editor/testdata/update_columns/before.py
@@ -1,6 +1,0 @@
-import mesop as me
-from mesop.labs.layout import columns
-
-def app():
-    me.text()
-    columns(columns=2)

--- a/mesop/examples/__init__.py
+++ b/mesop/examples/__init__.py
@@ -1,7 +1,6 @@
 from mesop.examples import buttons as buttons
 from mesop.examples import chat as chat
 from mesop.examples import checkbox_and_radio as checkbox_and_radio
-from mesop.examples import columns as columns
 from mesop.examples import composite as composite
 from mesop.examples import docs as docs
 from mesop.examples import dynamic_values as dynamic_values

--- a/mesop/examples/columns.py
+++ b/mesop/examples/columns.py
@@ -1,9 +1,0 @@
-import mesop as me
-from mesop.labs.layout import columns
-
-
-@me.page(path="/columns")
-def main():
-  with columns(columns=2):
-    me.text("first_column")
-    me.text("second_column")

--- a/mesop/examples/index.py
+++ b/mesop/examples/index.py
@@ -39,7 +39,5 @@ def body():
 - [text](/components/text/e2e/text_app)
 - [tooltip](/components/tooltip/e2e/tooltip_app)
 
-/columns
-
 """
     )

--- a/mesop/labs/layout.py
+++ b/mesop/labs/layout.py
@@ -1,6 +1,0 @@
-import mesop as me
-
-
-@me.component()
-def columns(columns: int = 2):
-  return me.box(style=me.Style(columns=columns))


### PR DESCRIPTION
This was an experimentation from a while back but I don't think this is the right way to support columns because it's usually not what people expect. This basically splits a big body of text across multiple columns, but usually I think people want a grid-like layout (even a single row) where each column is a body of text.