### PR TITLE
Stop sending component configs with every render event in Editor mode

### DIFF
--- a/mesop/web/src/shell/shell.ts
+++ b/mesop/web/src/shell/shell.ts
@@ -66,7 +66,11 @@ export class Shell {
       zone: this.zone,
       onRender: (rootComponent, componentConfigs) => {
         this.rootComponent = rootComponent;
-        this.componentConfigs = componentConfigs;
+        // Component configs are only sent for the first response.
+        // For subsequent reponses, use the component configs previously
+        if (componentConfigs.length) {
+          this.componentConfigs = componentConfigs;
+        }
         this.error = undefined;
       },
       onNavigate: (route) => {


### PR DESCRIPTION
Fixes #269.

The previous implementation was naive - sending down all the component configs with every render event which is wasteful and eats >300ms. We can use the component configs from the first render.

The only downside to this change is that if the user adds a new component (e.g. using `@me.component`) it won't send down the new component config, but this isn't that big of a deal because 1) the component will work, it just won't show up in the right-hand devtools/editor panel, and 2) the developer can refresh the page (triggering all the component configs to be resent).