### PR TITLE
Allow me.navigate to work for absolute URLs

### DIFF
--- a/mesop/web/src/shell/shell.ts
+++ b/mesop/web/src/shell/shell.ts
@@ -89,7 +89,12 @@ export class Shell {
         },
         onCommand: (command) => {
           if (command.hasNavigate()) {
-            this.router.navigateByUrl(command.getNavigate()!.getUrl()!);
+            const url = command.getNavigate()!.getUrl()!;
+            if (url.startsWith("http://") || url.startsWith("https://")) {
+              window.location.href = url; // Handle absolute URLs
+            } else {
+              this.router.navigateByUrl(url); // Handle relative URLs
+            }
           } else if (command.hasScrollIntoView()) {
             // Scroll into view
             const key = command.getScrollIntoView()!.getKey();


### PR DESCRIPTION
https://github.com/google/mesop/issues/403
Allow for me.navigate to work for absolute paths as well as relative paths.