### PR TITLE
Update grpc-tools to 1.12.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "fs-extra": "^9.0.1",
     "glob": "^7.2.0",
     "google-protobuf": "3.21.2",
-    "grpc-tools": "1.11.3",
+    "grpc-tools": "1.12.4",
     "grpc-web": "1.4.2",
     "highlight.js": "^10.7.0",
     "inquirer": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9566,10 +9566,10 @@ graphviz@0.0.9:
   dependencies:
     temp "~0.4.0"
 
-grpc-tools@1.11.3:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/grpc-tools/-/grpc-tools-1.11.3.tgz#8218a86ef994e58bd06330b74033de8d7719ea0d"
-  integrity sha512-cRSK2uhDKHtZ9hLRM35HxaMAMxyh/L7C96Ojt58DhQBdwTOQlV1VIJHSK6X/pDeSQKhaQqWMFfebt8tIcvRfjQ==
+grpc-tools@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/grpc-tools/-/grpc-tools-1.12.4.tgz#a044c9e8157941033ea7a5f144c2dc9dc4501de4"
+  integrity sha512-5+mLAJJma3BjnW/KQp6JBjUMgvu7Mu3dBvBPd1dcbNIb+qiR0817zDpgPjS7gRb+l/8EVNIa3cB02xI9JLToKg==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.5"
 


### PR DESCRIPTION
Ref: https://github.com/google/mesop/issues/361

This upgrade is needed to support Mesop builds of ARM on Linux. This includes running Linux on Docker images on MacOS.

There are various warnings that show up when running ./scripts/cli.sh

It's unclear to me if these are OK to ignore not. It's also unclear which package some of these errors are coming. I think some may be comming from "google-protobuf" library. I guess there was recently a patch version update to 3.21.3 (we have 3.21.2) but that is not released yet.

On the Linux builds, we get a various warnings like this:

```
external/com_google_protobuf_javascript/generator/js_generator.cc: In member function 'bool google::protobuf::compiler::js::GeneratorOptions::ParseFromOptions(const std::vector<std::pair<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >&, std::string*)':
external/com_google_protobuf_javascript/generator/js_generator.cc:3449:21: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::pair<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
 3449 |   for (int i = 0; i < options.size(); i++) {
      |                   ~~^~~~~~~~~~~~~~~~
external/com_google_protobuf_javascript/generator/js_generator.cc: In member function 'void google::protobuf::compiler::js::Generator::GenerateFilesInDepOrder(const google::protobuf::compiler::js::GeneratorOptions&, google::protobuf::io::Printer*, const std::vector<const google::protobuf::FileDescriptor*>&) const':
external/com_google_protobuf_javascript/generator/js_generator.cc:3555:21: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<const google::protobuf::FileDescriptor*>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
 3555 |   for (int i = 0; i < files.size(); i++) {
      |                   ~~^~~~~~~~~~~~~~
```

The warnings on MacOS are a bit different (only pasted a small subset):

```
external/zlib/gzwrite.c:361:13: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
int ZEXPORT gzputs(file, s)
INFO: From Compiling gzread.c [for tool]:
external/zlib/gzread.c:21:11: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
local int gz_load(state, buf, len, have)
external/zlib/infback.c:83:12: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
local void fixedtables(state)
INFO: From Compiling src/google/protobuf/compiler/cpp/helpers.cc [for tool]:
external/com_google_protobuf/src/google/protobuf/compiler/cpp/helpers.cc:197:25: warning: unused function 'VerifyInt32TypeToVerifyCustom' [-Wunused-function]
inline VerifySimpleType VerifyInt32TypeToVerifyCustom(VerifyInt32Type t) {
INFO: From Linking external/com_google_protobuf/libprotoc_lib.a [for tool]:
/Library/Developer/CommandLineTools/usr/bin/libtool: warning duplicate member name 'enum.o' from 'bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/_objs/protoc_lib/0/enum.o(enum.o)' and 'bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/_objs/protoc_lib/1/enum.o(enum.o)'
/Library/Developer/CommandLineTools/usr/bin/libtool: warning duplicate member name 'enum_field.o' from 'bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/_objs/protoc_lib/1/enum_field.o(enum_field.o)' and 'bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/com_google_protobuf/_objs/protoc_lib/0/enum_field.o(enum_field.o)'
```