### PR TITLE
Add `on_blur` for input / textarea

### DIFF
--- a/demo/input.py
+++ b/demo/input.py
@@ -6,7 +6,7 @@ class State:
   input: str = ""
 
 
-def on_input(e: me.InputEvent):
+def on_blur(e: me.InputBlurEvent):
   state = me.state(State)
   state.input = e.value
 
@@ -19,5 +19,5 @@ def on_input(e: me.InputEvent):
 )
 def app():
   s = me.state(State)
-  me.input(label="Basic input", on_input=on_input)
+  me.input(label="Basic input", on_blur=on_blur)
   me.text(text=s.input)

--- a/demo/textarea.py
+++ b/demo/textarea.py
@@ -6,7 +6,7 @@ class State:
   input: str = ""
 
 
-def on_input(e: me.InputEvent):
+def on_blur(e: me.InputBlurEvent):
   state = me.state(State)
   state.input = e.value
 
@@ -19,5 +19,5 @@ def on_input(e: me.InputEvent):
 )
 def app():
   s = me.state(State)
-  me.textarea(label="Basic input", on_input=on_input)
+  me.textarea(label="Basic input", on_blur=on_blur)
   me.text(text=s.input)

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -16,3 +16,5 @@ For longer text inputs, also see [Textarea](./textarea.md)
 
 ::: mesop.components.input.input.input
 ::: mesop.components.input.input.native_textarea
+::: mesop.components.input.input.InputBlurEvent
+::: mesop.events.InputEvent

--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -15,3 +15,6 @@ This is similar to [Input](./input.md), but Textarea is better suited for long t
 ## API
 
 ::: mesop.components.input.input.textarea
+::: mesop.components.input.input.native_textarea
+::: mesop.components.input.input.InputBlurEvent
+::: mesop.events.InputEvent

--- a/mesop/__init__.py
+++ b/mesop/__init__.py
@@ -60,6 +60,7 @@ from mesop.components.html.html import html as html
 from mesop.components.icon.icon import icon as icon
 from mesop.components.image.image import image as image
 from mesop.components.input.input import EnterEvent as EnterEvent
+from mesop.components.input.input import InputBlurEvent as InputBlurEvent
 from mesop.components.input.input import input as input
 from mesop.components.input.input import native_textarea as native_textarea
 from mesop.components.input.input import textarea as textarea

--- a/mesop/components/input/e2e/__init__.py
+++ b/mesop/components/input/e2e/__init__.py
@@ -1,1 +1,2 @@
 from . import input_app as input_app
+from . import input_blur_app as input_blur_app

--- a/mesop/components/input/e2e/input_blur_app.py
+++ b/mesop/components/input/e2e/input_blur_app.py
@@ -1,0 +1,32 @@
+import mesop as me
+
+
+@me.stateclass
+class State:
+  input: str = ""
+  input_value_when_button_clicked: str
+
+
+def on_blur(e: me.InputBlurEvent):
+  state = me.state(State)
+  state.input = e.value
+
+
+def click_button(e: me.ClickEvent):
+  state = me.state(State)
+  state.input_value_when_button_clicked = state.input
+
+
+@me.page(path="/components/input/e2e/input_blur_app")
+def app():
+  s = me.state(State)
+  me.input(label="Input", on_blur=on_blur)
+  me.button("button", on_click=click_button)
+  me.text("Input: " + s.input)
+  me.text(
+    "input_value_when_button_clicked: " + s.input_value_when_button_clicked
+  )
+
+  me.textarea(label="Regular textarea", on_blur=on_blur, value="hello world")
+
+  me.native_textarea(on_blur=on_blur)

--- a/mesop/components/input/e2e/input_test.ts
+++ b/mesop/components/input/e2e/input_test.ts
@@ -7,3 +7,34 @@ test('test input interactivity works', async ({page}) => {
   await page.getByLabel('Basic input').press('Enter');
   expect(await page.getByText('boo').textContent()).toEqual('boo');
 });
