### PR TITLE
Fix property access for MesopEvent

### DIFF
--- a/mesop/web/src/component_renderer/component_renderer.ts
+++ b/mesop/web/src/component_renderer/component_renderer.ts
@@ -325,11 +325,8 @@ export class ComponentRenderer {
   dispatchCustomUserEvent = (event: Event) => {
     const mesopEvent = event as MesopEvent<any>;
     const userEvent = new UserEvent();
-    // Use bracket property access to avoid renaming because MesopEvent
-    // is referenced by web component modules which may be compiled independently
-    // so property renaming is unsafe.
-    userEvent.setStringValue(JSON.stringify(mesopEvent['payload']));
-    userEvent.setHandlerId(mesopEvent['handlerId']);
+    userEvent.setStringValue(JSON.stringify(mesopEvent.payload));
+    userEvent.setHandlerId(mesopEvent.handlerId);
     userEvent.setKey(this.component.getKey());
     this.channel.dispatch(userEvent);
   };


### PR DESCRIPTION
I was mistakened in #416 where I actually need to use dot property access so that downstream the property name is consistently renamed across files in the main JS binary. The web components do not actually access the property names for MesopEvent so we don't need to worry about syncing the property names there.