### PR TITLE
Remove $ prefix from shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can try [Mesop on Colab](https://colab.research.google.com/github/google/mes
 **Step 1:** Install it
 
 ```sh
-$ pip install mesop
+pip install mesop
 ```
 
 **Step 2:** Copy the example above into `main.py`
@@ -74,7 +74,7 @@ $ pip install mesop
 **Step 3:** Run the app
 
 ```sh
-$ mesop main.py
+mesop main.py
 ```
 
 Learn more in [Getting Started](https://google.github.io/mesop/getting_started/installing/).

--- a/demo/README.md
+++ b/demo/README.md
@@ -25,7 +25,7 @@ pip install -r demo/requirements.txt --no-binary pydantic
 This app is deployed to Google Cloud Run.
 
 ```sh
-$ gcloud run deploy mesop --source .
+gcloud run deploy mesop --source .
 ```
 
 See our Mesop deployment [docs](https://google.github.io/mesop/guides/deployment/#deploy-to-google-cloud-run) for more background.

--- a/docs/getting_started/installing.md
+++ b/docs/getting_started/installing.md
@@ -3,7 +3,7 @@
 If you are familiar with setting up a Python environment, then run the following command in your terminal:
 
 ```shell
-$ pip install mesop
+pip install mesop
 ```
 
 If you're not familiar with setting up a Python environment, follow one of the options below.
@@ -61,7 +61,7 @@ Once you've activated the virtual environment, you will see ".venv" at the start
 4. **Install mesop:**
 
 ```shell
-$ pip install mesop
+pip install mesop
 ```
 
 Make sure your Python environment is setup correctly by running a hello world app.
@@ -80,7 +80,7 @@ def app():
 Then run the following command in your terminal:
 
 ```shell
-$ mesop hello_world.py
+mesop hello_world.py
 ```
 
 Open the URL printed in the terminal (i.e. http://localhost:32123) in the browser to see your Mesop app loaded.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -55,7 +55,7 @@ In your terminal, go to the application directory, which has the files listed ab
 Run the following command:
 
 ```sh
-$ gcloud run deploy
+gcloud run deploy
 ```
 
 Follow the instructions and then you should be able to access your deployed app.

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ Try Mesop on Colab: [![Open In Colab](assets/colab.svg)](https://colab.research.
 __Step 1:__ Install it
 
 ```sh
-$ pip install mesop
+pip install mesop
 ```
 
 __Step 2:__ Copy the example above into `main.py`
@@ -76,7 +76,7 @@ __Step 2:__ Copy the example above into `main.py`
 __Step 3:__ Run the app
 
 ```sh
-$ mesop main.py
+mesop main.py
 ```
 
 ## Next Steps

--- a/docs/internal/development.md
+++ b/docs/internal/development.md
@@ -22,7 +22,7 @@ If [ibazel](https://github.com/bazelbuild/bazel-watcher) breaks, but bazel works
 We recommend using this for most Mesop framework development.
 
 ```sh
-$ ./scripts/cli.sh
+./scripts/cli.sh
 ```
 
 > NOTE: this automatically serves the angular app.
@@ -34,7 +34,7 @@ $ ./scripts/cli.sh
 If you update `//build_defs/requirements.txt`, run:
 
 ```sh
-$ bazel run //build_defs:pip_requirements.update
+bazel run //build_defs:pip_requirements.update
 ```
 
 ### venv
@@ -42,25 +42,25 @@ $ bazel run //build_defs:pip_requirements.update
 To support IDE type-checking (Pylance) in VS Code, we use Aspect's [rules_py](https://docs.aspect.build/rulesets/aspect_rules_py/) which generates a venv target.
 
 ```sh
-$ bazel run //mesop/cli:cli.venv
+bazel run //mesop/cli:cli.venv
 ```
 
 Then, you can activate the venv:
 
 ```sh
-$ source .cli.venv/bin/activate
+source .cli.venv/bin/activate
 ```
 
 You will need to setup a symlink to have Python IDE support for protos:
 
 ```sh
-$ ./scripts/setup_proto_py_modules.sh
+./scripts/setup_proto_py_modules.sh
 ```
 
 Check that you're using venv's python:
 
 ```sh
-$ which python
+which python
 ```
 
 Copy the python interpreter path and paste it into VS Code.
@@ -68,7 +68,7 @@ Copy the python interpreter path and paste it into VS Code.
 Finally, install third-party dependencies.
 
 ```sh
-$ pip install -r build_defs/requirements_lock.txt
+pip install -r build_defs/requirements_lock.txt
 ```
 
 > NOTE: You may need to run the command with `sudo` if you get a permission denied error, particularly with "\_distutils_hack".

--- a/docs/internal/modes.md
+++ b/docs/internal/modes.md
@@ -6,7 +6,7 @@ There are two modes that you can run Mesop in.
 
 Recommended for developers using Mesop when they are developing the apps locally. This provides good error messages and hot reloading.
 
-- **How to run:** `$ ibazel run //mesop/cli -- --path=mesop/mesop/example_index.py`
+- **How to run:** `ibazel run //mesop/cli -- --path=mesop/mesop/example_index.py`
 - Angular should run in dev mode.
 - Developer Tools and Visual Editor are available.
 
@@ -16,4 +16,4 @@ Recommended when developers deploy applications built with Mesop for public serv
 
 - Developer tools aren't available.
 - Angular doesn't run in dev mode.
-- **How to run:** `$ bazel run //mesop/cli -- --path=mesop/mesop/example_index.py --prod`
+- **How to run:** `bazel run //mesop/cli -- --path=mesop/mesop/example_index.py --prod`

--- a/docs/internal/new_component.md
+++ b/docs/internal/new_component.md
@@ -3,7 +3,7 @@
 ## How-to
 
 ```sh
-$ python scripts/scaffold_component.py $component_name
+python scripts/scaffold_component.py $component_name
 ```
 
 ## API Guidelines

--- a/docs/internal/publishing.md
+++ b/docs/internal/publishing.md
@@ -17,7 +17,7 @@ For example, if the current version is: `0.7.0`, then you should increment the v
 From the workspace root, run the following command:
 
 ```sh
-$ source ./scripts/pip.sh
+source ./scripts/pip.sh
 ```
 
 This will build the Mesop pip package and install it locally so you can test it.
@@ -29,7 +29,7 @@ This will build the Mesop pip package and install it locally so you can test it.
 The above shell script will run the following command:
 
 ```sh
-$ mesop main.py
+mesop main.py
 ```
 
 This will start the Mesop dev server and you can test that hot reload works.
@@ -37,7 +37,7 @@ This will start the Mesop dev server and you can test that hot reload works.
 ### Gunicorn integration
 
 ```sh
-$ pip install gunicorn && gunicorn main:me
+pip install gunicorn && gunicorn main:me
 ```
 
 ## Upload to PyPI

--- a/docs/internal/testing.md
+++ b/docs/internal/testing.md
@@ -17,11 +17,11 @@ We use [Playwright](https://playwright.dev/) as our e2e test framework. Unlike m
 ### Run tests
 
 ```shell
-$ yarn playwright test
+yarn playwright test
 ```
 
 ### Debug tests
 
 ```shell
-$ yarn playwright test --debug
+yarn playwright test --debug
 ```

--- a/docs/internal/type_checking.md
+++ b/docs/internal/type_checking.md
@@ -7,7 +7,7 @@ For our Python code, we use [pyright](https://github.com/microsoft/pyright) as o
 To run Python type-checking, run:
 
 ```shell
-$ ./scripts/run_py_typecheck.sh
+./scripts/run_py_typecheck.sh
 ```
 
 This will setup the pre-requisites needed for type-checking.

--- a/mesop/examples/web_component/firebase_auth/README.md
+++ b/mesop/examples/web_component/firebase_auth/README.md
@@ -1,9 +1,9 @@
 # README
 
 ```sh
-$ gcloud config set project mesop-auth-test
+gcloud config set project mesop-auth-test
 ```
 
 ```sh
-$ gcloud auth application-default login
+gcloud auth application-default login
 ```


### PR DESCRIPTION
Since mkdocs for material doesn't strip out the $ when copying the code, it's annoying to have the prefix.

See: #430.