### PR TITLE
Enable markdown tables + attribute lists

### DIFF
--- a/demo/markdown_demo.py
+++ b/demo/markdown_demo.py
@@ -50,8 +50,8 @@ Inline `code`
 
 First Header  | Second Header
 ------------- | -------------
-Content Cell  | Content Cell
-Content Cell  | Content Cell
+Content Cell { .foo }  | Content Cell { .foo }
+Content Cell { .bar } | Content Cell { .bar }
 """
 
 

--- a/demo/markdown_demo.py
+++ b/demo/markdown_demo.py
@@ -45,6 +45,13 @@ SAMPLE_MARKDOWN = """
 
 ## Code
 Inline `code`
+
+## Table
+
+First Header  | Second Header
+------------- | -------------
+Content Cell  | Content Cell
+Content Cell  | Content Cell
 """
 
 

--- a/mesop/components/markdown/e2e/markdown_app.py
+++ b/mesop/components/markdown/e2e/markdown_app.py
@@ -71,6 +71,13 @@ foo()
 
 ## Code
 Inline `code`
+
+## Table
+
+First Header  | Second Header
+------------- | -------------
+Content Cell  | Content Cell
+Content Cell  | Content Cell
 """
 
 

--- a/mesop/components/markdown/e2e/markdown_app.py
+++ b/mesop/components/markdown/e2e/markdown_app.py
@@ -76,8 +76,8 @@ Inline `code`
 
 First Header  | Second Header
 ------------- | -------------
-Content Cell  | Content Cell
-Content Cell  | Content Cell
+Content Cell { .foo }  | Content Cell { .foo }
+Content Cell { .bar } | Content Cell { .bar }
 """
 
 

--- a/mesop/components/markdown/e2e/markdown_test.ts
+++ b/mesop/components/markdown/e2e/markdown_test.ts
@@ -15,6 +15,14 @@ test('renders table markup', async ({page}) => {
   ).toHaveCount(2);
 
   await expect(
-    page.locator(`//table/tbody/tr/td[contains(text(), "Content Cell")]`),
-  ).toHaveCount(4);
+    page.locator(
+      `//table/tbody/tr/td[contains(text(), "Content Cell") and @class="foo"]`,
+    ),
+  ).toHaveCount(2);
+
+  await expect(
+    page.locator(
+      `//table/tbody/tr/td[contains(text(), "Content Cell") and @class="bar"]`,
+    ),
+  ).toHaveCount(2);
 });

--- a/mesop/components/markdown/e2e/markdown_test.ts
+++ b/mesop/components/markdown/e2e/markdown_test.ts
@@ -6,3 +6,15 @@ test('test', async ({page}) => {
     await page.getByText('Sample Markdown Document').textContent(),
   ).toContain('Sample Markdown Document');
 });
+
+test('renders table markup', async ({page}) => {
+  await page.goto('/components/markdown/e2e/markdown_app');
+
+  await expect(
+    page.locator(`//table/thead/tr/th[contains(text(), "Header")]`),
+  ).toHaveCount(2);
+
+  await expect(
+    page.locator(`//table/tbody/tr/td[contains(text(), "Content Cell")]`),
+  ).toHaveCount(4);
+});

--- a/mesop/components/markdown/markdown.py
+++ b/mesop/components/markdown/markdown.py
@@ -28,6 +28,8 @@ def markdown(
     html = markdown_lib.markdown(
       text,
       extensions=[
+        "attr_list",
+        "tables",
         CodeHiliteExtension(css_class="highlight"),
         "fenced_code",
       ],

--- a/mesop/web/src/app/styles.scss
+++ b/mesop/web/src/app/styles.scss
@@ -235,6 +235,15 @@ mesop-markdown pre {
   overflow-x: scroll;
 }
 
+// Add some basic style to the table mark up.
+mesop-markdown table,
+mesop-markdown th,
+mesop-markdown td {
+  border: 1px #000 solid;
+  border-collapse: collapse;
+  padding: 10px;
+}
+
 // Generated with pygments
 // pygmentize -S xcode -f html -a .highlight > style.css
 pre {


### PR DESCRIPTION
This change allows markdown tables to be rendered correctly. One caveat is that custom styling is not possible unless someone includes an custom stylesheet via CDN or external URL.

This means that the default rendering is very basic.

If a user wants to use render markdown from a pandas data frame, they will need to install tabulate separately.

Attribute lists have also been enabled to make it easier to style the the tables via CSS.
[
<img width="316" alt="Screenshot 2024-07-01 at 5 26 28 PM" src="https://github.com/google/mesop/assets/539889/1c01af5a-f64e-4b07-94ed-971c929a6437">
](url)

Ref #546