### PR TITLE
Fix broken iframe links in docs

### DIFF
--- a/docs/components/code.md
+++ b/docs/components/code.md
@@ -4,10 +4,10 @@ Code is used to render code with syntax highlighting. `code` is a simple wrapper
 
 ## Examples
 
-<iframe class="component-demo" src="https://google.github.io/mesop/demo/?demo=code"></iframe>
+<iframe class="component-demo" src="https://google.github.io/mesop/demo/?demo=code_demo"></iframe>
 
 ```python
---8<-- "demo/code.py"
+--8<-- "demo/code_demo.py"
 ```
 
 ## API

--- a/docs/components/html.md
+++ b/docs/components/html.md
@@ -9,7 +9,7 @@ There are two modes for rendering HTML components:
 
 ## Examples
 
-<iframe class="component-demo" src="https://mesop-y677hytkra-uc.a.run.app/html"></iframe>
+<iframe class="component-demo" src="https://google.github.io/mesop/demo/?demo=html_demo" style="height: 200px"></iframe>
 
 ```python
 --8<-- "demo/html_demo.py"

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -7,7 +7,7 @@ Select allows the user to choose from a list of values and is based on the [Angu
 <iframe class="component-demo" src="https://google.github.io/mesop/demo/?demo=select_demo" style="height: 200px"></iframe>
 
 ```python
---8<-- "demo/select.py"
+--8<-- "demo/select_demo.py"
 ```
 
 ## API

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -4,7 +4,7 @@ Select allows the user to choose from a list of values and is based on the [Angu
 
 ## Examples
 
-<iframe class="component-demo" src="https://google.github.io/mesop/demo/?demo=select" style="height: 200px"></iframe>
+<iframe class="component-demo" src="https://google.github.io/mesop/demo/?demo=select_demo" style="height: 200px"></iframe>
 
 ```python
 --8<-- "demo/select.py"


### PR DESCRIPTION
- Fix select to select_demo
- Fix code to code_demo
- The html one does not have a live demo yet since the demo gallery is at v0.8.0

Ref: https://github.com/google/mesop/issues/596