### PR TITLE
Do not use class variables in runtime modules

### DIFF
--- a/mesop/runtime/context.py
+++ b/mesop/runtime/context.py
@@ -19,15 +19,6 @@ Handler = Callable[[Any], Generator[None, None, None] | None]
 
 
 class Context:
-  _states: dict[type[Any], object]
-  # Previous states is used for performing state diffs.
-  _previous_states: dict[type[Any], object]
-  _handlers: dict[str, Handler]
-  _commands: list[pb.Command]
-  _node_slot: pb.Component | None
-  _node_slot_children_count: int | None
-  _viewport_size: pb.ViewportSize | None = None
-
   def __init__(
     self,
     get_handler: Callable[[str], Handler | None],
@@ -36,13 +27,15 @@ class Context:
     self._get_handler = get_handler
     self._current_node = pb.Component()
     self._previous_node: pb.Component | None = None
-    self._states = states
-    self._previous_states = copy.deepcopy(states)
+    self._states: dict[type[Any], object] = states
+    # Previous states is used for performing state diffs.
+    self._previous_states: dict[type[Any], object] = copy.deepcopy(states)
     self._trace_mode = False
-    self._handlers = {}
-    self._commands = []
-    self._node_slot = None
-    self._node_slot_children_count = None
+    self._handlers: dict[str, Handler] = {}
+    self._commands: list[pb.Command] = []
+    self._node_slot: pb.Component | None = None
+    self._node_slot_children_count: int | None = None
+    self._viewport_size: pb.ViewportSize | None = None
 
   def commands(self) -> list[pb.Command]:
     return self._commands

--- a/mesop/runtime/runtime.py
+++ b/mesop/runtime/runtime.py
@@ -38,12 +38,12 @@ T = TypeVar("T")
 
 
 class Runtime:
-  _path_to_page_config: dict[str, PageConfig] = {}
+  _path_to_page_config: dict[str, PageConfig]
   _handlers: dict[str, Handler]
   _state_classes: list[type[Any]]
   _loading_errors: list[pb.ServerError]
   component_fns: set[Callable[..., Any]]
-  js_modules: set[str] = set()
+  js_modules: set[str]
   debug_mode: bool = False
   # If True, then the server is still re-executing the modules
   # needed for hot reloading.
@@ -53,7 +53,9 @@ class Runtime:
   hot_reload_counter = 0
 
   def __init__(self):
+    self._path_to_page_config = {}
     self.component_fns = set()
+    self.js_modules = set()
     self._handlers = {}
     self.event_mappers: dict[Type[Any], Callable[[pb.UserEvent, Key], Any]] = {}
     self._state_classes = []

--- a/mesop/runtime/runtime.py
+++ b/mesop/runtime/runtime.py
@@ -38,28 +38,21 @@ T = TypeVar("T")
 
 
 class Runtime:
-  _path_to_page_config: dict[str, PageConfig]
-  _handlers: dict[str, Handler]
-  _state_classes: list[type[Any]]
-  _loading_errors: list[pb.ServerError]
-  component_fns: set[Callable[..., Any]]
-  js_modules: set[str]
-  debug_mode: bool = False
-  # If True, then the server is still re-executing the modules
-  # needed for hot reloading.
-  is_hot_reload_in_progress: bool = False
-  # Keeps track of the hot reload count so that the server can tell
-  # clients polling whether to request a hot reload.
-  hot_reload_counter = 0
-
   def __init__(self):
-    self._path_to_page_config = {}
-    self.component_fns = set()
-    self.js_modules = set()
-    self._handlers = {}
+    self.debug_mode: bool = False
+    # If True, then the server is still re-executing the modules
+    # needed for hot reloading.
+    self.is_hot_reload_in_progress: bool = False
+    # Keeps track of the hot reload count so that the server can tell
+    # clients polling whether to request a hot reload.
+    self.hot_reload_counter = 0
+    self._path_to_page_config: dict[str, PageConfig] = {}
+    self.component_fns: set[Callable[..., Any]] = set()
+    self.js_modules: set[str] = set()
+    self._handlers: dict[str, Handler] = {}
     self.event_mappers: dict[Type[Any], Callable[[pb.UserEvent, Key], Any]] = {}
-    self._state_classes = []
-    self._loading_errors = []
+    self._state_classes: list[type[Any]] = []
+    self._loading_errors: list[pb.ServerError] = []
 
   def context(self) -> Context:
     if "_mesop_context" not in g:


### PR DESCRIPTION
- It's better to do the type annotations inside `__init__` instead of annotating at the class variable.
- Initializing class variables is sketchy, particularly with mutable objects.
- We were previously initializing class variables to mutable values on Runtime, which is technically not too bad because Runtime is a singleton object, but this is still a bad practice.