### PR TITLE
Replace hot reload mechanism

### DIFF
--- a/docs/internal/hot_reload.md
+++ b/docs/internal/hot_reload.md
@@ -4,10 +4,7 @@ One of Mesop's key benefits is that it provides a fast iteration cycle through h
 
 ## How it works
 
-- Developer edits application source code.
-- This triggers an ibazel rebuild. Note: this does not restart the server because we tag the CLI binary target with `"ibazel_live_reload"`. This tells ibazel to keep the server alive and trigger a live reload via a script which is provided via the environmental variable `IBAZEL_LIVERELOAD_URL`. This script is passed by `cli.py` into `configure_static_file_serving` which injects the script into index.html.
-- ibazel notifies Mesop's server via stdin because our binary target has the tag: `"ibazel_notify_changes"`. The Mesop server, when in debug mode, starts a daemon thread which monitors for a successful build and does two things: 1. resets the Mesop runtime, 2. re-executes the main module, which was passed via the `--path` flag.
-- On the client-side, in `HotReloaderService`, we monkey-patch the injected LiveReload service so that instead of doing a reload, we simply doing another request via the Channel service with the existing state. The advantage of this is that we preserve DOM state (e.g. input controls, scroll) and it's faster than doing a full page reload.
+See:https://github.com/google/mesop/pull/211
 
 ## Design decisions
 

--- a/mesop/cli/BUILD
+++ b/mesop/cli/BUILD
@@ -34,8 +34,6 @@ py_binary(
     ],
     main = "cli.py",
     tags = [
-        # This tag starts the live_reload server inside iBazel and instructs it to send reload events to webbrowsers.
-        "ibazel_live_reload",
         # This tag instructs ibazel to pipe into stdin a event describing actions.
         "ibazel_notify_changes",
     ],

--- a/mesop/cli/cli.py
+++ b/mesop/cli/cli.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import sys
 import threading
 from typing import Sequence
@@ -101,7 +100,6 @@ def main(argv: Sequence[str]):
     static_file_runfiles_base=PROD_PACKAGE_PATH
     if FLAGS.prod
     else EDITOR_PACKAGE_PATH,
-    livereload_script_url=os.environ.get("IBAZEL_LIVERELOAD_URL"),
   )
 
   if FLAGS.verbose:

--- a/mesop/runtime/runtime.py
+++ b/mesop/runtime/runtime.py
@@ -32,7 +32,12 @@ class Runtime:
   _loading_errors: list[pb.ServerError]
   component_fns: set[Callable[..., Any]]
   debug_mode: bool = False
+  # If True, then the server is still re-executing the modules
+  # needed for hot reloading.
   is_hot_reload_in_progress: bool = False
+  # If True, then the server has re-executed modules needed for hot reloading
+  # and is waiting for the client to request a hot reload.
+  hot_reload_ready_for_client: bool = False
 
   def __init__(self):
     self.component_fns = set()
@@ -156,3 +161,4 @@ def enable_debug_mode():
 
 def hot_reload_finished():
   _runtime.is_hot_reload_in_progress = False
+  _runtime.hot_reload_ready_for_client = True

--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -1,4 +1,5 @@
 import base64
+import time
 from typing import Generator, Sequence
 
 from flask import Flask, Response, abort, request, stream_with_context
@@ -163,5 +164,18 @@ def configure_flask_app(
   def teardown(error=None):
     global _requests_in_flight
     _requests_in_flight -= 1
+
+  if not prod_mode:
+
+    @flask_app.route("/hot-reload")
+    def hot_reload() -> Response:
+      while True:
+        # Sleep a short duration but not too short that we hog up excessive CPU.
+        time.sleep(0.1)
+        if runtime().hot_reload_ready_for_client:
+          break
+      response = Response("OK", status=200)
+      runtime().hot_reload_ready_for_client = False
+      return response
 
   return flask_app

--- a/mesop/web/src/editor/editor.ts
+++ b/mesop/web/src/editor/editor.ts
@@ -25,7 +25,7 @@ import {DevTools} from '../dev_tools/dev_tools';
 import {DevToolsSettings} from '../dev_tools/services/dev_tools_settings';
 import {
   HotReloadWatcher,
-  IbazelHotReloadWatcher,
+  DefaultHotReloadWatcher,
 } from '../services/hot_reload_watcher';
 import {Shell} from '../shell/shell';
 import {EditorService, SelectionMode} from '../services/editor_service';
@@ -50,7 +50,7 @@ import {CommandDialogService} from '../dev_tools/command_dialog/command_dialog_s
     MatSidenavModule,
     Shell,
   ],
-  providers: [{provide: HotReloadWatcher, useClass: IbazelHotReloadWatcher}],
+  providers: [{provide: HotReloadWatcher, useClass: DefaultHotReloadWatcher}],
   styleUrl: 'editor.css',
 })
 class Editor {

--- a/mesop/web/src/services/hot_reload_watcher.ts
+++ b/mesop/web/src/services/hot_reload_watcher.ts
@@ -1,3 +1,8 @@
+/**
+ * This module primarily serves as an interface for the
+ * hot reloader mechanism used in downstream.
+ */
+
 import {Injectable} from '@angular/core';
 import {Channel} from './channel';
 
@@ -11,27 +16,11 @@ export abstract class HotReloadWatcher {
   }
 }
 
-/** Encapsulates all ibazel-specific implementation details of hot reload watcher. */
+/** Simple implementation of a hot reload watcher. */
 @Injectable()
-export class IbazelHotReloadWatcher extends HotReloadWatcher {
+export class DefaultHotReloadWatcher extends HotReloadWatcher {
   constructor(channel: Channel) {
     super(channel);
-    if (anyWindow['LiveReload']) {
-      this.monkeyPatchLiveReload();
-    } else {
-      console.log('LiveReload not detected; polling hot reload instead.');
-      setInterval(() => {
-        channel.hotReload();
-      }, 500);
-    }
-  }
-
-  monkeyPatchLiveReload(): void {
-    // Since I couldn't find an official livereload API to tap into
-    // I'm hacking this by monkeypatching reloadPage, which is effectively
-    // a wrapper around document.reload().
-    anyWindow['LiveReload']['reloader']['reloadPage'] = () => {
-      this.handleReload();
-    };
+    channel.checkForHotReload();
   }
 }


### PR DESCRIPTION
This PR has two goals:

1. Fix the DevEx issues described in #199.
2. Unify the hot reload mechanism between `ibazel` and `mesop` CLI. This way if we break one, particularly for the `mesop` CLI, we will feel the pain right away as framework developers.

This creates a new HTTP endpoint "/hot-reload" that the Mesop client app long polls against. If "/hot-reload" returns a 200 (OK) HTTP response this means the Mesop server has finished re-executing the changed modules, then the Mesop client app triggers a hot reload request.

As a nice side-effect, this avoids the ibazel livereload mechanism which is somewhat hairy and relies on this pre-compiled [JS file](https://github.com/jaschaephraim/lrserver/blob/afed386b3640edd11a398a686f178a810530c990/livereload_v4.0.2/livereload.js).

Fixes #199.

Note: this will require downstream updates.