### PR TITLE
Create a demo page to iframe the demo site & update demo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Mesop is a Python-based UI framework that allows you to rapidly build web apps l
 
 ## Write your first Mesop app in less than 10 lines of code...
 
-[Demo app](https://mesop-y677hytkra-uc.a.run.app/text_io)
+[Demo app](https://google.github.io/mesop/demo/text_io)
 
 ```python
 import time

--- a/docs/components/audio.md
+++ b/docs/components/audio.md
@@ -4,7 +4,7 @@ Audio is the equivalent of an [`<audio>` HTML element](https://developer.mozilla
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/audio" style="height: 80px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=audio" style="height: 80px"></iframe>
 
 ```python
 --8<-- "demo/audio.py"

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -4,7 +4,7 @@ Badge decorates a UI component and is oftentimes used for unread message count a
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/badge" style="height: 100px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=badge" style="height: 100px"></iframe>
 
 ```python
 --8<-- "demo/badge.py"

--- a/docs/components/box.md
+++ b/docs/components/box.md
@@ -4,7 +4,7 @@ Box is a [content component](../guides/components.md#content-components) which a
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/box" style="height: 160px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=box" style="height: 160px"></iframe>
 
 ```python
 --8<-- "demo/box.py"

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -4,7 +4,7 @@ Button is based on the [Angular Material button component](https://material.angu
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/button" style="height: 200px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=button" style="height: 200px"></iframe>
 
 ```python
 --8<-- "demo/button.py"

--- a/docs/components/chat.md
+++ b/docs/components/chat.md
@@ -4,7 +4,7 @@ Chat component is a quick way to create a simple chat interface. Chat is part of
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/chat"></iframe>
+<iframe class="component-demo" src="/demo/?demo=chat"></iframe>
 
 ```python
 --8<-- "demo/chat.py"

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -4,7 +4,7 @@ Checkbox is a multi-selection form control and is based on the [Angular Material
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/checkbox" style="height: 100px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=checkbox" style="height: 100px"></iframe>
 
 ```python
 --8<-- "demo/checkbox.py"

--- a/docs/components/code.md
+++ b/docs/components/code.md
@@ -4,7 +4,7 @@ Code is used to render code with syntax highlighting. `code` is a simple wrapper
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/code"></iframe>
+<iframe class="component-demo" src="/demo/?demo=code"></iframe>
 
 ```python
 --8<-- "demo/code.py"

--- a/docs/components/divider.md
+++ b/docs/components/divider.md
@@ -4,7 +4,7 @@ Divider is used to provide visual separation and is based on the [Angular Materi
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/divider" style="height: 100px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=divider" style="height: 100px"></iframe>
 
 ```python
 --8<-- "demo/divider.py"

--- a/docs/components/embed.md
+++ b/docs/components/embed.md
@@ -4,7 +4,7 @@ Embed allows you to embed/[iframe](https://developer.mozilla.org/en-US/docs/Web/
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/embed"></iframe>
+<iframe class="component-demo" src="/demo/?demo=embed"></iframe>
 
 ```python
 --8<-- "demo/embed.py"

--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -4,7 +4,7 @@ Icon displays a Material icon/symbol and is based on the [Angular Material icon 
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/icon" style="height: 60px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=icon" style="height: 60px"></iframe>
 
 ```python
 --8<-- "demo/icon.py"

--- a/docs/components/image.md
+++ b/docs/components/image.md
@@ -4,7 +4,7 @@ Image is the equivalent of an [`<img>` HTML element](https://developer.mozilla.o
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/image" style="height: 200px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=image" style="height: 200px"></iframe>
 
 ```python
 --8<-- "demo/image.py"

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -6,7 +6,7 @@ For longer text inputs, also see [Textarea](./textarea.md)
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/input" style="height: 120px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=input" style="height: 120px"></iframe>
 
 ```python
 --8<-- "demo/input.py"

--- a/docs/components/markdown.md
+++ b/docs/components/markdown.md
@@ -4,7 +4,7 @@ Markdown is used to render markdown text.
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/markdown_demo"></iframe>
+<iframe class="component-demo" src="/demo/?demo=markdown_demo"></iframe>
 
 ```python
 --8<-- "demo/markdown_demo.py"

--- a/docs/components/plot.md
+++ b/docs/components/plot.md
@@ -4,7 +4,7 @@ Plot provides a convenient way to render [Matplotlib](https://matplotlib.org/) f
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/plot"></iframe>
+<iframe class="component-demo" src="/demo/?demo=plot"></iframe>
 
 ```python
 --8<-- "demo/plot.py"

--- a/docs/components/progress_bar.md
+++ b/docs/components/progress_bar.md
@@ -4,7 +4,7 @@ Progress Bar is used to indicate something is in progress and is based on the [A
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/progress_bar" style="height: 60px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=progress_bar" style="height: 60px"></iframe>
 
 ```python
 --8<-- "demo/progress_bar.py"

--- a/docs/components/progress_spinner.md
+++ b/docs/components/progress_spinner.md
@@ -5,7 +5,7 @@ Progress Spinner is used to indicate something is in progress and is based on th
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/progress_spinner" style="height: 70px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=progress_spinner" style="height: 70px"></iframe>
 
 ```python
 --8<-- "demo/progress_spinner.py"

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -4,7 +4,7 @@ Radio is a single selection form control based on the [Angular Material radio co
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/radio" style="height: 100px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=radio" style="height: 100px"></iframe>
 
 ```python
 --8<-- "demo/radio.py"

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -4,7 +4,7 @@ Select allows the user to choose from a list of values and is based on the [Angu
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/select" style="height: 200px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=select" style="height: 200px"></iframe>
 
 ```python
 --8<-- "demo/select.py"

--- a/docs/components/sidenav.md
+++ b/docs/components/sidenav.md
@@ -4,7 +4,7 @@ Sidenav is a sidebar typically used for navigation and is based on the [Angular 
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/sidenav" style="height: 100px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=sidenav" style="height: 100px"></iframe>
 
 ```python
 --8<-- "demo/sidenav.py"

--- a/docs/components/slide_toggle.md
+++ b/docs/components/slide_toggle.md
@@ -4,7 +4,7 @@ Slide Toggle allows the user to toggle on and off and is based on the [Angular M
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/slide_toggle" style="height: 100px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=slide_toggle" style="height: 100px"></iframe>
 
 ```python
 --8<-- "demo/slide_toggle.py"

--- a/docs/components/slider.md
+++ b/docs/components/slider.md
@@ -4,7 +4,7 @@ Slider allows the user to select from a range of values and is based on the [Ang
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/slider" style="height: 120px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=slider" style="height: 120px"></iframe>
 
 ```python
 --8<-- "demo/slider.py"

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -4,7 +4,7 @@ Table allows the user to render an [Angular Material table component](https://ma
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/table"></iframe>
+<iframe class="component-demo" src="/demo/?demo=table"></iframe>
 
 ```python
 --8<-- "demo/table.py"

--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -4,7 +4,7 @@ Text displays text as-is. If you have markdown text, use the [Markdown](./markdo
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/text"></iframe>
+<iframe class="component-demo" src="/demo/?demo=text"></iframe>
 
 ```python
 --8<-- "demo/text.py"

--- a/docs/components/text_to_image.md
+++ b/docs/components/text_to_image.md
@@ -4,7 +4,7 @@ Text To Image component is a quick and simple way of getting started with Mesop.
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/text_to_image"></iframe>
+<iframe class="component-demo" src="/demo/?demo=text_to_image"></iframe>
 
 ```python
 --8<-- "demo/text_to_image.py"

--- a/docs/components/text_to_text.md
+++ b/docs/components/text_to_text.md
@@ -4,7 +4,7 @@ Text to text component allows you to take in user inputted text and return a tra
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/text_to_text"></iframe>
+<iframe class="component-demo" src="/demo/?demo=text_to_text"></iframe>
 
 ```python
 --8<-- "demo/text_to_text.py"

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -6,7 +6,7 @@ This is similar to [Input](./input.md), but Textarea is better suited for long t
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/textarea" style="height: 200px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=textarea" style="height: 200px"></iframe>
 
 ```python
 --8<-- "demo/textarea.py"

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -4,7 +4,7 @@ Tooltip is based on the [Angular Material tooltip component](https://material.an
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/tooltip" style="height: 100px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=tooltip" style="height: 100px"></iframe>
 
 ```python
 --8<-- "demo/tooltip.py"

--- a/docs/components/uploader.md
+++ b/docs/components/uploader.md
@@ -5,7 +5,7 @@ matches the look of Angular Material Components.
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/uploader" style="height: 200px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=uploader" style="height: 200px"></iframe>
 
 ```python
 --8<-- "demo/uploader.py"

--- a/docs/components/video.md
+++ b/docs/components/video.md
@@ -4,7 +4,7 @@ Video is the equivalent of an [`<video>` HTML element](https://developer.mozilla
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/video" style="height: 300px"></iframe>
+<iframe class="component-demo" src="/demo/?demo=video" style="height: 300px"></iframe>
 
 ```python
 --8<-- "demo/video.py"

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,7 @@
+---
+hide:
+  - navigation
+  - toc
+---
+<link rel="stylesheet" href="/stylesheets/demo.css">
+<script src="/javascript/demo.js"></script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,9 +53,9 @@ Mesop is a Python-based UI framework that allows you to rapidly build web apps l
 
 <h2 style="margin: 0.5rem"> See what you can build in less than 10 lines of code... </h2>
 
-<iframe class="immersive-demo" src="https://mesop-y677hytkra-uc.a.run.app/"></iframe>
+<iframe class="immersive-demo" src="/demo/"></iframe>
 
-Check out how the above [demo gallery](https://mesop-y677hytkra-uc.a.run.app/) was [built in pure Mesop](https://github.com/google/mesop/blob/main/demo/main.py)!
+Check out how the above [demo gallery](./demo.md) was [built in pure Mesop](https://github.com/google/mesop/blob/main/demo/main.py)!
 
 ## Try it
 

--- a/docs/javascript/demo.js
+++ b/docs/javascript/demo.js
@@ -1,0 +1,7 @@
+const urlParams = new URLSearchParams(window.location.search);
+const demoParam = urlParams.get('demo') || '';
+
+const iframe = document.createElement('iframe');
+iframe.src = 'https://mesop-tdcukehw6q-uc.a.run.app/' + demoParam;
+iframe.className = 'full-screen-iframe';
+document.body.appendChild(iframe);

--- a/docs/stylesheets/demo.css
+++ b/docs/stylesheets/demo.css
@@ -1,0 +1,10 @@
+header,
+.md-container {
+  display: none !important;
+}
+
+.full-screen-iframe {
+  border: 0;
+  width: 100vw;
+  height: 100vh;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,7 @@ nav:
       - Advanced:
           - Embed: components/embed.md
           - Plot: components/plot.md
-  - Demo Gallery 🔗: https://mesop-y677hytkra-uc.a.run.app/
+  - Demo Gallery 🔗: demo.md
   - Blog:
       - blog/index.md
   - Internal:
@@ -100,7 +100,8 @@ theme:
 
 extra_css:
   - stylesheets/extra.css
-
+extra_javascript:
+  - javascripts/extra.js
 markdown_extensions:
   - attr_list
   - pymdownx.emoji:


### PR DESCRIPTION
**Summary of changes:**
- Because we don't have a permanent domain/address to host the demo site (e.g. mesop.dev), I wanted to create a more permanent link than the Cloud Run generated URLs, e.g. https://mesop-y677hytkra-uc.a.run.app so that if we switch GCP projects, our demo links won't break. I do this through some trickery with mkdocs material and using demo.md as effectively an iframe host.
- The one downside to this approach is that if you click on a new demo, the URL doesn't update automatically (note: if you update the URL though, then the iframe src is updated). We could theoretically update the URL through some postMessage, but this is rather complicated and doesn't seem like too big of an issue.
- This switches the Cloud Run URL from my personal GCP project to a Google-owned GCP project.