### PR TITLE
Add Firestore state session backend

### DIFF
--- a/mesop/server/BUILD
+++ b/mesop/server/BUILD
@@ -2,6 +2,7 @@ load(
     "//build_defs:defaults.bzl",
     "THIRD_PARTY_PY_ABSL_PY",
     "THIRD_PARTY_PY_DOTENV",
+    "THIRD_PARTY_PY_FIREBASE_ADMIN",
     "THIRD_PARTY_PY_FLASK",
     "THIRD_PARTY_PY_MSGPACK",
     "THIRD_PARTY_PY_PYTEST",
@@ -41,7 +42,7 @@ py_test(
 py_test(
     name = "state_session_test",
     srcs = ["state_session_test.py"],
-    deps = [":server"] + THIRD_PARTY_PY_PYTEST,
+    deps = [":server"] + THIRD_PARTY_PY_PYTEST + THIRD_PARTY_PY_FIREBASE_ADMIN,
 )
 
 py_test(

--- a/mesop/server/config.py
+++ b/mesop/server/config.py
@@ -11,8 +11,9 @@ load_dotenv()
 class Config(BaseModel):
   """Mesop app configuration."""
 
-  state_session_backend: Literal["memory", "file", "none"] = "none"
+  state_session_backend: Literal["memory", "file", "firestore", "none"] = "none"
   state_session_backend_file_base_dir: Path = Path("/tmp")
+  state_session_backend_firestore_collection: str = "mesop_state_sessions"
 
   @property
   def state_session_enabled(self):
@@ -24,6 +25,10 @@ def CreateConfigFromEnv() -> Config:
     state_session_backend=os.getenv("MESOP_STATE_SESSION_BACKEND", "none"),  # type: ignore
     state_session_backend_file_base_dir=Path(
       os.getenv("MESOP_STATE_SESSION_BACKEND_FILE_BASE_DIR", "/tmp")
+    ),
+    state_session_backend_firestore_collection=os.getenv(
+      "MESOP_STATE_SESSION_BACKEND_FIRESTORE_COLLECTION",
+      "mesop_state_sessions",
     ),
   )
 

--- a/mesop/server/config_test.py
+++ b/mesop/server/config_test.py
@@ -50,10 +50,10 @@ def test_state_session_backend_file():
 
 @pytest.mark.usefixtures("clear_mesop_env")
 def test_state_session_backend_firestore():
-  os.environ["MESOP_STATE_SESSION_BACKEND"] = "filestore"
+  os.environ["MESOP_STATE_SESSION_BACKEND"] = "firestore"
   os.environ["MESOP_STATE_SESSION_BACKEND_FIRESTORE_COLLECTION"] = "collection"
   config = CreateConfigFromEnv()
-  assert config.state_session_backend == "filestore"
+  assert config.state_session_backend == "firestore"
   assert config.state_session_backend_firestore_collection == "collection"
 
 

--- a/mesop/server/config_test.py
+++ b/mesop/server/config_test.py
@@ -48,5 +48,14 @@ def test_state_session_backend_file():
   )
 
 
+@pytest.mark.usefixtures("clear_mesop_env")
+def test_state_session_backend_firestore():
+  os.environ["MESOP_STATE_SESSION_BACKEND"] = "filestore"
+  os.environ["MESOP_STATE_SESSION_BACKEND_FIRESTORE_COLLECTION"] = "collection"
+  config = CreateConfigFromEnv()
+  assert config.state_session_backend == "filestore"
+  assert config.state_session_backend_firestore_collection == "collection"
+
+
 if __name__ == "__main__":
   raise SystemExit(pytest.main([__file__]))

--- a/mesop/server/state_session.py
+++ b/mesop/server/state_session.py
@@ -203,6 +203,12 @@ class FirestoreStateSessionBackend(StateSessionBackend):
     self.db = self._initialize_firestore_db()
 
   def _initialize_firestore_db(self):
+    logging.warning(
+      "You need to manually create a TTL policy on your Firestore to clear out stale\n"
+      "session data. Otherwise, you will exceed the 1GB free storage allowance.\n\n"
+      "You can create a TTL policy by running this command: \n\n"
+      f"  gcloud firestore fields ttls update expiresAt --collection-group={self.collection_name}\n\n"
+    )
     # Lazy load Firestore dependencies since it is not a core functionality.
     import firebase_admin
     from firebase_admin import firestore


### PR DESCRIPTION
- Adds `firestore` option to `MESOP_STATE_SESSION_BACKEND`
- New config: `MESOP_STATE_SESSION_BACKEND_FIRESTORE_COLLECTION`
- Updates config.md
- Notes on implementation
  - User needs to manually set the TTL policy - Though the policy seems a bit slow to delete stuff
  - Uses the `(default)` database only
  - Uses application default credentials to pick project

Ref #556 