### PR TITLE
Budget more time for playwright tests & disable retries

### DIFF
--- a/mesop/tests/e2e/web_components/slot_test.ts
+++ b/mesop/tests/e2e/web_components/slot_test.ts
@@ -1,35 +1,39 @@
 import {test, expect, Page} from '@playwright/test';
 
-test('web components - slot', async ({page}) => {
-  await page.goto('http://localhost:32123/web_component/slot/slot_app');
-  // Make sure the page has loaded:
-  expect(page.getByRole('button', {name: 'Decrement'})).toBeVisible();
+test.describe(() => {
+  // All tests in this describe group will get 2 retry attempts.
+  test.describe.configure({retries: 2});
+  test('web components - slot', async ({page}) => {
+    await page.goto('http://localhost:32123/web_component/slot/slot_app');
+    // Make sure the page has loaded:
+    expect(page.getByRole('button', {name: 'Decrement'})).toBeVisible();
 
-  assertValue(10);
-  await page.getByRole('button', {name: 'increment'}).click();
-  assertValue(11);
-  await page.getByRole('button', {name: 'increment'}).click();
-  assertValue(12);
-  await page.getByRole('button', {name: 'Decrement'}).click();
-  assertValue(11);
-  await page.getByRole('button', {name: 'Decrement'}).click();
-  assertValue(10);
+    assertValue(10);
+    await page.getByRole('button', {name: 'increment'}).click();
+    assertValue(11);
+    await page.getByRole('button', {name: 'increment'}).click();
+    assertValue(12);
+    await page.getByRole('button', {name: 'Decrement'}).click();
+    assertValue(11);
+    await page.getByRole('button', {name: 'Decrement'}).click();
+    assertValue(10);
 
-  async function assertValue(value: number) {
-    // Check that the outer component is displaying the right value.
-    expect(
-      await page
-        .locator('div')
-        .filter({hasText: `Value: ${value} increment Start of`})
-        .textContent(),
-    ).toContain(value.toString());
+    async function assertValue(value: number) {
+      // Check that the outer component is displaying the right value.
+      expect(
+        await page
+          .locator('div')
+          .filter({hasText: `Value: ${value} increment Start of`})
+          .textContent(),
+      ).toContain(value.toString());
 
-    // Check that the inner component is displaying the right value.
-    expect(
-      await page
-        .locator('slot-counter-component')
-        .getByText('Value:')
-        .textContent(),
-    ).toContain(value.toString());
-  }
+      // Check that the inner component is displaying the right value.
+      expect(
+        await page
+          .locator('slot-counter-component')
+          .getByText('Value:')
+          .textContent(),
+      ).toContain(value.toString());
+    }
+  });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ import {defineConfig, devices} from '@playwright/test';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  timeout: process.env.CI ? 30000 : 15000, // Budget more time for CI since tests run slower there.
+  timeout: process.env.CI ? 50000 : 25000, // Budget more time for CI since tests run slower there.
   testDir: '.',
   // Use a custom snapshot path template because Playwright's default
   // is platform-specific which isn't necessary for Mesop e2e tests


### PR DESCRIPTION
- Removed retries for the overall test suites because it can mask real issues and we can mark specific tests as flaky, such as web component slot test which is flaky both locally and on GitHub.
