### PR TITLE
Fix node_modules path in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
-version: '3.9'
 services:
   mesop:
     build: .
     volumes:
       - .:/workspaces/mesop
-      - node_modules:/workspace/mesop/node_modules
+      - node_modules:/workspaces/mesop/node_modules
       - vscode_extensions:/home/mesop-dev/.vscode-server/extensions
     ports:
       - '32123:32123'


### PR DESCRIPTION
This fixes another issue brought up in https://github.com/google/mesop/issues/445.

Turns out the directory mapping on the node_modules volume was point to the wrong path.

----

- Tested this change successfully by creating a Codespace (so no regression)
- Also tested this locally and it worked
  - Caveat is that I did run into issues due to [the ](https://github.com/google/mesop/issues/361). Since I needed to temporarily update the package.json this led to fails installing npm packages. So essentially needed to do the bazel clean expunge thing. 
     - There is one weird thing I noticed is that there are symlinks to bazel-bin, bazel-mesop, bazel-out, bazel-testlogs that get created that could cause problems since the symlinks would be different inside the container and outside the container. So may need a way to ignore those symlinks in the container.
      - At the moment, it doesn't seem to cause an issue. But it could. Basically, before running the devcontainer locally in vscode, probably wise to do the bazel clean expunge and delete the local npm modules first to ensure a clean installation.

The caveats are more just notes to self when I finally get to writing the instructions out.