### PR TITLE
Enable RUF lint rules

### DIFF
--- a/demo/table.py
+++ b/demo/table.py
@@ -62,5 +62,5 @@ def on_click(e: me.TableClickEvent):
   state = me.state(State)
   state.selected_cell = (
     f"Selected cell at col {e.col_index} and row {e.row_index} "
-    f"with value {str(df.iat[e.row_index, e.col_index])}"
+    f"with value {df.iat[e.row_index, e.col_index]!s}"
   )

--- a/mesop/bin/bin.py
+++ b/mesop/bin/bin.py
@@ -94,7 +94,7 @@ $\u001b[35m mesop {argv[1]}\u001b[0m"""
   #
   # Ref:
   # https://docs.python.org/3/library/sys_path_init.html
-  sys.path = [os.path.dirname(absolute_path)] + sys.path
+  sys.path = [os.path.dirname(absolute_path), *sys.path]
 
   app = create_app(
     prod_mode=FLAGS.prod,

--- a/mesop/components/table/e2e/table_app.py
+++ b/mesop/components/table/e2e/table_app.py
@@ -57,5 +57,5 @@ def on_click(e: me.TableClickEvent):
   state = me.state(State)
   state.selected_cell = (
     f"Selected cell at col {e.col_index} and row {e.row_index} "
-    f"with value {str(df.iat[e.row_index, e.col_index])}"
+    f"with value {df.iat[e.row_index, e.col_index]!s}"
   )

--- a/mesop/server/state_session_test.py
+++ b/mesop/server/state_session_test.py
@@ -1,3 +1,4 @@
+# ruff: noqa: RUF013
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -377,10 +378,10 @@ class FakeFirestoreDocumentReference(DocumentReference):
 
   def get(
     self,
-    field_paths: Optional[Iterable[str]] = None,  # type: ignore
+    field_paths: Iterable[str] = None,  # type: ignore
     transaction=None,
     retry: retries.Retry = gapic_v1.method.DEFAULT,  # type: ignore
-    timeout: Optional[float] = None,  # type: ignore
+    timeout: float = None,  # type: ignore
   ) -> DocumentSnapshot:
     return self.doc
 
@@ -389,7 +390,7 @@ class FakeFirestoreDocumentReference(DocumentReference):
     document_data: dict,
     merge: bool = False,
     retry: retries.Retry = gapic_v1.method.DEFAULT,  # type: ignore
-    timeout: Optional[float] = None,  # type: ignore
+    timeout: float = None,  # type: ignore
   ) -> write.WriteResult:
     self.doc = DocumentSnapshot(
       self,
@@ -407,7 +408,7 @@ def delete(
   self,
   option: _helpers.WriteOption = None,  # type: ignore
   retry: retries.Retry = gapic_v1.method.DEFAULT,  # type: ignore
-  timeout: Optional[float] = None,  # type: ignore
+  timeout: float = None,  # type: ignore
 ) -> Timestamp:
   self.doc = DocumentSnapshot(
     self,

--- a/mesop/server/state_session_test.py
+++ b/mesop/server/state_session_test.py
@@ -377,10 +377,10 @@ class FakeFirestoreDocumentReference(DocumentReference):
 
   def get(
     self,
-    field_paths: Iterable[str] = None,  # type: ignore
+    field_paths: Optional[Iterable[str]] = None,  # type: ignore
     transaction=None,
     retry: retries.Retry = gapic_v1.method.DEFAULT,  # type: ignore
-    timeout: float = None,  # type: ignore
+    timeout: Optional[float] = None,  # type: ignore
   ) -> DocumentSnapshot:
     return self.doc
 
@@ -389,7 +389,7 @@ class FakeFirestoreDocumentReference(DocumentReference):
     document_data: dict,
     merge: bool = False,
     retry: retries.Retry = gapic_v1.method.DEFAULT,  # type: ignore
-    timeout: float = None,  # type: ignore
+    timeout: Optional[float] = None,  # type: ignore
   ) -> write.WriteResult:
     self.doc = DocumentSnapshot(
       self,
@@ -407,7 +407,7 @@ def delete(
   self,
   option: _helpers.WriteOption = None,  # type: ignore
   retry: retries.Retry = gapic_v1.method.DEFAULT,  # type: ignore
-  timeout: float = None,  # type: ignore
+  timeout: Optional[float] = None,  # type: ignore
 ) -> Timestamp:
   self.doc = DocumentSnapshot(
     self,

--- a/mesop/utils/path_utils.py
+++ b/mesop/utils/path_utils.py
@@ -2,7 +2,7 @@ import os
 
 
 def get_path_from_workspace_root(*args: str) -> str:
-  path_args = [_get_bazel_workspace_directory()] + list(args)
+  path_args = [_get_bazel_workspace_directory(), *list(args)]
   return os.path.join(*path_args)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ select = [
     "SIM",
     # isort
     "I",
+    # Ruff
+    "RUF",
 ]
 ignore = [
     "E501",   # ignore line-length (e.g. long docstring)


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf

In particular, it contains https://docs.astral.sh/ruff/rules/mutable-class-default/ which would catch the issue that was fixed in #642. 