### PR TITLE
Add SecurityPolicy to docs

### DIFF
--- a/docs/api/page.md
+++ b/docs/api/page.md
@@ -35,7 +35,7 @@ def foo():
 ## API
 
 ::: mesop.features.page.page
-
+::: mesop.security.security_policy.SecurityPolicy
 ::: mesop.events.events.LoadEvent
 
 ## `on_load`

--- a/docs/guides/web_security.md
+++ b/docs/guides/web_security.md
@@ -36,3 +36,7 @@ def app():
 ```
 
 You can also use wildcards to allow-list multiple subdomains from the same site, such as: `https://*.example.com`.
+
+## API
+
+You can configure the security policy at the page level. See [SecurityPolicy on the Page API docs](../api/page.md#mesop.security.security_policy.SecurityPolicy).

--- a/mesop/security/security_policy.py
+++ b/mesop/security/security_policy.py
@@ -7,12 +7,12 @@ class SecurityPolicy:
   A class to represent the security policy.
 
   Attributes:
-      allowed_iframe_parents: A list of allowed iframe parents.
-      allowed_connect_srcs: A list of sites you can connect to, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src).
-      allowed_connect_srcs: A list of sites you load scripts from, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src).
-      dangerously_disable_trusted_types: A flag to disable trusted types.
-        Highly recommended to not disable trusted types because
-        it's an important web security feature!
+    allowed_iframe_parents: A list of allowed iframe parents.
+    allowed_connect_srcs: A list of sites you can connect to, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src).
+    allowed_connect_srcs: A list of sites you load scripts from, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src).
+    dangerously_disable_trusted_types: A flag to disable trusted types.
+      Highly recommended to not disable trusted types because
+      it's an important web security feature!
   """
 
   allowed_iframe_parents: list[str] = field(default_factory=list)


### PR DESCRIPTION
- Fixes indentation in security_policy.py because mkdocs complained