### PR TITLE
Add devcontainer support for Mesop dev.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+  "name": "Mesop developer environment",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "mesop",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "files.autoSave": "onFocusChange",
+        "yaml.schemas": {
+          "https://squidfunk.github.io/mkdocs-material/schema.json": "mkdocs.yml"
+        },
+        "yaml.customTags": [
+          "!ENV scalar",
+          "!ENV sequence",
+          "tag:yaml.org,2002:python/name:material.extensions.emoji.to_svg",
+          "tag:yaml.org,2002:python/name:material.extensions.emoji.twemoji",
+          "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format"
+        ],
+        "[typescript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        },
+        "editor.formatOnSave": true,
+        "search.exclude": {
+          "**/tmp/**": true,
+          "bazel-bin/**": true,
+          "bazel-out/**": true,
+          "bazel-mesop/**": true
+        },
+        "python.analysis.extraPaths": ["./bazel-bin"]
+      },
+      "extensions": [
+        "esbenp.prettier-vscode",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff"
+      ]
+    }
+  },
+  "workspaceFolder": "/workspaces/mesop",
+  "postCreateCommand": "bash scripts/devcontainer_setup.sh"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM python:3.10.14-bullseye
+
+RUN apt-get update && \
+  apt-get install -y \
+  # General dependencies
+  curl \
+  locales \
+  locales-all \
+  lsof \
+  tmux \
+  vim && \
+  # Clean local repository of package files since they won't be needed anymore.
+  # Make sure this line is called after all apt-get update/install commands have
+  # run.
+  apt-get clean && \
+  # Also delete the index files which we also don't need anymore.
+  rm -rf /var/lib/apt/lists/*
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Install nvm/node.js
+RUN mkdir -p /usr/local/nvm
+ENV NVM_DIR /usr/local/nvm
+ENV NVM_VERSION=0.39.7
+ENV NODE_VERSION=18.19.1
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$NVM_VERSION/install.sh | bash
+RUN bash --login -c "nvm install $NODE_VERSION && nvm use $NODE_VERSION"
+ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin
+ENV PATH $NODE_PATH:$PATH
+
+# Install Bazel tools
+RUN npm install -g yarn @bazel/bazelisk @bazel/ibazel
+
+RUN groupadd -g 900 mesop-dev && useradd -u 900 -s /bin/bash -g mesop-dev mesop-dev && \
+  mkdir /home/mesop-dev && \
+  mkdir -p /home/mesop-dev/.vscode-server/extensions && \
+  chown -R mesop-dev:mesop-dev /home/mesop-dev
+
+USER mesop-dev
+
+WORKDIR /workspaces/mesop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.9'
+services:
+  mesop:
+    build: .
+    volumes:
+      - .:/workspaces/mesop
+      - node_modules:/workspace/mesop/node_modules
+      - vscode_extensions:/home/mesop-dev/.vscode-server/extensions
+    ports:
+      - '32123:32123'
+    tty: true
+
+volumes:
+  # Store node modules on volume for better performance. Also prevents overwriting node
+  # node modules installed on host machine via bind mount.
+  node_modules:
+  vscode_extensions:

--- a/scripts/devcontainer_setup.sh
+++ b/scripts/devcontainer_setup.sh
@@ -1,0 +1,25 @@
+# postCreateCommands for devcontainer.json
+
+# Ensure that the node modules directory is writable.
+#
+# We're storing node modules on a Docker volume (not to be confused with bind mounts on
+# the host OS) for better performance. When this volume gets created, it is owned by
+# root.
+sudo chown mesop-dev:mesop-dev node_modules
+
+# Update third party python packages needed for Mesop.
+bazel run //build_defs:pip_requirements.update
+
+# Virtual Env to use with VS Code.
+bazel run //mesop/cli:cli.venv
+source .cli.venv/bin/activate
+
+# Allows VS Code to recognize third party dependencies.
+pip install -r build_defs/requirements_lock.txt
+
+# Allows VS Code to recognize protos.
+./scripts/setup_proto_py_modules.sh
+
+# Precommit support for Git (installs into venv)
+pip install pre-commit==3.7.1
+pre-commit install


### PR DESCRIPTION
- This change allows one click installation with Github Codespaces
  - Using the default resources, it does take a long time to install
- This change also allows remote container dev in VSCode
  - Running ibazel in the container is  a bit slow
  - Does not support Linux ARM yet. See #361
  - Also can't push commits unless ssh keys are set up
    - Need to see if there is a better way to do that
- Will add docs later
- Probably still need to work out various kinks

Ref #101

# Mesop Demo from Codespaces
<img width="1404" alt="Screenshot 2024-06-05 at 8 16 17 PM" src="https://github.com/google/mesop/assets/539889/c3f61a72-3ef6-4581-85f8-6932753b0bbf">

# Mesop VSCode workspace from Codespaces
<img width="1915" alt="Screenshot 2024-06-05 at 8 16 34 PM" src="https://github.com/google/mesop/assets/539889/d6e75fc3-b514-43e4-acf3-401d1e8b1bf7">
