### PR TITLE
Remove query params from stylesheet URLs when adding it to CSP

### DIFF
--- a/mesop/examples/custom_font.py
+++ b/mesop/examples/custom_font.py
@@ -3,7 +3,11 @@ import mesop as me
 
 @me.page(
   path="/custom_font",
-  stylesheets=["https://fonts.googleapis.com/css2?family=Tiny5&display=swap"],
+  stylesheets=[
+    "https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,100..900;1,100..900&family=Inter:wght@100..900&display=swap",
+    "https://fonts.googleapis.com/css2?family=Tiny5&display=swap",
+  ],
 )
 def app():
-  me.text("custom font", style=me.Style(font_family="Tiny5"))
+  me.text("Custom font: Inter Tight", style=me.Style(font_family="Inter Tight"))
+  me.text("Custom font: Tiny5", style=me.Style(font_family="Tiny5"))

--- a/mesop/examples/web_component/BUILD
+++ b/mesop/examples/web_component/BUILD
@@ -11,6 +11,7 @@ py_library(
     deps = [
         "//mesop",
         "//mesop/examples/web_component/code_mirror_editor",
+        "//mesop/examples/web_component/custom_font_csp_repro",
         "//mesop/examples/web_component/firebase_auth",
         "//mesop/examples/web_component/plotly",
         "//mesop/examples/web_component/quickstart",

--- a/mesop/examples/web_component/__init__.py
+++ b/mesop/examples/web_component/__init__.py
@@ -1,6 +1,9 @@
 from mesop.examples.web_component.code_mirror_editor import (
   code_mirror_editor_app as code_mirror_editor_app,
 )
+from mesop.examples.web_component.custom_font_csp_repro import (
+  custom_font_app as custom_font_app,
+)
 from mesop.examples.web_component.firebase_auth import (
   firebase_auth_app as firebase_auth_app,
 )

--- a/mesop/examples/web_component/custom_font_csp_repro/BUILD
+++ b/mesop/examples/web_component/custom_font_csp_repro/BUILD
@@ -1,0 +1,14 @@
+load("//build_defs:defaults.bzl", "py_library")
+
+package(
+    default_visibility = ["//build_defs:mesop_examples"],
+)
+
+py_library(
+    name = "custom_font_csp_repro",
+    srcs = glob(["*.py"]),
+    data = glob(["*.js"]),
+    deps = [
+        "//mesop",
+    ],
+)

--- a/mesop/examples/web_component/custom_font_csp_repro/counter_component.js
+++ b/mesop/examples/web_component/custom_font_csp_repro/counter_component.js
@@ -1,0 +1,38 @@
+import {
+  LitElement,
+  html,
+} from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
+
+class CounterComponent extends LitElement {
+  static properties = {
+    value: {type: Number},
+    decrementEvent: {type: String},
+  };
+
+  constructor() {
+    super();
+    this.value = 0;
+    this.decrementEvent = '';
+  }
+
+  render() {
+    return html`
+      <div class="container">
+        <span>Value: ${this.value}</span>
+        <button id="decrement-btn" @click="${this._onDecrement}">
+          Decrement
+        </button>
+      </div>
+    `;
+  }
+
+  _onDecrement() {
+    this.dispatchEvent(
+      new MesopEvent(this.decrementEvent, {
+        value: this.value - 1,
+      }),
+    );
+  }
+}
+
+customElements.define('quickstart-counter-component', CounterComponent);

--- a/mesop/examples/web_component/custom_font_csp_repro/counter_component.py
+++ b/mesop/examples/web_component/custom_font_csp_repro/counter_component.py
@@ -1,0 +1,22 @@
+from typing import Any, Callable
+
+import mesop.labs as mel
+
+
+@mel.web_component(path="./counter_component.js")
+def counter_component(
+  *,
+  value: int,
+  on_decrement: Callable[[mel.WebEvent], Any],
+  key: str | None = None,
+):
+  return mel.insert_web_component(
+    name="quickstart-counter-component",
+    key=key,
+    events={
+      "decrementEvent": on_decrement,
+    },
+    properties={
+      "value": value,
+    },
+  )

--- a/mesop/examples/web_component/custom_font_csp_repro/custom_font_app.py
+++ b/mesop/examples/web_component/custom_font_csp_repro/custom_font_app.py
@@ -1,0 +1,42 @@
+from pydantic import BaseModel
+
+import mesop as me
+import mesop.labs as mel
+from mesop.examples.web_component.quickstart.counter_component import (
+  counter_component,
+)
+
+# This is intended to repro a bug where loading stylesheet for a custom
+# font would cause issues with the CSP and prevent web components
+# from loading.
+# https://github.com/google/mesop/issues/549
+
+
+@me.page(
+  path="/web_component/custom_font_csp_repro/custom_font_app",
+  stylesheets=[
+    "https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,100..900;1,100..900&family=Inter:wght@100..900&display=swap",
+  ],
+)
+def page():
+  me.text("Custom font: Inter Tight", style=me.Style(font_family="Inter Tight"))
+  counter_component(
+    value=me.state(State).value,
+    on_decrement=on_decrement,
+  )
+
+
+@me.stateclass
+class State:
+  value: int = 10
+
+
+class ChangeValue(BaseModel):
+  value: int
+
+
+def on_decrement(e: mel.WebEvent):
+  # Creating a Pydantic model from the JSON value of the WebEvent
+  # to enforce type safety.
+  decrement = ChangeValue(**e.value)
+  me.state(State).value = decrement.value

--- a/mesop/server/static_file_serving.py
+++ b/mesop/server/static_file_serving.py
@@ -14,6 +14,7 @@ from werkzeug.security import safe_join
 from mesop.exceptions import MesopException
 from mesop.runtime import runtime
 from mesop.utils.runfiles import get_runfile_location, has_runfiles
+from mesop.utils.url_utils import remove_url_query_param
 
 WEB_COMPONENTS_PATH_SEGMENT = "__web-components-module__"
 
@@ -164,7 +165,9 @@ def configure_static_file_serving(
       }
     )
     if page_config and page_config.stylesheets:
-      csp["style-src"] += " " + " ".join(page_config.stylesheets)
+      csp["style-src"] += " " + " ".join(
+        [remove_url_query_param(url) for url in page_config.stylesheets]
+      )
     security_policy = None
     if page_config and page_config.security_policy:
       security_policy = page_config.security_policy

--- a/mesop/tests/e2e/web_components/custom_font_csp_test.ts
+++ b/mesop/tests/e2e/web_components/custom_font_csp_test.ts
@@ -1,0 +1,31 @@
+import {test, expect} from '@playwright/test';
+
+test('web components - make sure custom font does not cause CSP issues', async ({
+  page,
+}) => {
+  await page.goto('/web_component/custom_font_csp_repro/custom_font_app');
+  // Make sure page has loaded.
+  expect(await page.getByText('Custom font: ').textContent()).toEqual(
+    'Custom font: Inter Tight',
+  );
+
+  // Make sure the custom font is actually loaded.
+  const isFontLoaded = await page.evaluate((fontName) => {
+    return new Promise((resolve) => {
+      if (document.fonts.check(`12px "${fontName}"`)) {
+        resolve(true);
+      } else {
+        document.fonts.ready.then(() => {
+          resolve(document.fonts.check(`12px "${fontName}"`));
+        });
+      }
+    });
+  }, 'Inter Tight');
+  expect(isFontLoaded).toEqual(true);
+
+  expect(await page.getByText('Value: ').textContent()).toEqual('Value: 10');
+  await page.getByRole('button', {name: 'Decrement'}).click();
+  await page.getByText('Value: 9').textContent();
+  await page.getByRole('button', {name: 'Decrement'}).click();
+  await page.getByText('Value: 8').textContent();
+});

--- a/mesop/utils/BUILD
+++ b/mesop/utils/BUILD
@@ -6,8 +6,19 @@ package(
 
 py_library(
     name = "utils",
-    srcs = glob(["*.py"]),
+    srcs = glob(
+        ["*.py"],
+        exclude = ["*_test.py"],
+    ),
     deps = ["//mesop/protos:ui_py_pb2"] + PYTHON_RUNFILES_DEP + THIRD_PARTY_PY_PYDANTIC,
+)
+
+py_test(
+    name = "url_utils_test",
+    srcs = ["url_utils_test.py"],
+    deps = [
+        ":utils",
+    ] + THIRD_PARTY_PY_PYTEST,
 )
 
 py_test(

--- a/mesop/utils/url_utils.py
+++ b/mesop/utils/url_utils.py
@@ -1,0 +1,12 @@
+from urllib.parse import urlparse, urlunparse
+
+
+def remove_url_query_param(url: str) -> str:
+  """
+  Remove query parameters from a URL.
+
+  Args:
+      url: The input URL.
+  """
+  parsed = urlparse(url)
+  return urlunparse(parsed._replace(query=""))

--- a/mesop/utils/url_utils_test.py
+++ b/mesop/utils/url_utils_test.py
@@ -1,0 +1,27 @@
+import pytest
+
+from mesop.utils.url_utils import remove_url_query_param
+
+
+@pytest.mark.parametrize(
+  "input_url,expected_output",
+  [
+    ("https://example.com", "https://example.com"),
+    ("https://example.com?param=value", "https://example.com"),
+    ("https://example.com/?param=value", "https://example.com/"),
+    ("https://example.com?param1=value1&param2=value2", "https://example.com"),
+    ("https://example.com/path?param=value", "https://example.com/path"),
+    (
+      "https://example.com:8080/path?param=value",
+      "https://example.com:8080/path",
+    ),
+    ("http://example.com?param=value#fragment", "http://example.com#fragment"),
+    ("ftp://example.com?param=value", "ftp://example.com"),
+  ],
+)
+def test_remove_url_query_param(input_url: str, expected_output: str):
+  assert remove_url_query_param(input_url) == expected_output
+
+
+if __name__ == "__main__":
+  raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
Received a report that Mesop apps are having misconfigured CSP caused by stylesheet URLs.

I've removed query params because: 1) the query component is ignored (see error message below from Chrome) and 2) it can contain separator characters ";" and "," which was causing the CSP to break. As a follow-up, we can escape or raise an exception if any of the CSP inputs contains one of these separator characters.

```
The source list for Content Security Policy directive 'style-src' contains a source with an invalid path: '/css2?family=Tiny5&display=swap'. The query component, including the '?', will be ignored.
```

This also addresses the issue in #549.