### PR TITLE
Fix bug with .env not loading for pip installs

### DIFF
--- a/mesop/server/config.py
+++ b/mesop/server/config.py
@@ -5,12 +5,13 @@ from typing import Literal
 from dotenv import find_dotenv, load_dotenv
 from pydantic import BaseModel
 
-# Try to load .env file for PyPi Mesop build which should be in the user's current
-# working directory.
-if not load_dotenv(find_dotenv(usecwd=True)):
-  # If this fails, we may be running Mesop with Bazel, which looks for the .env file in
-  # `mesop/.env` from the root workspace.
+if os.environ.get("BUILD_WORKSPACE_DIRECTORY"):
+  # If running with Bazel, we look for `mesop/.env` from the root workspace.
   load_dotenv()
+else:
+  # Try to load .env file for PyPi Mesop build which should be in the user's current
+  # working directory.
+  load_dotenv(find_dotenv(usecwd=True))
 
 
 class Config(BaseModel):

--- a/mesop/server/config.py
+++ b/mesop/server/config.py
@@ -2,10 +2,15 @@ import os
 from pathlib import Path
 from typing import Literal
 
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 from pydantic import BaseModel
 
-load_dotenv()
+# Try to load .env file for PyPi Mesop build which should be in the user's current
+# working directory.
+if not load_dotenv(find_dotenv(usecwd=True)):
+  # If this fails, we may be running Mesop with Bazel, which looks for the .env file in
+  # `mesop/.env` from the root workspace.
+  load_dotenv()
 
 
 class Config(BaseModel):


### PR DESCRIPTION
For some reason the default `load_dotenv()` behavior is not working as expected for pip installs. To fix this, we update the code to explicitly search the user's current working directory.

This does not work when running in Bazel, so we still need to use `load_dotenv()`.

Tested this by running ./scripts/pip.sh and also testing ./scripts/cli.sh.

Ref: https://github.com/google/mesop/issues/592