### PR TITLE
Supports syntax highlighting in markdown (uses python-markdown + pygments)

### DIFF
--- a/build_defs/defaults.bzl
+++ b/build_defs/defaults.bzl
@@ -62,10 +62,6 @@ PYTHON_RUNFILES_DEP = [
     "@rules_python//python/runfiles",
 ]
 
-THIRD_PARTY_JS_MARKED = [
-    "@npm//marked",
-]
-
 THIRD_PARTY_JS_RXJS = [
     "@npm//rxjs",
 ]
@@ -86,8 +82,16 @@ THIRD_PARTY_PY_MATPLOTLIB = [
     requirement("matplotlib"),
 ]
 
+THIRD_PARTY_PY_MARKDOWN = [
+    requirement("markdown"),
+]
+
 THIRD_PARTY_PY_PYDANTIC = [
     requirement("pydantic"),
+]
+
+THIRD_PARTY_PY_PYGMENTS = [
+    requirement("pygments"),
 ]
 
 THIRD_PARTY_PY_PYTEST = [

--- a/build_defs/requirements.txt
+++ b/build_defs/requirements.txt
@@ -2,10 +2,12 @@ pytest
 flask
 mypy-protobuf
 absl-py
+markdown
 mkdocs-material
 mkdocstrings[python]
 protobuf
 pydantic==1.10.13 --no-binary pydantic
+pygments
 libcst==1.1.0
 
 matplotlib # only used for example

--- a/build_defs/requirements_lock.txt
+++ b/build_defs/requirements_lock.txt
@@ -399,6 +399,7 @@ markdown==3.5.1 \
     --hash=sha256:5874b47d4ee3f0b14d764324d2c94c03ea66bee56f2d929da9f2508d65e722dc \
     --hash=sha256:b65d7beb248dc22f2e8a31fb706d93798093c308dc1aba295aedeb9d41a813bd
     # via
+    #   -r build_defs/requirements.txt
     #   mkdocs
     #   mkdocs-autorefs
     #   mkdocs-material
@@ -762,7 +763,9 @@ pydantic==1.10.13 \
 pygments==2.16.1 \
     --hash=sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692 \
     --hash=sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29
-    # via mkdocs-material
+    # via
+    #   -r build_defs/requirements.txt
+    #   mkdocs-material
 pymdown-extensions==10.4 \
     --hash=sha256:bc46f11749ecd4d6b71cf62396104b4a200bad3498cb0f5dad1b8502fe461a35 \
     --hash=sha256:cfc28d6a09d19448bcbf8eee3ce098c7d17ff99f7bd3069db4819af181212037

--- a/mesop/components/markdown/BUILD
+++ b/mesop/components/markdown/BUILD
@@ -1,4 +1,5 @@
 load("//mesop/components:defs.bzl", "mesop_component")
+load("//build_defs:defaults.bzl", "THIRD_PARTY_PY_MARKDOWN", "THIRD_PARTY_PY_PYGMENTS")
 
 package(
     default_visibility = ["//build_defs:mesop_internal"],
@@ -6,5 +7,5 @@ package(
 
 mesop_component(
     name = "markdown",
-    ng_deps = ["//mesop/web/external:marked"],
+    py_deps = THIRD_PARTY_PY_MARKDOWN + THIRD_PARTY_PY_PYGMENTS,
 )

--- a/mesop/components/markdown/e2e/markdown_app.py
+++ b/mesop/components/markdown/e2e/markdown_app.py
@@ -3,6 +3,32 @@ import mesop as me
 SAMPLE_MARKDOWN = """
 # Sample Markdown Document
 
+Regular code block:
+
+```
+hello
+```
+
+Python code block:
+
+Syntax 1:
+
+```python
+def foo():
+  print("Hello, World!")
+
+foo()
+```
+
+Syntax 2:
+
+``` python
+def foo():
+  print("Hello, World!")
+
+foo()
+```
+
 ## Table of Contents
 1. [Headers](#headers)
 2. [Emphasis](#emphasis)

--- a/mesop/components/markdown/markdown.ng.html
+++ b/mesop/components/markdown/markdown.ng.html
@@ -1,1 +1,1 @@
-<div [style]="getStyle()" [innerHTML]="markdownHTML"></div>
+<div [style]="getStyle()" [innerHTML]="config().getHtml()"></div>

--- a/mesop/components/markdown/markdown.proto
+++ b/mesop/components/markdown/markdown.proto
@@ -3,5 +3,5 @@ syntax = "proto2";
 package mesop.components.markdown;
 
 message MarkdownType {
-    optional string text = 1;
+    optional string html = 1;
 }

--- a/mesop/components/markdown/markdown.py
+++ b/mesop/components/markdown/markdown.py
@@ -1,3 +1,6 @@
+import markdown as markdown_lib
+from markdown.extensions.codehilite import CodeHiliteExtension
+
 import mesop.components.markdown.markdown_pb2 as markdown_pb
 from mesop.component_helpers import (
   Style,
@@ -20,11 +23,22 @@ def markdown(
       text: **Required.** Markdown text
       style: Style to apply to component. Follows [HTML Element inline style API](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style).
   """
+
+  if text:
+    html = markdown_lib.markdown(
+      text,
+      extensions=[
+        CodeHiliteExtension(css_class="highlight"),
+        "fenced_code",
+      ],
+    )
+  else:
+    html = ""
   insert_component(
     key=key,
     type_name="markdown",
     style=style,
     proto=markdown_pb.MarkdownType(
-      text=text,
+      html=html,
     ),
   )

--- a/mesop/components/markdown/markdown.ts
+++ b/mesop/components/markdown/markdown.ts
@@ -5,7 +5,6 @@ import {
   Type,
 } from 'mesop/mesop/protos/ui_jspb_proto_pb/mesop/protos/ui_pb';
 import {MarkdownType} from 'mesop/mesop/components/markdown/markdown_jspb_proto_pb/mesop/components/markdown/markdown_pb';
-import {marked} from '../../web/external/marked';
 import {formatStyle} from '../../web/src/utils/styles';
 
 @Component({
@@ -17,10 +16,8 @@ export class MarkdownComponent {
   @Input({required: true}) type!: Type;
   @Input() key!: Key;
   @Input() style!: Style;
-  markdownHTML = '';
 
   private _config!: MarkdownType;
-  isChecked = false;
 
   constructor(readonly changeDetectorRef: ChangeDetectorRef) {}
 
@@ -28,8 +25,6 @@ export class MarkdownComponent {
     this._config = MarkdownType.deserializeBinary(
       this.type.getValue() as unknown as Uint8Array,
     );
-    this.markdownHTML = await marked.parse(this._config.getText()!);
-    this.changeDetectorRef.detectChanges();
   }
 
   config(): MarkdownType {

--- a/mesop/pip_package/requirements.txt
+++ b/mesop/pip_package/requirements.txt
@@ -2,5 +2,7 @@ flask
 absl-py
 pydantic==1.10.13 # --no-binary pydantic
 libcst==1.1.0
+markdown
 protobuf
+pygments
 watchdog # used by mesop CLI for hot reloading

--- a/mesop/web/src/app/styles.scss
+++ b/mesop/web/src/app/styles.scss
@@ -92,3 +92,216 @@ body {
 mesop-markdown pre {
   overflow-x: scroll;
 }
+
+// Generated with pygments
+// pygmentize -S xcode -f html -a .highlight > style.css
+pre {
+  line-height: 125%;
+}
+td.linenos .normal {
+  color: inherit;
+  background-color: transparent;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+span.linenos {
+  color: inherit;
+  background-color: transparent;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+td.linenos .special {
+  color: #000000;
+  background-color: #ffffc0;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+span.linenos.special {
+  color: #000000;
+  background-color: #ffffc0;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+.highlight .hll {
+  background-color: #ffffcc;
+}
+.highlight {
+  background: #ffffff;
+}
+.highlight .c {
+  color: #177500;
+} /* Comment */
+.highlight .err {
+  color: #000000;
+} /* Error */
+.highlight .k {
+  color: #a90d91;
+} /* Keyword */
+.highlight .l {
+  color: #1c01ce;
+} /* Literal */
+.highlight .n {
+  color: #000000;
+} /* Name */
+.highlight .o {
+  color: #000000;
+} /* Operator */
+.highlight .ch {
+  color: #177500;
+} /* Comment.Hashbang */
+.highlight .cm {
+  color: #177500;
+} /* Comment.Multiline */
+.highlight .cp {
+  color: #633820;
+} /* Comment.Preproc */
+.highlight .cpf {
+  color: #177500;
+} /* Comment.PreprocFile */
+.highlight .c1 {
+  color: #177500;
+} /* Comment.Single */
+.highlight .cs {
+  color: #177500;
+} /* Comment.Special */
+.highlight .kc {
+  color: #a90d91;
+} /* Keyword.Constant */
+.highlight .kd {
+  color: #a90d91;
+} /* Keyword.Declaration */
+.highlight .kn {
+  color: #a90d91;
+} /* Keyword.Namespace */
+.highlight .kp {
+  color: #a90d91;
+} /* Keyword.Pseudo */
+.highlight .kr {
+  color: #a90d91;
+} /* Keyword.Reserved */
+.highlight .kt {
+  color: #a90d91;
+} /* Keyword.Type */
+.highlight .ld {
+  color: #1c01ce;
+} /* Literal.Date */
+.highlight .m {
+  color: #1c01ce;
+} /* Literal.Number */
+.highlight .s {
+  color: #c41a16;
+} /* Literal.String */
+.highlight .na {
+  color: #836c28;
+} /* Name.Attribute */
+.highlight .nb {
+  color: #a90d91;
+} /* Name.Builtin */
+.highlight .nc {
+  color: #3f6e75;
+} /* Name.Class */
+.highlight .no {
+  color: #000000;
+} /* Name.Constant */
+.highlight .nd {
+  color: #000000;
+} /* Name.Decorator */
+.highlight .ni {
+  color: #000000;
+} /* Name.Entity */
+.highlight .ne {
+  color: #000000;
+} /* Name.Exception */
+.highlight .nf {
+  color: #000000;
+} /* Name.Function */
+.highlight .nl {
+  color: #000000;
+} /* Name.Label */
+.highlight .nn {
+  color: #000000;
+} /* Name.Namespace */
+.highlight .nx {
+  color: #000000;
+} /* Name.Other */
+.highlight .py {
+  color: #000000;
+} /* Name.Property */
+.highlight .nt {
+  color: #000000;
+} /* Name.Tag */
+.highlight .nv {
+  color: #000000;
+} /* Name.Variable */
+.highlight .ow {
+  color: #000000;
+} /* Operator.Word */
+.highlight .mb {
+  color: #1c01ce;
+} /* Literal.Number.Bin */
+.highlight .mf {
+  color: #1c01ce;
+} /* Literal.Number.Float */
+.highlight .mh {
+  color: #1c01ce;
+} /* Literal.Number.Hex */
+.highlight .mi {
+  color: #1c01ce;
+} /* Literal.Number.Integer */
+.highlight .mo {
+  color: #1c01ce;
+} /* Literal.Number.Oct */
+.highlight .sa {
+  color: #c41a16;
+} /* Literal.String.Affix */
+.highlight .sb {
+  color: #c41a16;
+} /* Literal.String.Backtick */
+.highlight .sc {
+  color: #2300ce;
+} /* Literal.String.Char */
+.highlight .dl {
+  color: #c41a16;
+} /* Literal.String.Delimiter */
+.highlight .sd {
+  color: #c41a16;
+} /* Literal.String.Doc */
+.highlight .s2 {
+  color: #c41a16;
+} /* Literal.String.Double */
+.highlight .se {
+  color: #c41a16;
+} /* Literal.String.Escape */
+.highlight .sh {
+  color: #c41a16;
+} /* Literal.String.Heredoc */
+.highlight .si {
+  color: #c41a16;
+} /* Literal.String.Interpol */
+.highlight .sx {
+  color: #c41a16;
+} /* Literal.String.Other */
+.highlight .sr {
+  color: #c41a16;
+} /* Literal.String.Regex */
+.highlight .s1 {
+  color: #c41a16;
+} /* Literal.String.Single */
+.highlight .ss {
+  color: #c41a16;
+} /* Literal.String.Symbol */
+.highlight .bp {
+  color: #5b269a;
+} /* Name.Builtin.Pseudo */
+.highlight .fm {
+  color: #000000;
+} /* Name.Function.Magic */
+.highlight .vc {
+  color: #000000;
+} /* Name.Variable.Class */
+.highlight .vg {
+  color: #000000;
+} /* Name.Variable.Global */
+.highlight .vi {
+  color: #000000;
+} /* Name.Variable.Instance */


### PR DESCRIPTION
Instead of doing the markdown rendering client-side using [marked.js](https://marked.js.org/), this changes our markdown component's implementation to instead do it on the server-side using [python-markdown](https://python-markdown.github.io/) for markdown rendering and [pygments](https://pygments.org/) for syntax highlighting.

Shifting it to server-side seems better because: 1) it ships less code to client-side which is more performant and 2) most of the heavy-lifting in Mesop apps is done on the server-side already so there wasn't much benefit to doing it client side.

Addresses part of #96.