### PR TITLE
Allow iframing any other sites

### DIFF
--- a/mesop/server/static_file_serving.py
+++ b/mesop/server/static_file_serving.py
@@ -148,7 +148,7 @@ def configure_static_file_serving(
         "default-src": "'self'",
         "font-src": "fonts.gstatic.com",
         # Mesop app developers should be able to iframe other sites.
-        "frame-src": "'self' https:",
+        "frame-src": "*",
         # Mesop app developers should be able to load images and media from various origins.
         "img-src": "'self' data: https: http:",
         "media-src": "'self' data: https:",

--- a/mesop/tests/e2e/snapshots/web_security_test.ts_csp-allowed-iframe-parents.txt
+++ b/mesop/tests/e2e/snapshots/web_security_test.ts_csp-allowed-iframe-parents.txt
@@ -1,6 +1,6 @@
 default-src 'self'
 font-src fonts.gstatic.com
-frame-src 'self' https:
+frame-src *
 img-src 'self' data: https: http:
 media-src 'self' data: https:
 style-src 'self' 'unsafe-inline' fonts.googleapis.com

--- a/mesop/tests/e2e/snapshots/web_security_test.ts_csp.txt
+++ b/mesop/tests/e2e/snapshots/web_security_test.ts_csp.txt
@@ -1,6 +1,6 @@
 default-src 'self'
 font-src fonts.gstatic.com
-frame-src 'self' https:
+frame-src *
 img-src 'self' data: https: http:
 media-src 'self' data: https:
 style-src 'self' 'unsafe-inline' fonts.googleapis.com


### PR DESCRIPTION
Closes #628.

`frame-src` (i.e. iframing other sites) is fairly low-risk and we may as well allow iframing any site. This is different than `frame-ancestors` which is much more security sensitive and has a strict allowlist.

Background: https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html#preventing-framing-attacks-clickjacking-cross-site-leaks