### PR TITLE
Implement gzipping for static file serving

### DIFF
--- a/mesop/server/BUILD
+++ b/mesop/server/BUILD
@@ -24,3 +24,9 @@ py_test(
     srcs = ["wsgi_app_test.py"],
     deps = [":server"] + THIRD_PARTY_PY_PYTEST,
 )
+
+py_test(
+    name = "static_file_serving_test",
+    srcs = ["static_file_serving_test.py"],
+    deps = [":server"] + THIRD_PARTY_PY_PYTEST,
+)

--- a/mesop/server/static_file_serving_test.py
+++ b/mesop/server/static_file_serving_test.py
@@ -1,0 +1,64 @@
+import gzip
+import tempfile
+from io import BytesIO
+
+from flask import Flask
+
+from mesop.server.static_file_serving import gzip_cache, send_file_compressed
+
+
+def test_send_file_compressed_uncached_request():
+  app = Flask(__name__)
+  with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+    file_content = b"abc"
+    tmp_file.write(file_content)
+    tmp_file_path = tmp_file.name
+
+  with app.test_request_context():
+    response = send_file_compressed(tmp_file_path)
+
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.direct_passthrough is False
+    assert int(response.headers["Content-Length"]) == len(response.get_data())
+
+    # Check if the ungzipped data is correct
+    with gzip.GzipFile(fileobj=BytesIO(response.get_data()), mode="rb") as f:
+      ungzipped_data = f.read()
+      assert ungzipped_data == file_content
+
+    # Check that cache is properly stored
+    assert len(gzip_cache) == 1
+    assert gzip_cache[tmp_file_path] == response.get_data()
+
+
+def test_send_file_compressed_cached_request():
+  app = Flask(__name__)
+  with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+    tmp_file.write(b"")
+    tmp_file_path = tmp_file.name
+
+  cached_bytes = b"test_data"
+  gzip_buffer = BytesIO()
+  with gzip.GzipFile(
+    mode="wb", fileobj=gzip_buffer, compresslevel=6
+  ) as gzip_file:
+    gzip_file.write(cached_bytes)
+  gzip_buffer.seek(0)
+  gzip_cache[tmp_file_path] = gzip_buffer.getvalue()
+  with app.test_request_context():
+    response = send_file_compressed(tmp_file_path)
+
+    assert response.headers["Content-Encoding"] == "gzip"
+    assert response.direct_passthrough is False
+    assert int(response.headers["Content-Length"]) == len(response.get_data())
+
+    # Check that the cached bytes is returned
+    with gzip.GzipFile(fileobj=BytesIO(response.get_data()), mode="rb") as f:
+      ungzipped_data = f.read()
+      assert ungzipped_data == cached_bytes
+
+
+if __name__ == "__main__":
+  import pytest
+
+  raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
- Fixes #231 
- This produces a significant size savings, particularly for the JS bundle (~4x: 1.6MB -> 400kb for prod mode).
- Although ideally gzipping is handled outside of the Flask server and at another layer (e.g. a web server like NGINX),  there's benefits to doing it in the Flask app because in development use case, particularly with Colab, it can be quite slow to load the JS bundle.
- To avoid paying the cost of gzipping the same files over and over again (~30ms on my local computer), this implements a singleton cache. This is OK assuming that the file contents of what we're caching do not change (for these static files, this should hold true).