### PR TITLE
Make hot reloading work with multiple clients

### DIFF
--- a/mesop/runtime/runtime.py
+++ b/mesop/runtime/runtime.py
@@ -35,9 +35,9 @@ class Runtime:
   # If True, then the server is still re-executing the modules
   # needed for hot reloading.
   is_hot_reload_in_progress: bool = False
-  # If True, then the server has re-executed modules needed for hot reloading
-  # and is waiting for the client to request a hot reload.
-  hot_reload_ready_for_client: bool = False
+  # Keeps track of the hot reload count so that the server can tell
+  # clients polling whether to request a hot reload.
+  hot_reload_counter = 0
 
   def __init__(self):
     self.component_fns = set()
@@ -150,6 +150,7 @@ def reset_runtime():
   old_runtime = _runtime
   _runtime = Runtime()
   _runtime.is_hot_reload_in_progress = True
+  _runtime.hot_reload_counter = old_runtime.hot_reload_counter
   _runtime.debug_mode = old_runtime.debug_mode
   _runtime.component_fns = old_runtime.component_fns
   _runtime.event_mappers = old_runtime.event_mappers
@@ -161,4 +162,4 @@ def enable_debug_mode():
 
 def hot_reload_finished():
   _runtime.is_hot_reload_in_progress = False
-  _runtime.hot_reload_ready_for_client = True
+  _runtime.hot_reload_counter += 1

--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -169,13 +169,13 @@ def configure_flask_app(
 
     @flask_app.route("/hot-reload")
     def hot_reload() -> Response:
+      counter = int(request.args["counter"])
       while True:
+        if counter < runtime().hot_reload_counter:
+          break
         # Sleep a short duration but not too short that we hog up excessive CPU.
         time.sleep(0.1)
-        if runtime().hot_reload_ready_for_client:
-          break
-      response = Response("OK", status=200)
-      runtime().hot_reload_ready_for_client = False
+      response = Response(str(runtime().hot_reload_counter), status=200)
       return response
 
   return flask_app


### PR DESCRIPTION
Fixes #200. 

The problem before this was that if there were multiple clients (e.g. multiple tabs, multiple frames) connected to the same Mesop development server, then only one of the client would be properly signaled to do a hot reload because Runtime is a singleton and `hot_reload_ready_for_client` was set to True as soon as one client was signaled to do a hot reload request.

This makes the hot reload watching protocol more robust by having the client send its current hot reload count and comparing whether the server has a higher count.

Note: if the client misses a hot reload event (e.g. the count is off by more than 1), it's not a big deal because the client will effectively just catch up to the latest.