### PR TITLE
Escape CSP source values

### DIFF
--- a/mesop/examples/testing/__init__.py
+++ b/mesop/examples/testing/__init__.py
@@ -5,6 +5,9 @@ from mesop.examples.testing import (
   conditional_event_handler as conditional_event_handler,
 )
 from mesop.examples.testing import (
+  csp_escaping as csp_escaping,
+)
+from mesop.examples.testing import (
   minimal_chat as minimal_chat,
 )
 from mesop.examples.testing import (

--- a/mesop/examples/testing/csp_escaping.py
+++ b/mesop/examples/testing/csp_escaping.py
@@ -1,0 +1,24 @@
+import mesop as me
+
+
+@me.page(
+  path="/testing/csp_escaping",
+  title="Stress test CSP escaping",
+  stylesheets=["http://google.com/stylesheets,1;2?q=a"],
+  security_policy=me.SecurityPolicy(
+    allowed_iframe_parents=[
+      "http://google.com/allowed_iframe_parents/1,1;2?q=a",
+      "http://google.com/allowed_iframe_parents/2,1;2?q=a",
+    ],
+    allowed_connect_srcs=[
+      "http://google.com/allowed_connect_srcs/1,1;2?q=a",
+      "http://google.com/allowed_connect_srcs/2,1;2?q=a",
+    ],
+    allowed_script_srcs=[
+      "http://google.com/allowed_script_srcs/1,1;2?q=a",
+      "http://google.com/allowed_script_srcs/2,1;2?q=a",
+    ],
+  ),
+)
+def page():
+  me.text("CSP escaping")

--- a/mesop/tests/e2e/snapshots/web_security_test.ts_csp-escaping.txt
+++ b/mesop/tests/e2e/snapshots/web_security_test.ts_csp-escaping.txt
@@ -1,0 +1,11 @@
+default-src 'self'
+font-src fonts.gstatic.com data:
+frame-src *
+img-src 'self' data: https: http:
+media-src 'self' data: https:
+style-src 'self' 'unsafe-inline' fonts.googleapis.com http://google.com/stylesheets%2C1%3B2
+script-src 'self' 'nonce-{{NONCE}}' http://google.com/allowed_script_srcs/1%2C1%3B2 http://google.com/allowed_script_srcs/2%2C1%3B2
+trusted-types angular angular#unsafe-bypass lit-html
+require-trusted-types-for 'script'
+connect-src 'self' http://google.com/allowed_connect_srcs/1%2C1%3B2 http://google.com/allowed_connect_srcs/2%2C1%3B2
+frame-ancestors 'self' http://google.com/allowed_iframe_parents/1%2C1%3B2 http://google.com/allowed_iframe_parents/2%2C1%3B2

--- a/mesop/tests/e2e/web_security_test.ts
+++ b/mesop/tests/e2e/web_security_test.ts
@@ -13,6 +13,12 @@ test('csp: allowed parent iframe origins', async ({page}) => {
   expect(cleanCsp(csp)).toMatchSnapshot('csp_allowed_iframe_parents.txt');
 });
 
+test('csp escaping', async ({page}) => {
+  const response = await page.goto('/testing/csp_escaping');
+  const csp = response?.headers()['content-security-policy']!;
+  expect(cleanCsp(csp)).toMatchSnapshot('csp_escaping.txt');
+});
+
 function cleanCsp(csp: string): string {
   return (
     csp

--- a/mesop/utils/url_utils.py
+++ b/mesop/utils/url_utils.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlparse, urlunparse
 
 
-def remove_url_query_param(url: str) -> str:
+def _remove_url_query_param(url: str) -> str:
   """
   Remove query parameters from a URL.
 
@@ -10,3 +10,12 @@ def remove_url_query_param(url: str) -> str:
   """
   parsed = urlparse(url)
   return urlunparse(parsed._replace(query=""))
+
+
+def _escape_url_for_csp(url: str) -> str:
+  escaped_url = url.replace(";", "%3B").replace(",", "%2C")
+  return escaped_url
+
+
+def sanitize_url_for_csp(url: str) -> str:
+  return _escape_url_for_csp(_remove_url_query_param(url))

--- a/mesop/utils/url_utils_test.py
+++ b/mesop/utils/url_utils_test.py
@@ -1,6 +1,10 @@
 import pytest
 
-from mesop.utils.url_utils import remove_url_query_param
+from mesop.utils.url_utils import (
+  _escape_url_for_csp,
+  _remove_url_query_param,
+  sanitize_url_for_csp,
+)
 
 
 @pytest.mark.parametrize(
@@ -20,7 +24,48 @@ from mesop.utils.url_utils import remove_url_query_param
   ],
 )
 def test_remove_url_query_param(input_url: str, expected_output: str):
-  assert remove_url_query_param(input_url) == expected_output
+  assert _remove_url_query_param(input_url) == expected_output
+
+
+@pytest.mark.parametrize(
+  "input_url,expected_output",
+  [
+    ("http://example.com/;param=value", "http://example.com/%3Bparam=value"),
+    ("http://example.com/,param=value", "http://example.com/%2Cparam=value"),
+    (
+      "http://example.com;param=value,param2=value2",
+      "http://example.com%3Bparam=value%2Cparam2=value2",
+    ),
+    ("http://example.com", "http://example.com"),
+    ("", ""),
+  ],
+)
+def test_escape_url_for_csp(input_url: str, expected_output: str):
+  assert _escape_url_for_csp(input_url) == expected_output
+
+
+@pytest.mark.parametrize(
+  "input_url,expected_output",
+  [
+    (
+      "http://example.com/;param=value,param2=value2",
+      "http://example.com/%3Bparam=value%2Cparam2=value2",
+    ),
+    ("http://example.com", "http://example.com"),
+    ("http://example.com/?query=param", "http://example.com/"),
+    (
+      "http://example.com/;param=value?query=param",
+      "http://example.com/%3Bparam=value",
+    ),
+    (
+      "http://example.com/,param=value?query=param",
+      "http://example.com/%2Cparam=value",
+    ),
+    ("", ""),
+  ],
+)
+def test_sanitize_url_for_csp(input_url: str, expected_output: str):
+  assert sanitize_url_for_csp(input_url) == expected_output
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This prevents values from accidentally (or potentially intentionally) breaking the CSP syntax.