+
+test('test input on_blur works', async ({page}) => {
+  await page.goto('/components/input/e2e/input_blur_app');
+
+  // Fill in input and then click button and make sure values match
+  await page.getByLabel('Input').click();
+  await page.getByLabel('Input').fill('abc');
+  await page.getByRole('button', {name: 'button'}).click();
+  await expect(page.getByText('Input: abc')).toBeVisible();
+  await expect(
+    page.getByText('input_value_when_button_clicked: abc'),
+  ).toBeVisible();
+
+  // Same with textarea:
+  await page.getByLabel('Regular textarea').click();
+  await page.getByLabel('Regular textarea').fill('123');
+  await page.getByRole('button', {name: 'button'}).click();
+  await expect(page.getByText('Input: 123')).toBeVisible();
+  await expect(
+    page.getByText('input_value_when_button_clicked: 123'),
+  ).toBeVisible();
+
+  // Same with native textarea:
+  await page.getByRole('textbox').nth(2).click();
+  await page.getByRole('textbox').nth(2).fill('second_textarea');
+  await page.getByRole('button', {name: 'button'}).click();
+  await expect(page.getByText('Input: second_textarea')).toBeVisible();
+  await expect(
+    page.getByText('input_value_when_button_clicked: second_textarea'),
+  ).toBeVisible();
+});

--- a/mesop/components/input/input.ng.html
+++ b/mesop/components/input/input.ng.html
@@ -6,6 +6,7 @@
   [readonly]="config().getReadonly()"
   [style]="getStyle()"
   (input)="onInput($event)"
+  (blur)="onBlur($event)"
   [cdkTextareaAutosize]="config().getAutosize()"
   [cdkAutosizeMinRows]="config().getMinRows()"
   [cdkAutosizeMaxRows]="config().getMaxRows()"
@@ -32,6 +33,7 @@
     [value]="config().getValue()"
     [readonly]="config().getReadonly()"
     (input)="onInput($event)"
+    (blur)="onBlur($event)"
     [rows]="config().getRows()"
     [cdkTextareaAutosize]="config().getAutosize()"
     [cdkAutosizeMinRows]="config().getMinRows()"
@@ -47,6 +49,7 @@
     [type]="config().getType()!"
     [value]="config().getValue()"
     [readonly]="config().getReadonly()"
+    (blur)="onBlur($event)"
     (input)="onInput($event)"
     (keyup)="onKeyUp($event)"
   />

--- a/mesop/components/input/input.proto
+++ b/mesop/components/input/input.proto
@@ -3,7 +3,7 @@ syntax = "proto2";
 
 package mesop.components.input;
 
