### PR TITLE
Add example webcomponent that uses markedjs, highlightjs, and mermaidjs

### DIFF
--- a/mesop/examples/web_component/BUILD
+++ b/mesop/examples/web_component/BUILD
@@ -12,6 +12,7 @@ py_library(
         "//mesop",
         "//mesop/examples/web_component/code_mirror_editor",
         "//mesop/examples/web_component/firebase_auth",
+        "//mesop/examples/web_component/markedjs",
         "//mesop/examples/web_component/plotly",
         "//mesop/examples/web_component/quickstart",
         "//mesop/examples/web_component/shared_js_module",

--- a/mesop/examples/web_component/__init__.py
+++ b/mesop/examples/web_component/__init__.py
@@ -4,6 +4,9 @@ from mesop.examples.web_component.code_mirror_editor import (
 from mesop.examples.web_component.firebase_auth import (
   firebase_auth_app as firebase_auth_app,
 )
+from mesop.examples.web_component.markedjs import (
+  markedjs_app as markedjs_app,
+)
 from mesop.examples.web_component.plotly import (
   plotly_app as plotly_app,
 )

--- a/mesop/examples/web_component/markedjs/BUILD
+++ b/mesop/examples/web_component/markedjs/BUILD
@@ -1,0 +1,14 @@
+load("//build_defs:defaults.bzl", "py_library")
+
+package(
+    default_visibility = ["//build_defs:mesop_examples"],
+)
+
+py_library(
+    name = "markedjs",
+    srcs = glob(["*.py"]),
+    data = glob(["*.js"]),
+    deps = [
+        "//mesop",
+    ],
+)

--- a/mesop/examples/web_component/markedjs/markedjs_app.py
+++ b/mesop/examples/web_component/markedjs/markedjs_app.py
@@ -62,6 +62,18 @@ def app():
   me.text("Hello World")
 ```
 
+```mermaid
+sequenceDiagram
+    Alice ->> Bob: Hello Bob, how are you?
+    Bob-->>John: How about you John?
+    Bob--x Alice: I am good thanks!
+    Bob-x John: I am good thanks!
+    Note right of John: Bob thinks a long<br/>long time, so long<br/>that the text does<br/>not fit on a row.
+
+    Bob-->Alice: Checking with John...
+    Alice->John: Yes... John, how are you?
+```
+
 ## Table
 
 First Header  | Second Header

--- a/mesop/examples/web_component/markedjs/markedjs_app.py
+++ b/mesop/examples/web_component/markedjs/markedjs_app.py
@@ -1,0 +1,99 @@
+import mesop as me
+from mesop.examples.web_component.markedjs.markedjs_component import (
+  markedjs_component,
+)
+
+SAMPLE_MARKDOWN = """
+# Sample Markdown Document
+
+## Table of Contents
+1. [Headers](#headers)
+2. [Emphasis](#emphasis)
+3. [Lists](#lists)
+4. [Links](#links)
+5. [Code](#code)
+6. [Blockquotes](#blockquotes)
+7. [Tables](#tables)
+8. [Horizontal Rules](#horizontal-rules)
+
+## Headers
+# Header 1
+## Header 2
+### Header 3
+#### Header 4
+##### Header 5
+###### Header 6
+
+## Emphasis
+*Italic text* or _Italic text_
+**Bold text** or __Bold text__
+***Bold and Italic*** or ___Bold and Italic___
+
+## Lists
+
+### Unordered List
+- Item 1
+- Item 2
+  - Subitem 2.1
+  - Subitem 2.2
+
+### Ordered List
+1. First item
+2. Second item
+   1. Subitem 2.1
+   2. Subitem 2.2
+
+## Links
+[Google](https://www.google.com/)
+
+## Code
+Inline `code`
+
+## Table
+
+First Header  | Second Header
+------------- | -------------
+Content Cell  | Content Cell
+Content Cell | Content Cell
+"""
+
+
+@me.stateclass
+class State:
+  markdown: str = SAMPLE_MARKDOWN
+
+
+@me.page(
+  path="/web_component/markedjs/markedjs_app",
+  stylesheets=[
+    "https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css"
+  ],
+  security_policy=me.SecurityPolicy(
+    allowed_connect_srcs=["https://cdn.jsdelivr.net"],
+    allowed_script_srcs=["https://cdn.jsdelivr.net"],
+  ),
+)
+def page():
+  state = me.state(State)
+  with me.box(
+    style=me.Style(display="flex", gap=20, padding=me.Padding.all(20))
+  ):
+    with me.box(style=me.Style(flex_grow=1)):
+      me.textarea(
+        value=state.markdown,
+        on_blur=on_blur,
+        style=me.Style(width="100%", height="100%"),
+        autosize=True,
+      )
+    with me.box(
+      style=me.Style(
+        padding=me.Padding.all(10),
+        border=me.Border.all(me.BorderSide(width=1, style="solid")),
+      )
+    ):
+      markedjs_component(state.markdown)
+
+
+def on_blur(e: me.InputBlurEvent):
+  state = me.state(State)
+  state.markdown = e.value

--- a/mesop/examples/web_component/markedjs/markedjs_app.py
+++ b/mesop/examples/web_component/markedjs/markedjs_app.py
@@ -46,8 +46,21 @@ SAMPLE_MARKDOWN = """
 ## Links
 [Google](https://www.google.com/)
 
+## Code Inline
+
+This is `var code = 'code';`
+
+
 ## Code
-Inline `code`
+
+```python
+import mesop as me
+
+
+@me.page(path="/hello_world")
+def app():
+  me.text("Hello World")
+```
 
 ## Table
 
@@ -66,11 +79,18 @@ class State:
 @me.page(
   path="/web_component/markedjs/markedjs_app",
   stylesheets=[
-    "https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css"
+    # Other themes here: https://www.jsdelivr.com/package/npm/highlight.js?tab=files&path=styles
+    "https://cdn.jsdelivr.net/npm/highlight.js@11.10.0/styles/night-owl.min.css",
   ],
   security_policy=me.SecurityPolicy(
     allowed_connect_srcs=["https://cdn.jsdelivr.net"],
     allowed_script_srcs=["https://cdn.jsdelivr.net"],
+    # CAUTION: this disables an important web security feature and
+    # should not be used for most mesop apps.
+    #
+    # Disabling trusted types because we need DomPurifier is not listed in TrustedHTML
+    # assignment.
+    dangerously_disable_trusted_types=True,
   ),
 )
 def page():

--- a/mesop/examples/web_component/markedjs/markedjs_component.js
+++ b/mesop/examples/web_component/markedjs/markedjs_component.js
@@ -1,0 +1,26 @@
+import {html, LitElement} from 'https://cdn.jsdelivr.net/npm/lit@3.1.4/+esm';
+import {unsafeHTML} from 'https://cdn.jsdelivr.net/npm/lit@3.1.4/directives/unsafe-html.js/+esm';
+import dompurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.1.6/+esm';
+import 'https://cdn.jsdelivr.net/npm/marked/marked.min.js';
+
+class MarkedJsComponent extends LitElement {
+  static properties = {
+    markdown: {type: String},
+  };
+
+  createRenderRoot() {
+    return this;
+  }
+
+  render() {
+    console.log();
+    return html`${unsafeHTML(
+      dompurify.sanitize(marked.parse(this.markdown), {
+        // Set to false since we can't modify the trusted types in Mesop
+        RETURN_TRUSTED_TYPE: false,
+      }),
+    )}`;
+  }
+}
+
+customElements.define('markedjs-component', MarkedJsComponent);

--- a/mesop/examples/web_component/markedjs/markedjs_component.js
+++ b/mesop/examples/web_component/markedjs/markedjs_component.js
@@ -4,6 +4,7 @@ import dompurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.1.6/+esm';
 import {Marked} from 'https://cdn.jsdelivr.net/npm/marked@13.0.2/+esm';
 import {markedHighlight} from 'https://cdn.jsdelivr.net/npm/marked-highlight@2.1.3/+esm';
 import highlightJs from 'https://cdn.jsdelivr.net/npm/highlight.js@11.10.0/+esm';
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10.9.1/+esm';
 
 class MarkedJsComponent extends LitElement {
   static properties = {
@@ -12,10 +13,14 @@ class MarkedJsComponent extends LitElement {
 
   constructor() {
     super();
+    mermaid.initialize({startOnLoad: true});
     this.marked = new Marked(
       markedHighlight({
         langPrefix: 'hljs language-',
         highlight(code, lang, info) {
+          if (lang === 'mermaid') {
+            return `<div class="mermaid">${code}</div>`;
+          }
           const language = highlightJs.getLanguage(lang) ? lang : 'plaintext';
           return highlightJs.highlight(code, {language}).value;
         },

--- a/mesop/examples/web_component/markedjs/markedjs_component.js
+++ b/mesop/examples/web_component/markedjs/markedjs_component.js
@@ -1,24 +1,35 @@
 import {html, LitElement} from 'https://cdn.jsdelivr.net/npm/lit@3.1.4/+esm';
 import {unsafeHTML} from 'https://cdn.jsdelivr.net/npm/lit@3.1.4/directives/unsafe-html.js/+esm';
 import dompurify from 'https://cdn.jsdelivr.net/npm/dompurify@3.1.6/+esm';
-import 'https://cdn.jsdelivr.net/npm/marked/marked.min.js';
+import {Marked} from 'https://cdn.jsdelivr.net/npm/marked@13.0.2/+esm';
+import {markedHighlight} from 'https://cdn.jsdelivr.net/npm/marked-highlight@2.1.3/+esm';
+import highlightJs from 'https://cdn.jsdelivr.net/npm/highlight.js@11.10.0/+esm';
 
 class MarkedJsComponent extends LitElement {
   static properties = {
     markdown: {type: String},
   };
 
+  constructor() {
+    super();
+    this.marked = new Marked(
+      markedHighlight({
+        langPrefix: 'hljs language-',
+        highlight(code, lang, info) {
+          const language = highlightJs.getLanguage(lang) ? lang : 'plaintext';
+          return highlightJs.highlight(code, {language}).value;
+        },
+      }),
+    );
+  }
+
   createRenderRoot() {
     return this;
   }
 
   render() {
-    console.log();
     return html`${unsafeHTML(
-      dompurify.sanitize(marked.parse(this.markdown), {
-        // Set to false since we can't modify the trusted types in Mesop
-        RETURN_TRUSTED_TYPE: false,
-      }),
+      dompurify.sanitize(this.marked.parse(this.markdown)),
     )}`;
   }
 }

--- a/mesop/examples/web_component/markedjs/markedjs_component.js
+++ b/mesop/examples/web_component/markedjs/markedjs_component.js
@@ -6,6 +6,12 @@ import {markedHighlight} from 'https://cdn.jsdelivr.net/npm/marked-highlight@2.1
 import highlightJs from 'https://cdn.jsdelivr.net/npm/highlight.js@11.10.0/+esm';
 import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10.9.1/+esm';
 
+/**
+ * Markdown component using MarkedJS
+ *
+ * - HighlightJS used for code highlighting
+ * - Mermaid JS integration for diagrams
+ */
 class MarkedJsComponent extends LitElement {
   static properties = {
     markdown: {type: String},

--- a/mesop/examples/web_component/markedjs/markedjs_component.py
+++ b/mesop/examples/web_component/markedjs/markedjs_component.py
@@ -1,0 +1,11 @@
+import mesop.labs as mel
+
+
+@mel.web_component(path="./markedjs_component.js")
+def markedjs_component(markdown: str):
+  return mel.insert_web_component(
+    name="markedjs-component",
+    properties={
+      "markdown": markdown,
+    },
+  )

--- a/mesop/server/static_file_serving.py
+++ b/mesop/server/static_file_serving.py
@@ -159,7 +159,7 @@ def configure_static_file_serving(
         "style-src": "'self' 'unsafe-inline' fonts.googleapis.com",
         "script-src": f"'self' 'nonce-{g.csp_nonce}'",
         # https://angular.io/guide/security#enforcing-trusted-types
-        "trusted-types": "angular angular#unsafe-bypass lit-html 'allow-duplicates'",
+        "trusted-types": "angular angular#unsafe-bypass lit-html",
         "require-trusted-types-for": "'script'",
       }
     )

--- a/mesop/server/static_file_serving.py
+++ b/mesop/server/static_file_serving.py
@@ -159,7 +159,7 @@ def configure_static_file_serving(
         "style-src": "'self' 'unsafe-inline' fonts.googleapis.com",
         "script-src": f"'self' 'nonce-{g.csp_nonce}'",
         # https://angular.io/guide/security#enforcing-trusted-types
-        "trusted-types": "angular angular#unsafe-bypass lit-html",
+        "trusted-types": "angular angular#unsafe-bypass lit-html 'allow-duplicates'",
         "require-trusted-types-for": "'script'",
       }
     )


### PR DESCRIPTION
This component uses MarkedJS for markdown, Mermaid for diagrams, and HighlightJS for code highlighting support.

- One issue is that I kept running into a duplicate trusted type issue with lit-html, so I needed to allow duplicates, but not sure if that's a good thing or not.
- This is an example workaround for the markdown issue that requires four indents for nested lists: https://github.com/google/mesop/issues/665
- Also curious to test this out with mel.chat  (replacing the me.markdown with this element) (https://github.com/google/mesop/issues/591)

# Screenshot

<img width="1305" alt="Screenshot 2024-07-26 at 4 51 28 PM" src="https://github.com/user-attachments/assets/74de9c8f-dfb8-48ce-8a1a-8ee9723b4388">

