### PR TITLE
Demo gallery: open github link in new tab/window

### DIFF
--- a/demo/main.py
+++ b/demo/main.py
@@ -513,7 +513,7 @@ def header(demo_name: str | None = None):
           ),
         ):
           me.markdown(
-            "<a href='https://github.com/google/mesop/'>google/mesop</a>",
+            "<a href='https://github.com/google/mesop/' target='_blank'>google/mesop</a>",
             style=me.Style(
               font_size=18,
               margin=me.Margin(left=8, right=4, bottom=-16, top=-16),


### PR DESCRIPTION
Otherwise, there's an error because the demo gallery runs in an iframe and the GitHub repo page prohibits being iframed.