### PR TITLE
Make labs.chat text easier to read

### DIFF
--- a/mesop/labs/chat.py
+++ b/mesop/labs/chat.py
@@ -48,7 +48,7 @@ _STYLE_CHAT_INPUT = me.Style(width="100%")
 _STYLE_CHAT_INPUT_BOX = me.Style(padding=me.Padding(top=30))
 _STYLE_CHAT_BUBBLE_NAME = me.Style(
   font_weight="bold",
-  font_size="12px",
+  font_size="13px",
   padding=me.Padding(left=15, right=15, bottom=5),
 )
 _STYLE_CHAT_BUBBLE_PLAINTEXT = me.Style(margin=me.Margin(top=15, bottom=15))
@@ -100,7 +100,8 @@ def _make_chat_bubble_style(role: Role) -> me.Style:
   )
   return me.Style(
     width="80%",
-    font_size="13px",
+    font_size="16px",
+    line_height="1.5",
     background=background,
     border_radius="15px",
     padding=me.Padding(right=15, left=15, bottom=3),


### PR DESCRIPTION
I find it somewhat hard to read the chat text - WDYT about adjusting it higher? (We could also make it configurable via a parameter, but generally I think chat UIs are around this font size).

**Before:**

<img width="1034" alt="Screenshot 2024-05-15 at 7 30 57 PM" src="https://github.com/google/mesop/assets/7344640/10c575c7-e7aa-4926-8383-65de038927f0">

**After:**

<img width="1047" alt="Screenshot 2024-05-15 at 7 29 25 PM" src="https://github.com/google/mesop/assets/7344640/b95a9336-ebf7-4b88-95df-3a92b3d2ae9a">
