### PR TITLE
Create a concurrency test to stress-test state is isolated across sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,14 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+      - name: Run playwright test (concurrency)
+        run: yarn playwright test mesop/tests/e2e/concurrency/state_test.ts --repeat-each=48 --workers=16
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
       - name: Run playwright test with memory state session
         run: MESOP_STATE_SESSION_BACKEND=memory yarn playwright test
       - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3

--- a/mesop/examples/__init__.py
+++ b/mesop/examples/__init__.py
@@ -6,6 +6,7 @@ from mesop.examples import box as box
 from mesop.examples import buttons as buttons
 from mesop.examples import checkbox_and_radio as checkbox_and_radio
 from mesop.examples import composite as composite
+from mesop.examples import concurrency_state as concurrency_state
 from mesop.examples import custom_font as custom_font
 from mesop.examples import dict_state as dict_state
 from mesop.examples import docs as docs

--- a/mesop/examples/concurrency_state.py
+++ b/mesop/examples/concurrency_state.py
@@ -1,0 +1,6 @@
+import mesop as me
+
+
+@me.page(path="/concurrency_state")
+def page():
+  me.text("concurrency_state")

--- a/mesop/examples/concurrency_state.py
+++ b/mesop/examples/concurrency_state.py
@@ -4,3 +4,14 @@ import mesop as me
 @me.page(path="/concurrency_state")
 def page():
   me.text("concurrency_state")
+  me.input(label="State input", on_input=on_input)
+  me.text("Input: " + me.state(State).input)
+
+
+@me.stateclass
+class State:
+  input: str
+
+
+def on_input(e: me.InputEvent):
+  me.state(State).input = e.value

--- a/mesop/tests/e2e/concurrency/state_test.ts
+++ b/mesop/tests/e2e/concurrency/state_test.ts
@@ -11,7 +11,9 @@ test('state updates correctly', async ({page}) => {
   await page.goto('/concurrency_state');
   const randomString = generateRandomString(16);
   await page.getByLabel('State input').fill(randomString);
-  await expect(page.getByText('Input: ' + randomString)).toBeVisible();
+  await expect(page.getByText('Input: ' + randomString)).toBeVisible({
+    timeout: 15000,
+  });
 });
 
 function generateRandomString(length: number) {

--- a/mesop/tests/e2e/concurrency/state_test.ts
+++ b/mesop/tests/e2e/concurrency/state_test.ts
@@ -1,0 +1,25 @@
+/**
+ * The purpose of this test is to ensure that sessions have proper
+ * state isolation, particularly under high concurrency.
+ *
+ * Run test as:
+ * yarn playwright test mesop/tests/e2e/concurrency/state_test.ts --repeat-each=48 --workers=16
+ */
+import {test, expect} from '@playwright/test';
+
+test('state updates correctly', async ({page}) => {
+  await page.goto('/concurrency_state');
+  const randomString = generateRandomString(16);
+  await page.getByLabel('State input').fill(randomString);
+  await expect(page.getByText('Input: ' + randomString)).toBeVisible();
+});
+
+function generateRandomString(length: number) {
+  const characters =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length));
+  }
+  return result;
+}


### PR DESCRIPTION
Fixes #654.

This test has its own GitHub Actions workflow step because I couldn't figure out a way to force a high number of workers for a specific test using playwright's config.