### PR TITLE
Add angular#unsafe-bypass to CSP

### DIFF
--- a/mesop/server/static_file_serving.py
+++ b/mesop/server/static_file_serving.py
@@ -101,7 +101,8 @@ def configure_static_file_serving(
         # https://github.com/angular/angular/pull/55260
         "style-src-attr": "'unsafe-inline'",
         "script-src": f"'self' 'nonce-{g.csp_nonce}'",
-        "trusted-types": "angular",
+        # https://angular.io/guide/security#enforcing-trusted-types
+        "trusted-types": "angular angular#unsafe-bypass",
         "require-trusted-types-for": "'script'",
       }
     )


### PR DESCRIPTION
This only seems to be needed downstream because we render markdown by setting it to innerHTML which calls https://github.com/angular/angular/blob/f7894885b80dbdca99877569ea98aac2dc175e6c/packages/core/src/sanitization/sanitization.ts#L47

It's unclear how this was working earlier in OSS because even when you use the HTML sanitizer it still relies internally on the bypass APIs