-// Next id: 25
+// Next id: 26
 message InputType {
   optional bool disabled = 1;
   optional string id = 2;
@@ -21,6 +21,7 @@ message InputType {
   optional string label = 16;
   optional string on_input_handler_id = 17;
   optional string on_enter_handler_id = 24;
+  optional string on_blur_handler_id = 25;
   // Used for textarea only.
   optional int32 rows = 18;
   optional bool autosize = 20;

--- a/mesop/components/input/input.py
+++ b/mesop/components/input/input.py
@@ -27,10 +27,32 @@ register_event_mapper(
 )
 
 
+@dataclass(kw_only=True)
+class InputBlurEvent(MesopEvent):
+  """Represents an inpur blur event (when a user loses focus of an input).
+
+  Attributes:
+      value: Input value.
+      key (str): key of the component that emitted this event.
+  """
+
+  value: str
+
+
+register_event_mapper(
+  InputBlurEvent,
+  lambda userEvent, key: InputBlurEvent(
+    value=userEvent.string_value,
+    key=key.key,
+  ),
+)
+
+
 @register_native_component
 def textarea(
   *,
   label: str = "",
+  on_blur: Callable[[InputBlurEvent], Any] | None = None,
   on_input: Callable[[InputEvent], Any] | None = None,
   rows: int = 5,
   autosize: bool = False,
@@ -54,10 +76,11 @@ def textarea(
 
   Args:
     label: Label for input.
+    on_blur: [blur](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event) is fired when the input has lost focus.
+    on_input: [input](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) is fired whenever the input has changed (e.g. user types). Note: this can cause performance issues. Use `on_blur` instead.
     autosize: If True, the textarea will automatically adjust its height to fit the content, up to the max_rows limit.
     min_rows: The minimum number of rows the textarea will display.
     max_rows: The maximum number of rows the textarea will display.
-    on_input: [input](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) is a native browser event.
     rows: The number of lines to show in the text area.
     appearance: The form field appearance style.
     style: Style for input.
@@ -96,6 +119,9 @@ def textarea(
       subscript_sizing=subscript_sizing,
       hint_label=hint_label,
       label=label,
+      on_blur_handler_id=register_event_handler(on_blur, event=InputBlurEvent)
+      if on_blur
+      else "",
       on_input_handler_id=register_event_handler(on_input, event=InputEvent)
       if on_input
       else "",
@@ -108,6 +134,7 @@ def textarea(
 def input(
   *,
   label: str = "",
+  on_blur: Callable[[InputBlurEvent], Any] | None = None,
   on_input: Callable[[InputEvent], Any] | None = None,
   on_enter: Callable[[EnterEvent], Any] | None = None,
   type: Literal[
@@ -144,7 +171,8 @@ def input(
 
   Args:
     label: Label for input.
-    on_input: [input](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) is a native browser event.
+    on_blur: [blur](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event) is fired when the input has lost focus.
+    on_input: [input](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) is fired whenever the input has changed (e.g. user types). Note: this can cause performance issues. Use `on_blur` instead.
     on_enter: triggers when the browser detects an "Enter" key on a [keyup](https://developer.mozilla.org/en-US/docs/Web/API/Element/keyup_event) native browser event.
     type: Input type of the element. For textarea, use `me.Textarea(...)`
     appearance: The form field appearance style.
@@ -181,6 +209,9 @@ def input(
       subscript_sizing=subscript_sizing,
       hint_label=hint_label,
       label=label,
+      on_blur_handler_id=register_event_handler(on_blur, event=InputBlurEvent)
+      if on_blur
+      else "",
       on_input_handler_id=register_event_handler(on_input, event=InputEvent)
       if on_input
       else "",
@@ -194,6 +225,7 @@ def input(
 
 def native_textarea(
   *,
+  on_blur: Callable[[InputBlurEvent], Any] | None = None,
   on_input: Callable[[InputEvent], Any] | None = None,
   autosize: bool = False,
   min_rows: int | None = None,
@@ -208,7 +240,8 @@ def native_textarea(
   """Creates a browser native Textarea component. Intended for advanced use cases with maximum UI control.
 
   Args:
-    on_input: [input](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) is a native browser event.
+    on_blur: [blur](https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event) is fired when the input has lost focus.
+    on_input: [input](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) is fired whenever the input has changed (e.g. user types). Note: this can cause performance issues. Use `on_blur` instead.
     autosize: If True, the textarea will automatically adjust its height to fit the content, up to the max_rows limit.
     min_rows: The minimum number of rows the textarea will display.
     max_rows: The maximum number of rows the textarea will display.
@@ -233,6 +266,9 @@ def native_textarea(
       placeholder=placeholder,
       value=value,
       readonly=readonly,
+      on_blur_handler_id=register_event_handler(on_blur, event=InputBlurEvent)
+      if on_blur
+      else "",
       on_input_handler_id=register_event_handler(on_input, event=InputEvent)
       if on_input
       else "",

--- a/mesop/components/input/input.ts
+++ b/mesop/components/input/input.ts
@@ -91,4 +91,12 @@ export class InputComponent {
       this.channel.dispatch(userEvent);
     }
   }
+
+  onBlur(event: Event): void {
+    const userEvent = new UserEvent();
+    userEvent.setHandlerId(this.config().getOnBlurHandlerId()!);
+    userEvent.setStringValue((event.target as HTMLInputElement).value);
+    userEvent.setKey(this.key);
+    this.channel.dispatch(userEvent);
+  }
 }


### PR DESCRIPTION
Fixes #516.

This allows people to avoid using `on_input` in the common case.