### PR TITLE
Prevent page or web component from being registered after traffic has been served

### DIFF
--- a/mesop/examples/testing/__init__.py
+++ b/mesop/examples/testing/__init__.py
@@ -8,6 +8,12 @@ from mesop.examples.testing import (
   csp_escaping as csp_escaping,
 )
 from mesop.examples.testing import (
+  error_register_page_too_late as error_register_page_too_late,
+)
+from mesop.examples.testing import (
+  error_register_web_component_too_late as error_register_web_component_too_late,
+)
+from mesop.examples.testing import (
   minimal_chat as minimal_chat,
 )
 from mesop.examples.testing import (

--- a/mesop/examples/testing/error_register_page_too_late.py
+++ b/mesop/examples/testing/error_register_page_too_late.py
@@ -1,0 +1,10 @@
+import mesop as me
+
+
+@me.page(path="/testing/error_register_page_too_late")
+def page():
+  me.text("error_register_page_too_late")
+
+  @me.page(path="/testing/error_register_page_too_late/too_late_page")
+  def too_late_page():
+    me.text("too_late_page")

--- a/mesop/examples/testing/error_register_web_component_too_late.py
+++ b/mesop/examples/testing/error_register_web_component_too_late.py
@@ -1,0 +1,11 @@
+import mesop as me
+import mesop.labs as mel
+
+
+@me.page(path="/testing/error_register_web_component_too_late")
+def page():
+  me.text("error_register_web_component_too_late")
+
+  @mel.web_component(path="./fake_module.js")
+  def web_component():
+    pass

--- a/mesop/tests/e2e/late_registration_error_test.ts
+++ b/mesop/tests/e2e/late_registration_error_test.ts
@@ -1,0 +1,27 @@
+import {test, expect} from '@playwright/test';
+
+test('register page too late should cause an error', async ({page}) => {
+  await page.goto('/testing/error_register_page_too_late');
+
+  await expect(
+    page.getByText('Sorry, there was an error. Please contact the developer.'),
+  ).toBeVisible();
+
+  await page.goto('/testing/error_register_page_too_late/too_late_page');
+
+  await expect(
+    page.getByText(
+      'User Error: Accessed path: /testing/error_register_page_too_late/too_late_page not registered',
+    ),
+  ).toBeVisible();
+});
+
+test('register web component too late should cause an error', async ({
+  page,
+}) => {
+  await page.goto('/testing/error_register_web_component_too_late');
+
+  await expect(
+    page.getByText('Sorry, there was an error. Please contact the developer.'),
+  ).toBeVisible();
+});


### PR DESCRIPTION
We want to avoid an anti-pattern where Mesop app developers are defining a page or web component dynamically after _any_ traffic has been served (page and web components are registered globally as part of the runtime singleton, and are not scoped to a specific context/request). 

For example, we want to prevent the following:

```py
@me.page()
def p():
   s = me.state(State)

  @me.page(security_policy=me.SecurityPolicy(allowed_frame_parents=[s.user_input]))
  def dynamic_page():
     pass
```