### PR TITLE
Disable gzip in cache in editor mode to make component development easier

### DIFF
--- a/mesop/cli/cli.py
+++ b/mesop/cli/cli.py
@@ -128,6 +128,9 @@ def main(argv: Sequence[str]):
     else EDITOR_PACKAGE_PATH,
     # Keep this palceholder arg; it will be replaced downstream sync.
     livereload_script_url=None,
+    # Disabling the gzip cache in editor mode makes developing components
+    # much easier.
+    disable_gzip_cache=not FLAGS.prod,
   )
 
   if FLAGS.verbose:


### PR DESCRIPTION
#261 inadvertently made developing Mesop Angular components painful because the gzip cache would make client-side changes force a server restart in order to observe the changes.