### PR TITLE
Add some new style properties

### DIFF
--- a/demo/basic_animation.py
+++ b/demo/basic_animation.py
@@ -10,7 +10,19 @@ class State:
   ex2_opacity: float = 1.0
   ex3_width: int
   ex4_left: int
+  ex5_rotate_deg: int
+  ex6_transforms_index: int = 0
 
+
+TRANSFORM_OPERATIONS = [
+  "none",
+  "matrix(1, 2, 3, 4, 5, 6)",
+  "translate(120px, 50%)",
+  "scale(2, 0.5)",
+  "rotate(0.5turn)",
+  "skew(30deg, 20deg)",
+  "scale(0.5) translate(-100%, -100%)",
+]
 
 DEFAULT_MARGIN = me.Style(margin=me.Margin.all(30))
 BUTTON_MARGIN = me.Style(margin=me.Margin.symmetric(vertical=15))
@@ -39,7 +51,7 @@ def app():
         margin=me.Margin.all(10),
       )
     ):
-      me.text("")
+      me.text("Mesop")
 
   with me.box(style=DEFAULT_MARGIN):
     me.text("Fade in / Fade out", type="headline-5")
@@ -59,12 +71,12 @@ def app():
         margin=me.Margin.all(10),
       )
     ):
-      me.text("")
+      me.text("Mesop")
 
   with me.box(style=DEFAULT_MARGIN):
     me.text("Resize", type="headline-5")
     me.text(
-      "Can be used for things like progress bars or opening closing accordion/tabs."
+      "Could be used for things like progress bars or opening closing accordion/tabs."
     )
     me.button(
       "Transform", type="flat", on_click=transform_width, style=BUTTON_MARGIN
@@ -88,7 +100,7 @@ def app():
 
   with me.box(style=DEFAULT_MARGIN):
     me.text("Move", type="headline-5")
-    me.text("Can be used for opening and closing sidebars.")
+    me.text("Could be used for opening and closing sidebars.")
     me.button(
       "Transform", type="flat", on_click=transform_margin, style=BUTTON_MARGIN
     )
@@ -103,6 +115,43 @@ def app():
         )
       ):
         me.text("")
+
+  with me.box(style=DEFAULT_MARGIN):
+    me.text("Rotate", type="headline-5")
+    me.text("Uses the rotate CSS property to emulate a rotation animation.")
+    me.button(
+      "Transform", type="flat", on_click=transform_rotate, style=BUTTON_MARGIN
+    )
+    with me.box():
+      with me.box(
+        style=me.Style(
+          background="rgba(255, 0, 0, 1)",
+          rotate=f"{state.ex5_rotate_deg}deg",
+          width=100,
+          height=100,
+        )
+      ):
+        me.text("Mesop")
+
+  with me.box(style=DEFAULT_MARGIN):
+    me.text("Transform", type="headline-5")
+    me.text("Apply a sequence of transformations.")
+    me.button(
+      "Transform",
+      type="flat",
+      on_click=transform_transform,
+      style=BUTTON_MARGIN,
+    )
+    with me.box():
+      with me.box(
+        style=me.Style(
+          background="rgba(255, 0, 0, 1)",
+          transform=TRANSFORM_OPERATIONS[state.ex6_transforms_index],
+          width=100,
+          height=100,
+        )
+      ):
+        me.text("Mesop")
 
 
 def transform_red_yellow(e: me.ClickEvent):
@@ -168,15 +217,35 @@ def transform_margin(e: me.ClickEvent):
   state = me.state(State)
   if state.ex4_left == 0:
     while state.ex4_left < 200:
-      state.ex4_left += 10
+      state.ex4_left += 5
       yield
-      time.sleep(0.1)
     state.ex4_left = 200
     yield
   else:
     while state.ex4_left > 0:
-      state.ex4_left -= 10
+      state.ex4_left -= 5
       yield
-      time.sleep(0.1)
     state.ex4_left = 0
     yield
+
+
+def transform_rotate(e: me.ClickEvent):
+  """Update the degrees to rotate."""
+  state = me.state(State)
+  if state.ex5_rotate_deg == 0:
+    while state.ex5_rotate_deg < 365:
+      state.ex5_rotate_deg += 5
+      yield
+    state.ex5_rotate_deg = 0
+    yield
+
+
+def transform_transform(e: me.ClickEvent):
+  """Update the index to run different transform operations."""
+  state = me.state(State)
+  while state.ex6_transforms_index < len(TRANSFORM_OPERATIONS):
+    yield
+    time.sleep(0.2)
+    state.ex6_transforms_index += 1
+  state.ex6_transforms_index = 0
+  yield

