### PR TITLE
Polish the editor/devtools UX

### DIFF
--- a/mesop/web/src/dev_tools/dev_tools.scss
+++ b/mesop/web/src/dev_tools/dev_tools.scss
@@ -3,11 +3,11 @@
   height: 100%;
   display: block;
   background: #fff;
+  border-left: 1px solid #dcdcdc;
 }
 
 .panel-header {
   border-bottom: 1px solid #dcdcdc;
-  border-left: 1px solid #dcdcdc;
   display: flex;
   font-size: 0.9rem;
   position: fixed;

--- a/mesop/web/src/editor/editor.ng.html
+++ b/mesop/web/src/editor/editor.ng.html
@@ -1,17 +1,11 @@
 <mat-sidenav-container class="container">
   <mat-sidenav-content #sidenavContent class="content">
-    <div class="content-frame-border">
-      <mesop-shell></mesop-shell>
-      <div #dragHandle class="resize-handle"></div>
-      <div class="editor-button-container">
-        <button
-          class="editor-button"
-          mat-icon-button
-          (click)="toggleDevTools()"
-        >
-          <mat-icon>code</mat-icon>
-        </button>
-      </div>
+    <mesop-shell></mesop-shell>
+    <div #dragHandle class="resize-handle" [hidden]="!showDevTools()"></div>
+    <div class="editor-button-container">
+      <button class="editor-button" mat-icon-button (click)="toggleDevTools()">
+        <mat-icon>code</mat-icon>
+      </button>
     </div>
   </mat-sidenav-content>
   <mat-sidenav

--- a/mesop/web/src/editor/editor.scss
+++ b/mesop/web/src/editor/editor.scss
@@ -6,12 +6,6 @@
   overflow: hidden;
 }
 
-.content-frame-border {
-  border: 1px solid #dcdcdc;
-  height: 100%;
-  overflow: auto;
-}
-
 .right-sidenav {
   width: 420px;
 }


### PR DESCRIPTION
Fixes #244.

- Removes the slight border around the app content when developing in editor mode. Instead, we put a border on the devtools panel itself to provide visual distinction.
- This fixes an unrelated issue in the same area where you can accidentally resize devtools even when devtools isn't open, which creates a funky situation. I originally wanted the resizer there in case people resize devtools to be too small, but in that case you can always reload the page and you'll see the devtools at the default width.