### PR TITLE
Catch accidental usages of mutable default state values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: check-case-conflict
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.4
+    rev: v0.5.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/mesop/dataclass_utils/dataclass_utils.py
+++ b/mesop/dataclass_utils/dataclass_utils.py
@@ -69,13 +69,15 @@ def dataclass_with_defaults(cls: Type[C]) -> Type[C]:
       elif get_origin(type_hint) == dict:
         setattr(cls, name, field(default_factory=dict))
       elif isinstance(type_hint, type):
-        if is_dataclass(cls) or has_parent(type_hint):
+        if has_parent(type_hint):
           setattr(cls, name, field(default_factory=type_hint))
         else:
           setattr(
             cls, name, field(default_factory=dataclass_with_defaults(type_hint))
           )
-
+  # If a class is already a dataclass, then don't wrap it with another dataclass decorator.
+  if is_dataclass(cls):
+    return cls
   return dataclass(cls)
 
 

--- a/mesop/dataclass_utils/dataclass_utils.py
+++ b/mesop/dataclass_utils/dataclass_utils.py
@@ -1,6 +1,6 @@
 import base64
 import json
-from dataclasses import asdict, dataclass, field, is_dataclass
+from dataclasses import Field, asdict, dataclass, field, is_dataclass
 from datetime import datetime
 from io import StringIO
 from typing import Any, Type, TypeVar, cast, get_origin, get_type_hints