--- a/mesop/component_helpers/style.py
+++ b/mesop/component_helpers/style.py
@@ -22,6 +22,42 @@ ItemAlignmentValues = Literal[
   "center",
   "start",
   "end",
+  "flex-start",
+  "flex-end",
+  "self-start",
+  "self-end",
+  "baseline",
+  "first baseline",
+  "last baseline",
+  "safe center",
+  "unsafe center",
+  "inherit",
+  "initial",
+  "revert",
+  "revert-layer",
+  "unset",
+]
+ItemJustifyValues = Literal[
+  "normal",
+  "stretch",
+  "center",
+  "start",
+  "end",
+  "flex-start",
+  "flex-end",
+  "self-start",
+  "self-end",
+  "left",
+  "right",
+  "baseline",
+  "first baseline",
+  "last baseline",
+  "safe center",
+  "inherit",
+  "initial",
+  "revert",
+  "revert-layer",
+  "unset",
 ]
 OverflowValues = Literal["visible", "hidden", "clip", "scroll", "auto"]
 OverflowWrapValues = Literal["normal", "break-word", "anywhere"]
@@ -208,6 +244,7 @@ class Style:
   Attributes:
       align_content: Aligns the flexible container's items on the cross-axis. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/align-content).
       align_items: Specifies the default alignment for items inside a flexible container. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items).
+      align_self: Overrides a grid or flex item's align-items value. In Grid, it aligns the item inside the grid area. In Flexbox, it aligns the item on the cross axis. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/align-self).
       aspect_ratio: Specifies the desired width-to-height ratio of a component. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio).
       background: Sets the background color or image of the component. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/background).
       border: Defines the border properties for each side of the component. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/border).
@@ -245,6 +282,8 @@ class Style:
       grid_template_rows: Sets the grid template rows. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-rows).
       height: Sets the height of the component. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/height).
       justify_content: Aligns the flexible container's items on the main-axis. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content).
+      justify_items: Defines the default justify-self for all items of the box, giving them all a default way of justifying each box along the appropriate axis. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items).
+      justify_self: Sets the way a box is justified inside its alignment container along the appropriate axis. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self).
       left: Helps set horizontal position of a positioned element. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/left).
       letter_spacing: Increases or decreases the space between characters in text. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/letter-spacing).
       line height: Set the line height (relative to the font size). See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height).
@@ -257,11 +296,13 @@ class Style:
       padding: Sets the padding space required on each side of an element. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/padding).
       position: Specifies the type of positioning method used for an element (static, relative, absolute, fixed, or sticky). See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/position).
       right: Helps set horizontal position of a positioned element. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/right).
+      rotate: Allows you to specify rotation transforms individually and independently of the transform property. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/rotate).
       row_gap: Sets the gap between rows. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap).
       text_align: Specifies the horizontal alignment of text in an element. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align).
       text_decoration: Specifies the decoration added to text. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration).
       text_overflow: Specifies how overflowed content that is not displayed should be signaled to the user. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow).
       top: Helps set vertical position of a positioned element. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/top).
+      transform: Lets you rotate, scale, skew, or translate an element. It modifies the coordinate space of the CSS visual formatting model. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/transform).
       visibility: Sets the visibility property. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/visibility).
       white_space: Specifies how white space inside an element is handled. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space).
       width: Sets the width of the component. See [MDN doc](https://developer.mozilla.org/en-US/docs/Web/CSS/width).
@@ -273,6 +314,7 @@ class Style:
 
   align_content: ContentAlignmentValues | None = None
   align_items: ItemAlignmentValues | None = None
+  align_self: ItemAlignmentValues | None = None
   aspect_ratio: str | None = None
   background: str | None = None
   border: Border | None = None
@@ -348,7 +390,8 @@ class Style:
   grid_template_rows: str | None = None
   height: int | str | None = None
   justify_content: ContentAlignmentValues | None = None
-  justify_items: ItemAlignmentValues | None = None
+  justify_items: ItemJustifyValues | None = None
+  justify_self: ItemJustifyValues | None = None
   left: int | str | None = None
   letter_spacing: int | str | None = None
   line_height: str | None = None
@@ -370,6 +413,7 @@ class Style:
     | None
   ) = None
   right: int | str | None = None
