### PR TITLE
Fix false on enter trigger when using IME.

### DIFF
--- a/mesop/components/input/input.ng.html
+++ b/mesop/components/input/input.ng.html
@@ -52,6 +52,7 @@
     (blur)="onBlur($event)"
     (input)="onInput($event)"
     (keyup)="onKeyUp($event)"
+    (keydown)="onKeyDown($event)"
   />
   }
 </mat-form-field>


### PR DESCRIPTION
The isComposing field tells us if we are using an input method editor (IME) which
will display a menu of characters that can't be represented on a standard QWERTY
keyboard. The user can select from this menu by pressing "enter" or clicking the
menu item. The user will then need to press "enter" to confirm the selection (at
least on MacOS).

If we do not check isComposing on key up, this will trigger the Mesop on enter
event.

If we check isComposing on key up, the enter confirmation will trigger the Mesop
on enter event since isComposing becomes false on key up.

We need to track isComposing with the key down event since this will trigger the
on enter event when "enter" is pressed again (when the IME is inactive and
a selection has been made and applied).

Safari has a bug where the order of operations for isComposing is in a different
order. See https://bugs.webkit.org/show_bug.cgi?id=165004.

In order to work around this issue, we need to count expectedIsComposingCount
equals false twice on Safari rather than just once.

Ref: https://github.com/google/mesop/issues/588