### PR TITLE
Add an on_enter handler for input type components

### DIFF
--- a/mesop/__init__.py
+++ b/mesop/__init__.py
@@ -57,6 +57,7 @@ from mesop.components.divider.divider import divider as divider
 from mesop.components.embed.embed import embed as embed
 from mesop.components.icon.icon import icon as icon
 from mesop.components.image.image import image as image
+from mesop.components.input.input import EnterEvent as EnterEvent
 from mesop.components.input.input import input as input
 from mesop.components.input.input import native_textarea as native_textarea
 from mesop.components.input.input import textarea as textarea

--- a/mesop/components/input/e2e/input_app.py
+++ b/mesop/components/input/e2e/input_app.py
@@ -11,10 +11,15 @@ def on_input(e: me.InputEvent):
   state.input = e.value
 
 
+def on_enter(e: me.EnterEvent):
+  state = me.state(State)
+  state.input = "boo"
+
+
 @me.page(path="/components/input/e2e/input_app")
 def app():
   s = me.state(State)
-  me.input(label="Basic input", on_input=on_input)
+  me.input(label="Basic input", on_input=on_input, on_enter=on_enter)
   me.text(text=s.input)
 
   me.textarea(

--- a/mesop/components/input/e2e/input_test.ts
+++ b/mesop/components/input/e2e/input_test.ts
@@ -4,4 +4,6 @@ test('test input interactivity works', async ({page}) => {
   await page.goto('/components/input/e2e/input_app');
   await page.getByLabel('Basic input').fill('hi');
   expect(await page.getByText('hi').textContent()).toEqual('hi');
+  await page.getByLabel('Basic input').press('Enter');
+  expect(await page.getByText('boo').textContent()).toEqual('boo');
 });

--- a/mesop/components/input/input.ng.html
+++ b/mesop/components/input/input.ng.html
@@ -48,6 +48,7 @@
     [value]="config().getValue()"
     [readonly]="config().getReadonly()"
     (input)="onInput($event)"
+    (keyup)="onKeyUp($event)"
   />
   }
 </mat-form-field>

--- a/mesop/components/input/input.proto
+++ b/mesop/components/input/input.proto
@@ -3,7 +3,7 @@ syntax = "proto2";
 
 package mesop.components.input;
 
-// Next id: 24
+// Next id: 25
 message InputType {
   optional bool disabled = 1;
   optional string id = 2;
@@ -20,6 +20,7 @@ message InputType {
   optional string hint_label = 15;
   optional string label = 16;
   optional string on_input_handler_id = 17;
+  optional string on_enter_handler_id = 24;
   // Used for textarea only.
   optional int32 rows = 18;
   optional bool autosize = 20;

--- a/mesop/components/input/input.py
+++ b/mesop/components/input/input.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
 import mesop.components.input.input_pb2 as input_pb
@@ -5,9 +6,25 @@ from mesop.component_helpers import (
   Style,
   insert_component,
   register_event_handler,
+  register_event_mapper,
   register_native_component,
 )
-from mesop.events import InputEvent
+from mesop.events import InputEvent, MesopEvent
+
+
+@dataclass(kw_only=True)
+class EnterEvent(MesopEvent):
+  """Represents an "Enter" keyboard event."""
+
+  pass
+
+
+register_event_mapper(
+  EnterEvent,
+  lambda event, key: EnterEvent(
+    key=key.key,
+  ),
+)
 
 
 @register_native_component
@@ -92,6 +109,7 @@ def input(
   *,
   label: str = "",
   on_input: Callable[[InputEvent], Any] | None = None,
+  on_enter: Callable[[EnterEvent], Any] | None = None,
   type: Literal[
     "color",
     "date",
@@ -127,6 +145,7 @@ def input(
   Args:
     label: Label for input.
     on_input: [input](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) is a native browser event.
+    on_enter: triggers when the browser detects an "Enter" key on a [keyup](https://developer.mozilla.org/en-US/docs/Web/API/Element/keyup_event) native browser event.
     type: Input type of the element. For textarea, use `me.Textarea(...)`
     appearance: The form field appearance style.
     style: Style for input.
@@ -164,6 +183,9 @@ def input(
       label=label,
       on_input_handler_id=register_event_handler(on_input, event=InputEvent)
       if on_input
+      else "",
+      on_enter_handler_id=register_event_handler(on_enter, event=EnterEvent)
+      if on_enter
       else "",
     ),
     style=style,

--- a/mesop/components/input/input.ts
+++ b/mesop/components/input/input.ts
@@ -82,4 +82,13 @@ export class InputComponent {
     userEvent.setKey(this.key);
     this.channel.dispatch(userEvent);
   }
+
+  onKeyUp(event: Event): void {
+    if ((event as KeyboardEvent).key === 'Enter') {
+      const userEvent = new UserEvent();
+      userEvent.setHandlerId(this.config().getOnEnterHandlerId()!);
+      userEvent.setKey(this.key);
+      this.channel.dispatch(userEvent);
+    }
+  }
 }


### PR DESCRIPTION
Add an `on_enter` handler for `<input type="text">` type components, so that input boxes can be "submitted" using the keyboard. Currently, there's no handler for "Enter", so input boxes are usually "submitted" using a relevant button hooked to a handler.