### PR TITLE
Provide more explicit docs about mutable state default values

### DIFF
--- a/docs/guides/state_management.md
+++ b/docs/guides/state_management.md
@@ -38,12 +38,20 @@ You **MUST** use immutable default values _or_ use dataclasses `field` initializ
 
 ???+ failure "Bad: mutable default value"
 
-    This will raise an exception because dataclasses prevents you from using mutable collection types like `list` as the default value because this is a common footgun.
+    The following will raise an exception because dataclasses prevents you from using mutable collection types like `list` as the default value because this is a common footgun.
 
     ```py
     @me.stateclass
     class State:
       a: list[str] = ["abc"]
+    ```
+
+    If you set a default value to an instance of a custom type, an exception will not be raised, but you will be dangerously sharing the same mutable instance across sessions which could cause a serious privacy issue.
+
+    ```py
+    @me.stateclass
+    class State:
+      a: MutableClass = MutableClass()
     ```
 
 ???+ success "Good: default factory"

--- a/docs/guides/state_management.md
+++ b/docs/guides/state_management.md
@@ -66,7 +66,7 @@ You **MUST** use immutable default values _or_ use dataclasses `field` initializ
       a: list[str] = field(default_factory=lambda: ["abc"])
     ```
 
-???+ success "Good example of no default value"
+???+ success "Good: no default value"
 
     If you want a default of an empty list, you can just not define a default value and Mesop will automatically define an empty list default value.
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -161,8 +161,9 @@ p {
   font-size: 0.8rem;
 }
 
-.md-typeset .admonition {
-  font-size: 0.75rem;
+.md-typeset .admonition,
+.md-typeset details {
+  font-size: 0.8rem;
 }
 
 .highlight code {


### PR DESCRIPTION
I think the docs before were not vocal enough about avoiding this pitfall. I'm also exploring a way of programmatically safe-guarding against mutable default values, but it's a bit tricky - see #647.