@@ -37,7 +37,24 @@ def dataclass_with_defaults(cls: Type[C]) -> Type[C]:
   Provides defaults for every attribute in a dataclass (recursively) so
   Mesop developers don't need to manually set default values
   """
-  pass
+  for name in cls.__dict__:
+    # Skip dunder methods.
+    if name.startswith("__") and name.endswith("__"):
+      continue
+    classVar = cls.__dict__[name]
+    if not isinstance(classVar, Field):
+      try:
+        hash(classVar)
+      except TypeError as exc:
+        raise Exception(
+          "Detected non-hashable type=",
+          type(classVar).__name__,
+          "for name=",
+          name,
+          "for class=",
+          cls,
+        ) from exc
+
   annotations = get_type_hints(cls)
   for name, type_hint in annotations.items():
     if name not in cls.__dict__:  # Skip if default already set

--- a/mesop/dataclass_utils/dataclass_utils.py
+++ b/mesop/dataclass_utils/dataclass_utils.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E721
 import base64
 import json
 from dataclasses import Field, asdict, dataclass, field, is_dataclass

--- a/mesop/dataclass_utils/dataclass_utils_test.py
+++ b/mesop/dataclass_utils/dataclass_utils_test.py
@@ -286,5 +286,11 @@ def test_serialize_deserialize_state_with_list_dict():
   assert new_state == state
 
 
+# def test_proto_without_default_does_not_throw():
+#   @dataclass_with_defaults
+#   class StateWithMutableProto:
+#     proto: pb.Style
+
+
 if __name__ == "__main__":
   raise SystemExit(pytest.main([__file__]))

--- a/mesop/dataclass_utils/dataclass_utils_test.py
+++ b/mesop/dataclass_utils/dataclass_utils_test.py
@@ -301,6 +301,21 @@ def test_serialize_deserialize_state_with_list_dict():
   assert new_state == state
 
 
+def test_serialize_deserialize_state_with_proto_throws():
+  @dataclass_with_defaults
+  class State:
+    proto: pb.ComponentName
+
+  state = State()
+
+  with pytest.raises(Exception) as exc_info:
+    serialize_dataclass(state)
+
+  assert "Object of type ComponentName is not JSON serializable" in str(
+    exc_info.value
+  )
+
+
 def test_dataclass_default_value_throws():
   with pytest.raises(Exception) as exc_info:
 

--- a/mesop/dataclass_utils/dataclass_utils_test.py
+++ b/mesop/dataclass_utils/dataclass_utils_test.py
@@ -349,7 +349,7 @@ def test_proto_in_dataclass_with_default_throws():
 
     @dataclass
     class DataclassWithProto:
-      style: pb.Style = pb.Style()
+      style: pb.Style = pb.Style()  # noqa: RUF009 (intentionally do an anti-pattern to make sure exception is raised)
 
     @dataclass_with_defaults
     class StateWithMutableProto:

--- a/mesop/dataclass_utils/dataclass_utils_test.py
+++ b/mesop/dataclass_utils/dataclass_utils_test.py
@@ -8,6 +8,7 @@ import pytest
 import mesop.protos.ui_pb2 as pb
 from mesop.dataclass_utils.dataclass_utils import (
   dataclass_with_defaults,
+  has_parent,
   serialize_dataclass,
   update_dataclass_from_json,
 )
@@ -399,6 +400,32 @@ def test_proto_in_unannotated_class_with_default_throws():
     "Detected mutable default value for non-hashable type=Style for attribute=style in class=UnannotatedClassWithProto"
     in str(exc_info.value)
   )
+
+
+def test_has_parent_simple_class():
+  class SimpleClass:
+    val: str
+
+  assert has_parent(SimpleClass) is False
+
+
+def test_has_parent_dataclass():
+  @dataclass
+  class ADataclass:
+    val: str
+
+  assert has_parent(ADataclass) is False
+
+
+def test_has_parent_child_class():
+  class ParentClass:
+    pass
+
+  class ChildClass(ParentClass):
+    val: str
+
+  assert has_parent(ChildClass) is True
+  assert has_parent(ParentClass) is False
 
 
 if __name__ == "__main__":

--- a/mesop/dataclass_utils/dataclass_utils_test.py
+++ b/mesop/dataclass_utils/dataclass_utils_test.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import mesop.protos.ui_pb2 as pb
 from mesop.dataclass_utils.dataclass_utils import (
   dataclass_with_defaults,
   serialize_dataclass,
@@ -286,10 +287,20 @@ def test_serialize_deserialize_state_with_list_dict():
   assert new_state == state
 
 
-# def test_proto_without_default_does_not_throw():
-#   @dataclass_with_defaults
-#   class StateWithMutableProto:
-#     proto: pb.Style
+def test_proto_without_default_does_not_throw():
+  @dataclass_with_defaults
+  class StateWithMutableProto:
+    proto: pb.Style
+
+
+def test_proto_with_default_throws():
+  with pytest.raises(Exception) as exc_info:
+
+    @dataclass_with_defaults
+    class StateWithMutableProto:
+      proto: pb.Style = pb.Style()
+
+  assert "Detected mutable default value" in str(exc_info.value)
 
 
 if __name__ == "__main__":

--- a/mesop/dataclass_utils/dataclass_utils_test.py
+++ b/mesop/dataclass_utils/dataclass_utils_test.py
@@ -84,7 +84,7 @@ def test_dataclass_defaults_recursive():
   assert d.unannotated.val == ""
 
 
-def test_dataclass_field_defaults_works_with_already_annotated_nested_class_requires_default():
+def test_dataclass_field_defaults_works_with_already_annotated_nested_class():
   @dataclass
   class NestedDataclass:
     val: str = field(default="<default>")
@@ -97,7 +97,7 @@ def test_dataclass_field_defaults_works_with_already_annotated_nested_class_requ
   assert instance.nested.val == "<default>"
 
 
-def test_dataclass_defaults_works_with_already_annotated_nested_class_requires_default():
+def test_dataclass_defaults_works_with_already_annotated_nested_class():
   @dataclass
   class NestedDataclass:
     val: str = "default"


### PR DESCRIPTION
Fixes #644.

Note: this will raise an exception if someone tries to use a proto type in a state class. Before this, we weren't throwing an exception but we were silently not properly serializing & deserializing the proto state (effectively not updating the proto). We'll need to call this out when we sync downstream, and maybe we should support protos properly, but this is at least more explicit.