### PR TITLE
Add sudo support inside Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
   locales-all \
   lsof \
   tmux \
+  sudo \
   vim \
   # Playwright dependencies
   # This is the equivalent of `sudo yarn playwright install-deps`. We add these manually
@@ -54,7 +55,9 @@ RUN npm install -g yarn @bazel/bazelisk @bazel/ibazel
 RUN groupadd -g 900 mesop-dev && useradd -u 900 -s /bin/bash -g mesop-dev mesop-dev && \
   mkdir /home/mesop-dev && \
   mkdir -p /home/mesop-dev/.vscode-server/extensions && \
-  chown -R mesop-dev:mesop-dev /home/mesop-dev
+  chown -R mesop-dev:mesop-dev /home/mesop-dev \
+  && echo mesop-dev ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/mesop-dev \
+  && chmod 0440 /etc/sudoers.d/mesop-dev
 
 USER mesop-dev
 


### PR DESCRIPTION
This is related to #445

Apparently postCreateCommand is run the container user specified in the image, which for us is mesop-dev.

Unfortunately to install some additional software and configure access to node modules, we need root access via sudo.

A few things this will help us with:

1) Allow us to update the ownership of the node_modules directory to mesop-dev. This is because it is created as a Docker volume via Docker compose and ownership will be root. Need to verify if this is working correctly. Github Codespaces behavior seems a bit different.

2) Allows us to remove some of the Playwright installation dependencies out of the Docker image. With sudo we can install the additional browser dependencies via the yarn playwright "install-deps" command instead if we needed to. The nice thing of having it installed in the docker image is no need to reinstall if you shutdown or delete the container.