### PR TITLE
Setup reasonable default web security policies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,9 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+        # do not fix snapshot files because these are golden
+        # files which need to match the test output exactly.
+        exclude: /snapshots/
       # Suppress check-yaml because of false error:
       # "could not determine a constructor for the tag 'tag:yaml.org,2002:python/name:material.extensions.emoji.twemoji'"
       # - id: check-yaml

--- a/mesop/tests/e2e/snapshots/web_security_test.ts_csp.txt
+++ b/mesop/tests/e2e/snapshots/web_security_test.ts_csp.txt
@@ -1,0 +1,11 @@
+default-src 'self'
+font-src fonts.gstatic.com
+frame-ancestors 'self' https:
+frame-src 'self' https:
+img-src 'self' data: https:
+media-src 'self' data: https:
+style-src 'self' 'nonce-{{NONCE}}' fonts.googleapis.com
+style-src-attr 'unsafe-inline'
+script-src 'self' 'nonce-{{NONCE}}'
+trusted-types angular
+require-trusted-types-for 'script'

--- a/mesop/tests/e2e/web_security_test.ts
+++ b/mesop/tests/e2e/web_security_test.ts
@@ -1,0 +1,17 @@
+// http://localhost:32123/plot
+import {test, expect} from '@playwright/test';
+
+const EXPECTED_CSP =
+  "default-src 'self'; font-src fonts.gstatic.com; frame-ancestors 'self' https:; frame-src 'self' https:; img-src 'self' data: https:; media-src 'self' data: https:; style-src 'self' 'nonce-{{NONCE}}' fonts.googleapis.com; style-src-attr 'unsafe-inline'; script-src 'self' 'nonce-{{NONCE}}'; trusted-types angular; require-trusted-types-for 'script'";
+
+test('ensure web security best practices are followed', async ({page}) => {
+  const response = await page.goto('/');
+  const csp = response?.headers()['content-security-policy'];
+  expect(
+    csp
+      // nonce is randomly generated so we need to replace it with a stable string.
+      ?.replace(/nonce-\w+/g, 'nonce-{{NONCE}}')
+      // A bit of formatting to make it easier to read.
+      .replace(/; /g, '\n'),
+  ).toMatchSnapshot('csp.txt');
+});

--- a/mesop/web/src/app/dev/index.html
+++ b/mesop/web/src/app/dev/index.html
@@ -24,7 +24,9 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
-    <mesop-editor-app>Loading...</mesop-editor-app>
+    <mesop-editor-app ngCspNonce="$$INSERT_CSP_NONCE$$"
+      >Loading...</mesop-editor-app
+    >
     <script src="zone.js/dist/zone.js"></script>
     <script src="bundles/main.js" type="module"></script>
   </body>

--- a/mesop/web/src/app/editor/index.html
+++ b/mesop/web/src/app/editor/index.html
@@ -25,7 +25,9 @@
     <link rel="shortcut icon" href="./favicon.ico" type="image/x-icon" />
   </head>
   <body>
-    <mesop-editor-app>Loading...</mesop-editor-app>
+    <mesop-editor-app ngCspNonce="$$INSERT_CSP_NONCE$$"
+      >Loading...</mesop-editor-app
+    >
     <!-- Inject script (if needed) -->
     <script src="zone.js/dist/zone.js"></script>
     <script src="editor_bundle/bundle.js" type="module"></script>

--- a/mesop/web/src/app/prod/index.html
+++ b/mesop/web/src/app/prod/index.html
@@ -25,7 +25,7 @@
     <link rel="shortcut icon" href="./favicon.ico" type="image/x-icon" />
   </head>
   <body>
-    <mesop-app>Loading...</mesop-app>
+    <mesop-app ngCspNonce="$$INSERT_CSP_NONCE$$">Loading...</mesop-app>
     <!-- Inject script (if needed) -->
     <script src="zone.js/dist/zone.js"></script>
     <script src="prod_bundle.js" type="module"></script>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,6 +18,12 @@ const enableComponentTreeDiffs = process.env.ENABLE_COMPONENT_TREE_DIFFS
 export default defineConfig({
   timeout: process.env.CI ? 20000 : 10000, // Budget more time for CI since tests run slower there.
   testDir: '.',
+  // Use a custom snapshot path template because Playwright's default
+  // is platform-specific which isn't necessary for Mesop e2e tests
+  // which should be platform agnostic (we don't do screenshots; only textual diffs).
+  snapshotPathTemplate:
+    '{testDir}/{testFileDir}/snapshots/{testFileName}_{arg}{ext}',
+
   testMatch: 'e2e/*_test.ts',
   testIgnore: 'scripts/**',
   /* Run tests in files in parallel */


### PR DESCRIPTION
Fixes #225. I opened up #271 because it's the remaining major web security piece we should shore up.

Notes:
- CSP is quite easy to mess up due to weird syntax it uses, so I've done a snapshot test to avoid accidental regressions.
- Using CSP nonce requires us to generate a random string and set it on the server ([ref](https://angular.io/guide/security#content-security-policy:~:text=Set%20the%20ngCspNonce%20attribute%20on%20the%20root%20application%20element%20as%20%3Capp%20ngCspNonce%3D%22randomNonceGoesHere%22%3E%3C/app%3E.%20Use%20this%20approach%20if%20you%20have%20access%20to%20server%2Dside%20templating%20that%20can%20add%20the%20nonce%20both%20to%20the%20header%20and%20the%20index.html%20when%20constructing%20the%20response.))