+  rotate: str | None = None
   row_gap: int | str | None = None
   text_align: (
     Literal[
@@ -384,6 +428,7 @@ class Style:
   text_decoration: Literal["underline", "none"] | None = None
   text_overflow: Literal["ellipsis", "clip"] | None = None
   top: int | str | None = None
+  transform: str | None = None
   visibility: (
     Literal[
       "visible",
@@ -416,6 +461,7 @@ def to_style_proto(s: Style) -> pb.Style:
   return pb.Style(
     align_content=s.align_content,
     align_items=s.align_items,
+    align_self=s.align_self,
     aspect_ratio=s.aspect_ratio,
     background=s.background,
     border=_map_border(s.border),
@@ -454,6 +500,7 @@ def to_style_proto(s: Style) -> pb.Style:
     height=_px_str(s.height),
     justify_content=s.justify_content,
     justify_items=s.justify_items,
+    justify_self=s.justify_self,
     left=_px_str(s.left),
     letter_spacing=_px_str(s.letter_spacing),
     line_height=str(s.line_height),
@@ -466,11 +513,13 @@ def to_style_proto(s: Style) -> pb.Style:
     padding=_map_edge_insets(s.padding),
     position=s.position,
     right=_px_str(s.right),
+    rotate=s.rotate,
     row_gap=_px_str(s.row_gap),
     text_align=s.text_align,
     text_decoration=s.text_decoration,
     text_overflow=s.text_overflow,
     top=_px_str(s.top),
+    transform=s.transform,
     visibility=s.visibility,
     white_space=s.white_space,
     width=_px_str(s.width),

--- a/mesop/protos/ui.proto
+++ b/mesop/protos/ui.proto
@@ -274,10 +274,11 @@ message UserDefinedType {
     repeated Arg args = 1;
 }
 
-// Next id: 62
+// Next id: 67
 message Style {
     optional string align_content = 32;
     optional string align_items = 1;
+    optional string align_self = 63;
     optional string aspect_ratio = 50;
     optional string background = 2;
     optional Border border = 3;
@@ -316,6 +317,7 @@ message Style {
     optional string height = 15;
     optional string justify_content = 16;
     optional string justify_items = 42;
+    optional string justify_self = 64;
     optional string left = 54;
     optional string letter_spacing = 17;
     optional string line_height = 31;
@@ -328,11 +330,13 @@ message Style {
     optional EdgeInsets padding = 21;
     optional string position = 22;
     optional string right = 55;
+    optional string rotate = 66;
     optional string row_gap = 43;
     optional string text_align = 23;
     optional string text_decoration = 24;
     optional string text_overflow = 25;
     optional string top = 56;
+    optional string transform = 65;
     optional string visibility = 51;
     optional string white_space = 26;
     optional string width = 27;

--- a/mesop/web/src/utils/styles.ts
+++ b/mesop/web/src/utils/styles.ts
@@ -11,6 +11,9 @@ export function formatStyle(styleObj: Style): string {
   if (styleObj.getAlignItems()) {
     style += `align-items: ${styleObj.getAlignItems()};`;
   }
+  if (styleObj.getAlignSelf()) {
+    style += `align-self: ${styleObj.getAlignSelf()};`;
+  }
   if (styleObj.getAspectRatio()) {
     style += `aspect-ratio: ${styleObj.getAspectRatio()};`;
   }
@@ -144,6 +147,9 @@ export function formatStyle(styleObj: Style): string {
   if (styleObj.getJustifyItems()) {
     style += `justify-items: ${styleObj.getJustifyItems()};`;
   }
+  if (styleObj.getJustifySelf()) {
+    style += `justify-self: ${styleObj.getJustifySelf()};`;
+  }
   if (styleObj.getLeft()) {
     style += `left: ${styleObj.getLeft()};`;
   }
@@ -186,6 +192,9 @@ export function formatStyle(styleObj: Style): string {
   if (styleObj.getRight()) {
     style += `right: ${styleObj.getRight()};`;
   }
+  if (styleObj.getRotate()) {
+    style += `rotate: ${styleObj.getRotate()};`;
+  }
   if (styleObj.getRowGap()) {
     style += `row-gap: ${styleObj.getRowGap()};`;
   }
@@ -200,6 +209,9 @@ export function formatStyle(styleObj: Style): string {
   }
   if (styleObj.getTop()) {
     style += `top: ${styleObj.getTop()};`;
+  }
+  if (styleObj.getTransform()) {
+    style += `transform: ${styleObj.getTransform()};`;
   }
   if (styleObj.getVisibility()) {
     style += `visibility: ${styleObj.getVisibility()};`;


### PR DESCRIPTION
Properties added:

- rotate
- transform
- justify_self
- align_self

One thing to note here is that I noticed justify_self/justify_items and align_self/align_items do not have the exact same property values. Also there were some property values missing from the ItemAlignmentValues Literal definition. I ended up adding the missing values and creating a separate Literal definition for justify_self/justify_items. I believe this should be ok since it's just a Literal definition, so API should be the same still.

Also added some animation examples using rotate and transform.

- Fixes #302
- Fixes #303