### PR TITLE
Add file backend for state sessions

### DIFF
--- a/build_defs/defaults.bzl
+++ b/build_defs/defaults.bzl
@@ -113,3 +113,7 @@ THIRD_PARTY_PY_DEEPDIFF = [
 THIRD_PARTY_PY_DOTENV = [
     requirement("python-dotenv"),
 ]
+
+THIRD_PARTY_PY_MSGPACK = [
+    requirement("msgpack"),
+]

--- a/build_defs/requirements.txt
+++ b/build_defs/requirements.txt
@@ -1,6 +1,7 @@
 flask
 absl-py
 deepdiff==6.*
+msgpack
 markdown
 protobuf
 pydantic

--- a/build_defs/requirements_lock.txt
+++ b/build_defs/requirements_lock.txt
@@ -856,7 +856,9 @@ msgpack==1.0.8 \
     --hash=sha256:f51bab98d52739c50c56658cc303f190785f9a2cd97b823357e7aeae54c8f68a \
     --hash=sha256:f9904e24646570539a8950400602d66d2b2c492b9010ea7e965025cb71d0c86d \
     --hash=sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d
-    # via cachecontrol
+    # via
+    #   -r build_defs/requirements.txt
+    #   cachecontrol
 mypy-protobuf==3.6.0 \
     --hash=sha256:02f242eb3409f66889f2b1a3aa58356ec4d909cdd0f93115622e9e70366eca3c \
     --hash=sha256:56176e4d569070e7350ea620262478b49b7efceba4103d468448f1d21492fd6c

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -23,7 +23,7 @@ own RAM, which means cache misses will be common if each server has multiple pro
 and there is no session affinity. In addition, the amount of RAM must be carefully
 specified per instance in accordance with the expected user traffic and state size.
 
-The safest option for using the `memory` backend is to use a single a process with a
+The safest option for using the `memory` backend is to use a single process with a
 good amount of RAM. Python is not the most memory efficient, especially when saving data
 structures such as dicts.
 

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -14,25 +14,52 @@ Sets the backend to use for caching state data server-side. This makes it so sta
 not have to be sent to the server on every request, reducing bandwidth, especially if
 you have large state objects.
 
-The only backend option available at the moment is `memory`.
+The backend options available at the moment are `memory` and `file`.
+
+#### memory
 
 Users should be careful when using the `memory` backend. Each Mesop process has their
-own RAM, which means cache misses will be common if there is no session affinity. In
-addition, the amount of RAM must be carefully specified per machine in accordance with
-the expected user traffic and state size.
+own RAM, which means cache misses will be common if each server has multiple processes
+and there is no session affinity. In addition, the amount of RAM must be carefully
+specified per instance in accordance with the expected user traffic and state size.
 
 The safest option for using the `memory` backend is to use a single a process with a
-good amount of RAM. Python is not the most memory efficient, especially data structures
-such as dicts.
+good amount of RAM. Python is not the most memory efficient, especially when saving data
+structures such as dicts.
 
 The drawback of being limited to a single process is that requests will take longer to
 process since only one request can be handled at a time. This is especially problematic
 if your application contains long running API calls.
 
-If session affinity is available, you can scale up multiple machines, each running
+If session affinity is available, you can scale up multiple instances, each running
 single processes.
 
+#### file
+
+Users should be careful when using the `file` backend. Each Mesop instance has their
+own disk, which can be shared among multiple processes. This means cache misses will be
+common if there are multiple instances and no session affinity.
+
+If session affinity is available, you can scale up multiple instances, each running
+multiple Mesop processes. If no session affinity is available, then you can only
+vertically scale a single instance.
+
+The bottleneck with this backend is the disk read/write performance. The amount of disk
+space must also be carefully specified per instance in accordance with the expected user
+traffic and state size.
+
+You will also need to specify a directory to write the state data using
+`MESOP_STATE_SESSION_BACKEND_FILE_BASE_DIR`.
+
 **Default:** `none`
+
+### MESOP_STATE_SESSION_BACKEND_FILE_BASE_DIR
+
+This is only used when the `MESOP_STATE_SESSION_BACKEND` is set to `file`. This
+parameter specifies where Mesop will read/write the session state. This means the
+directory must be readable and writeable by the Mesop server processes.
+
+**Default:** `/tmp`
 
 ## Usage Examples
 

--- a/mesop/pip_package/requirements.txt
+++ b/mesop/pip_package/requirements.txt
@@ -2,6 +2,7 @@ absl-py
 deepdiff==6.*
 flask
 markdown
+msgpack
 protobuf
 pydantic
 pygments

--- a/mesop/server/BUILD
+++ b/mesop/server/BUILD
@@ -1,4 +1,13 @@
-load("//build_defs:defaults.bzl", "THIRD_PARTY_PY_ABSL_PY", "THIRD_PARTY_PY_DOTENV", "THIRD_PARTY_PY_FLASK", "THIRD_PARTY_PY_PYTEST", "py_library", "py_test")
+load(
+    "//build_defs:defaults.bzl",
+    "THIRD_PARTY_PY_ABSL_PY",
+    "THIRD_PARTY_PY_DOTENV",
+    "THIRD_PARTY_PY_FLASK",
+    "THIRD_PARTY_PY_MSGPACK",
+    "THIRD_PARTY_PY_PYTEST",
+    "py_library",
+    "py_test",
+)
 
 package(
     default_visibility = ["//build_defs:mesop_internal"],
@@ -8,13 +17,16 @@ py_library(
     name = "server",
     srcs = glob(["*.py"]),
     deps = [
-        "//mesop/component_helpers",
-        "//mesop/editor",
-        "//mesop/events",
-        "//mesop/protos:ui_py_pb2",
-        "//mesop/utils",
-        "//mesop/warn",
-    ] + THIRD_PARTY_PY_ABSL_PY + THIRD_PARTY_PY_FLASK + THIRD_PARTY_PY_DOTENV,
+               "//mesop/component_helpers",
+               "//mesop/editor",
+               "//mesop/events",
+               "//mesop/protos:ui_py_pb2",
+               "//mesop/utils",
+               "//mesop/warn",
+           ] + THIRD_PARTY_PY_ABSL_PY +
+           THIRD_PARTY_PY_FLASK +
+           THIRD_PARTY_PY_DOTENV +
+           THIRD_PARTY_PY_MSGPACK,
     # Note: prod_server.py has a runtime dependency on
     # //mesop/web/src/app/prod:web_package, so you must include it
     # in the consuming py_binary's data attribute.

--- a/mesop/server/config.py
+++ b/mesop/server/config.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Literal
 
 from dotenv import load_dotenv
@@ -10,7 +11,8 @@ load_dotenv()
 class Config(BaseModel):
   """Mesop app configuration."""
 
-  state_session_backend: Literal["memory", "none"] = "none"
+  state_session_backend: Literal["memory", "file", "none"] = "none"
+  state_session_backend_file_base_dir: Path = Path("/tmp")
 
   @property
   def state_session_enabled(self):
@@ -20,6 +22,9 @@ class Config(BaseModel):
 def CreateConfigFromEnv() -> Config:
   return Config(
     state_session_backend=os.getenv("MESOP_STATE_SESSION_BACKEND", "none"),  # type: ignore
+    state_session_backend_file_base_dir=Path(
+      os.getenv("MESOP_STATE_SESSION_BACKEND_FILE_BASE_DIR", "/tmp")
+    ),
   )
 
 

--- a/mesop/server/state_session.py
+++ b/mesop/server/state_session.py
@@ -1,9 +1,24 @@
+import logging
+import os
+import random
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, Protocol
 
+import msgpack
+
+from mesop.dataclass_utils import (
+  serialize_dataclass,
+  update_dataclass_from_json,
+)
 from mesop.server.config import Config, app_config
 
 States = dict[type[Any], object]
+
+
+def _current_datetime():
+  """Helper to return datetime now so we can mock the time easier."""
+  return datetime.now()
 
 
 class StateSessionBackend(Protocol):
@@ -64,12 +79,12 @@ class MemoryStateSessionBackend(StateSessionBackend):
     del self.cache[token]
 
   def save(self, token: str, states: States):
-    self.cache[token] = (datetime.now(), states)
+    self.cache[token] = (_current_datetime(), states)
 
   def clear_stale_sessions(self):
     stale_keys = set()
 
-    current_time = datetime.now()
+    current_time = _current_datetime()
     for key, (timestamp, _) in self.cache.items():
       if (
         timestamp + timedelta(minutes=self._SESSION_TTL_MINUTES) < current_time
@@ -80,12 +95,100 @@ class MemoryStateSessionBackend(StateSessionBackend):
       del self.cache[key]
 
 
+class FileStateSessionBackend(StateSessionBackend):
+  """Stores state on the filesystem.
+
+  This backend allows state to be shared across processes on the same server. If session
+  affinity is not available, then the only way to improve performance is to scale
+  vertically.
+
+  The main bottleneck is disk read/write performance. If using this backend, you should
+  load test against expected traffic and state size to see if this backend meets your
+  needs.
+  """
+
+  # Hardcode for now, but probably make adjustable in the future.
+  _SESSION_TTL_MINUTES = 10
+  # Rate in which we will attempt to clear stale sessions. This is done to
+  # to reduce concurrent attempts to delete stale sessions.
+  #
+  # Example: If the rate is set to 0.1, that means the clear state sessions function
+  # will run 1 in 10 requests or 10% of the time.
+  _SESSION_CLEAR_RATE = 0.1
+
+  def __init__(self, base_dir: Path):
+    if base_dir is None:
+      raise RuntimeError(
+        "Base dir must be set when using `FileStateSessionBackend`"
+      )
+    self.base_dir = base_dir
+    self.prefix = "session"
+
+  def _make_file_path(self, token: str) -> Path:
+    return self.base_dir / (self.prefix + token)
+
+  def restore(self, token: str, states: States):
+    """Gets the saved state from the given token and updates the given state."""
+    file_path = self._make_file_path(token)
+    try:
+      with open(file_path, "rb") as f:
+        states_data = msgpack.loads(f.read())
+      _deserialize_state(states, states_data)
+    except FileNotFoundError as e:
+      raise Exception("Token not found in state session backend.") from e
+    else:
+      try:
+        os.remove(file_path)
+      except FileNotFoundError as e:
+        logging.warning("Failed to delete file after restore - " + str(e))
+
+  def save(self, token: str, states: States):
+    """Saves state to the backend with the given token."""
+    with open(self._make_file_path(token), "wb") as f:
+      f.write(msgpack.dumps(_serialize_state(states)))
+
+  def clear_stale_sessions(self):
+    """Deletes unused state data."""
+    if random.random() > self._SESSION_CLEAR_RATE:
+      return
+
+    for filename in os.listdir(self.base_dir):
+      file_path = self.base_dir / filename
+      current_time = _current_datetime()
+      if os.path.isfile(file_path) and filename.startswith(self.prefix):
+        timestamp = datetime.fromtimestamp(os.path.getctime(file_path))
+        if (
+          timestamp + timedelta(minutes=self._SESSION_TTL_MINUTES)
+          < current_time
+        ):
+          try:
+            os.remove(file_path)
+          except FileNotFoundError as e:
+            logging.warning(
+              "Failed to delete file while clearing sessions - " + str(e)
+            )
+
+
 def CreateStateSessionFromConfig(config: Config):
   """Factory function to state session backend."""
   if config.state_session_backend == "memory":
     return MemoryStateSessionBackend()
+  elif config.state_session_backend == "file":
+    return FileStateSessionBackend(config.state_session_backend_file_base_dir)
   return NullStateSessionBackend()
 
 
 # The state session is a singleton object.
 state_session = CreateStateSessionFromConfig(app_config)
+
+
+def _serialize_state(states: States) -> list[str]:
+  states_data = []
+  for state in states.values():
+    states_data.append(serialize_dataclass(state))
+  return states_data
+
+
+def _deserialize_state(states: States, states_data: list[str]) -> str:
+  for state, serialized_state in zip(states.values(), states_data):
+    update_dataclass_from_json(state, serialized_state)

--- a/mesop/server/state_session.py
+++ b/mesop/server/state_session.py
@@ -132,7 +132,7 @@ class FileStateSessionBackend(StateSessionBackend):
     file_path = self._make_file_path(token)
     try:
       with open(file_path, "rb") as f:
-        states_data = msgpack.loads(f.read())
+        states_data = msgpack.unpackb(f.read())
       _deserialize_state(states, states_data)
     except FileNotFoundError as e:
       raise Exception("Token not found in state session backend.") from e
@@ -145,7 +145,7 @@ class FileStateSessionBackend(StateSessionBackend):
   def save(self, token: str, states: States):
     """Saves state to the backend with the given token."""
     with open(self._make_file_path(token), "wb") as f:
-      f.write(msgpack.dumps(_serialize_state(states)))
+      f.write(msgpack.packb(_serialize_state(states)))  # type: ignore
 
   def clear_stale_sessions(self):
     """Deletes unused state data."""
@@ -189,6 +189,6 @@ def _serialize_state(states: States) -> list[str]:
   return states_data
 
 
-def _deserialize_state(states: States, states_data: list[str]) -> str:
+def _deserialize_state(states: States, states_data: list[str]):
   for state, serialized_state in zip(states.values(), states_data):
     update_dataclass_from_json(state, serialized_state)

--- a/mesop/server/state_session_test.py
+++ b/mesop/server/state_session_test.py
@@ -168,8 +168,6 @@ def test_memory_backend_clear_stale_sessions():
 def test_file_backend_clear_stale_sessions_not_stale(tmp_path):
   # GIVEN
   backend = FileStateSessionBackend(tmp_path)
-  # Modify the clear rate so that sessions are always cleared.
-  backend._SESSION_CLEAR_RATE = 1.0
   empty_states: States = {
     type(StateA): StateA(str_value="ABC"),
   }
@@ -190,8 +188,6 @@ def test_file_backend_clear_stale_sessions_not_stale(tmp_path):
 def test_file_backend_clear_stale_sessions(tmp_path):
   # GIVEN
   backend = FileStateSessionBackend(tmp_path)
-  # Modify the clear rate so that sessions are always cleared.
-  backend._SESSION_CLEAR_RATE = 1.0
   empty_states: States = {
     type(StateA): StateA(str_value="ABC"),
   }
@@ -219,8 +215,8 @@ def test_file_backend_clear_stale_sessions(tmp_path):
 def test_file_backend_clear_stale_sessions_skipped(tmp_path):
   # GIVEN
   backend = FileStateSessionBackend(tmp_path)
-  # Modify the clear rate so that sessions are never cleared
-  backend._SESSION_CLEAR_RATE = -1.0
+  # Force create lock file to test skip behavior.
+  backend._can_clear_stale_session()
   empty_states: States = {
     type(StateA): StateA(str_value="ABC"),
   }
@@ -230,7 +226,7 @@ def test_file_backend_clear_stale_sessions_skipped(tmp_path):
   with patch(
     "mesop.server.state_session._current_datetime",
   ) as _mock_current_datetime:
-    _mock_current_datetime.return_value = datetime.now() + timedelta(minutes=15)
+    _mock_current_datetime.return_value = datetime.now()
     backend.clear_stale_sessions()
 
     # THEN

--- a/mesop/server/state_session_test.py
+++ b/mesop/server/state_session_test.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -52,7 +53,8 @@ def test_create_state_session_file():
   assert isinstance(
     CreateStateSessionFromConfig(
       Config(
-        state_session_backend="file", state_session_backend_file_base_dir="/tmp"
+        state_session_backend="file",
+        state_session_backend_file_base_dir=Path("/tmp"),
       )
     ),
     FileStateSessionBackend,


### PR DESCRIPTION
This change also adds a new dependency with msgpack. For now we use it to serialize/deserialize the JSON strings of the Mesop state. In the future we will want to serialize everything with msgpack.

The reason we can't do this now is because we will need to add msgpack encoding/decoding rules to support non-standard data types.

This change also adds a new config variable called MESOP_STATE_SESSION_BACKEND_FILE_BASE_DIR which allows the user to specify the location where the state sessions get written.

Ref #556