### PR TITLE
Remove unnecessary detail (event) from hot reload print

### DIFF
--- a/mesop/bin/bin.py
+++ b/mesop/bin/bin.py
@@ -148,7 +148,7 @@ class ReloadEventHandler(FileSystemEventHandler):
     if src_path.endswith(".py"):
       try:
         self.count += 1
-        print(f"Hot reload #{self.count}: starting...", event)
+        print(f"Hot reload #{self.count}: starting...")
         reset_runtime()
         execute_main_module(absolute_path=self.absolute_path)
         hot_reload_finished()


### PR DESCRIPTION
Accidentally left it in https://github.com/google/mesop/commit/03ebcc5b4cd4cf301b84311b8601ea1ea1d8f588