### PR TITLE
Redact internal & developer error messages in prod mode

### DIFF
--- a/mesop/exceptions/__init__.py
+++ b/mesop/exceptions/__init__.py
@@ -10,6 +10,13 @@ class MesopUserException(MesopException):
     return f"**User Error:** {super().__str__()}"
 
 
+##########################################################
+# Internal / system errors:
+# DO NOT CHANGE THE MESSAGE WITHOUT UPDATING server.py's
+# REDACTION LOGIC.
+##########################################################
+
+
 class MesopInternalException(MesopException):
   def __str__(self):
     return f"**Mesop Internal Error:** {super().__str__()}"

--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -70,6 +70,14 @@ def configure_flask_app(
   def yield_errors(error: pb.ServerError) -> Generator[str, None, None]:
     if not runtime().debug_mode:
       error.ClearField("traceback")
+      # Redact developer errors
+      if "Mesop Internal Error:" in error.exception:
+        error.exception = "Sorry, there was an internal error with Mesop."
+      if "Mesop Developer Error:" in error.exception:
+        error.exception = (
+          "Sorry, there was an error. Please contact the developer."
+        )
+
     ui_response = pb.UiResponse(error=error)
 
     yield serialize(ui_response)


### PR DESCRIPTION
Avoid leaking internal implementation details to end-users.

Note: MesopUserExceptions and general exceptions are still shown to the user.