### PR TITLE
Fix markdown indention in markdown demo

### DIFF
--- a/demo/dialog.py
+++ b/demo/dialog.py
@@ -99,7 +99,7 @@ def dialog_actions():
   """
   with me.box(
     style=me.Style(
-      display="flex", justify_content="end", margin=me.Margin(top=20)
+      display="flex", justify_content="end", gap=5, margin=me.Margin(top=20)
     )
   ):
     me.slot()

--- a/demo/markdown_demo.py
+++ b/demo/markdown_demo.py
@@ -31,14 +31,14 @@ SAMPLE_MARKDOWN = """
 ### Unordered List
 - Item 1
 - Item 2
-  - Subitem 2.1
-  - Subitem 2.2
+    - Subitem 2.1
+    - Subitem 2.2
 
 ### Ordered List
 1. First item
 2. Second item
-   1. Subitem 2.1
-   2. Subitem 2.2
+    1. Subitem 2.1
+    2. Subitem 2.2
 
 ## Links
 [Google](https://www.google.com/)


### PR DESCRIPTION
Also minor adjustment for dialog box actions. Add a small flex gap.

Apparently with the markdown module we're using, you need four spaces for the nested lists to trigger. So updated markdown demo to reflect.