### PR TITLE
Create an editor_cli target to make edit/refresh cycle faster

### DIFF
--- a/mesop/cli/BUILD
+++ b/mesop/cli/BUILD
@@ -42,6 +42,23 @@ py_binary(
     deps = [":cli_lib"],
 )
 
+# Editor CLI
+py_binary(
+    name = "editor_cli",
+    srcs = ["cli.py"],
+    data = COMMON_DATA + [
+        "//mesop/web/src/app/editor:web_package",
+    ],
+    main = "cli.py",
+    tags = [
+        # This tag instructs ibazel to pipe into stdin a event describing actions.
+        "ibazel_notify_changes",
+    ],
+    # Need to expose for Colab usage
+    visibility = ["//build_defs:mesop_users"],
+    deps = [":cli_lib"],
+)
+
 # Dev CLI
 py_binary(
     name = "dev_cli",

--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -1,2 +1,3 @@
+# Uses editor_cli which provides a faster development cycle than the regular "cli" target.
 (lsof -t -i:32123 | xargs kill) || true && \
-ibazel run //mesop/cli -- --path="mesop/mesop/example_index.py" --reload_demo_modules
+ibazel run //mesop/cli:editor_cli -- --path="mesop/mesop/example_index.py" --reload_demo_modules


### PR DESCRIPTION
Fixes #289.

By removing the prod dependency (JS binary) it makes the edit/refresh cycle much faster for client-side changes.