### PR TITLE
Do not show error box once error is no longer current

### DIFF
--- a/mesop/web/src/shell/shell.ng.html
+++ b/mesop/web/src/shell/shell.ng.html
@@ -1,6 +1,5 @@
-@for(error of this.errors; track $index) {
 <mesop-error-box *ngIf="error != null" [error]="error" />
-}
+
 <div class="status">
   <mat-progress-bar
     data-testid="connection-progress-bar"

--- a/mesop/web/src/shell/shell.ts
+++ b/mesop/web/src/shell/shell.ts
@@ -42,7 +42,7 @@ import {GlobalErrorHandlerService} from '../services/global_error_handler';
 })
 export class Shell {
   rootComponent!: ComponentProto;
-  errors: ServerError[] = [];
+  error: ServerError | undefined;
   componentConfigs: readonly ComponentConfig[] = [];
 
   constructor(
@@ -57,7 +57,7 @@ export class Shell {
     (errorHandler as GlobalErrorHandlerService).setOnError((error) => {
       const errorProto = new ServerError();
       errorProto.setException(`JS Error: ${error.toString()}`);
-      this.errors.push(errorProto);
+      this.error = errorProto;
     });
   }
 
@@ -67,12 +67,13 @@ export class Shell {
       onRender: (rootComponent, componentConfigs) => {
         this.rootComponent = rootComponent;
         this.componentConfigs = componentConfigs;
+        this.error = undefined;
       },
       onNavigate: (route) => {
         this.router.navigateByUrl(route);
       },
       onError: (error) => {
-        this.errors.push(error);
+        this.error = error;
       },
     });
   }


### PR DESCRIPTION
Closes #201.

The previous behavior was overly complicated in trying to show multiple errors, but it resulted in an annoying developer experience where you needed to manually close the red error box (or reload the page) once you fixed the error.

In the vast majority of cases, you're dealing with one error at a time, and if you really have multiple errors at once (e.g. JS errors), then you can still debug them one at a time with the error box still