### PR TITLE
Support query params

### DIFF
--- a/docs/api/query_params.md
+++ b/docs/api/query_params.md
@@ -1,0 +1,96 @@
+# Query Params API
+
+## Overview
+
+Query params, also sometimes called query string, provide a way to manage state in the URLs. They are useful for providing deep-links into your Mesop app.
+
+## Example
+
+Here's a simple working example that shows how you can read and write query params.
+
+```py
+@me.page(path="/examples/query_params/page_2")
+def page_2():
+  me.text(f"query_params={me.query_params}")
+  me.button("Add query param", on_click=add_query_param)
+  me.button("Navigate", on_click=navigate)
+
+def add_query_param(e: me.ClickEvent):
+  me.query_params["key"] = "value"
+
+def navigate(e: me.ClickEvent):
+  me.navigate("/examples/query_params", query_params=me.query_params)
+```
+
+## Usage
+
+You can use query parameters from `me.query_params`, which has a dictionary-like interface, where the key is the parameter name and value is the parameter value.
+
+### Get a query param value
+
+```py
+value: str = me.query_params['param_name']
+```
+This will raise a KeyError if the parameter doesn't exist. You can use `in` to check whether a key exists in `me.query_params`:
+
+```py
+if 'key' in me.query_params:
+    print(me.query_params['key'])
+```
+
+???+ NOTE "Repeated query params"
+    If a query param key is repeated, then you will get the _first_ value. If you want all the values use `get_all`.
+
+### Get all values
+
+To get all the values for a particular query parameter key, you can use `me.query_params.get_all`, which returns a sequence of parameter values (currently implemented as a `tuple`).
+
+```py
+all_values = me.query_params.get_all('param_name')
+```
+
+### Iterate
+
+```py
+for key in query_params:
+  value = query_params[key]
+```
+
+### Set query param
+
+```py
+query_params['new_param'] = 'value'
+```
+
+### Set repeated query param
+
+```py
+query_params['repeated_param'] = ['value1', 'value2']
+```
+
+### Delete
+
+```py
+del query_params['param_to_delete']
+```
+
+## Patterns
+
+### Navigate with existing query params
+
+Here's an example of how to navigate to a new page with query parameters:
+
+```py
+def click_navigate_button(e: me.ClickEvent):
+    me.query_params['q'] = "value"
+    me.navigate('/search', query_params=me.query_params)
+```
+
+### Navigate with only new query params
+
+You can also navigate by passing in a dictionary to `query_params` parameter for `me.navigate` if you do _not_ want to keep the existing query parameters.
+
+```py
+def click_navigate_button(e: me.ClickEvent):
+    me.navigate('/search', query_params={"q": "value})
+```

--- a/mesop/__init__.py
+++ b/mesop/__init__.py
@@ -169,6 +169,7 @@ from mesop.exceptions import (
   MesopUserException as MesopUserException,
 )
 from mesop.features import page as page
+from mesop.features.query_params import query_params as query_params
 from mesop.features.theme import set_theme_density as set_theme_density
 from mesop.features.theme import set_theme_mode as set_theme_mode
 from mesop.features.theme import theme_brightness as theme_brightness

--- a/mesop/commands/BUILD
+++ b/mesop/commands/BUILD
@@ -8,6 +8,7 @@ py_library(
     name = "commands",
     srcs = glob(["*.py"]),
     deps = [
+        "//mesop/features",
         "//mesop/protos:ui_py_pb2",
         "//mesop/runtime",
     ],

--- a/mesop/commands/navigate.py
+++ b/mesop/commands/navigate.py
@@ -1,11 +1,39 @@
+from typing import Sequence
+
+from mesop.features.query_params import (
+  QueryParams,
+)
+from mesop.features.query_params import (
+  query_params as me_query_params,
+)
 from mesop.runtime import runtime
+from mesop.utils.url_utils import remove_url_query_param
+from mesop.warn import warn
 
 
-def navigate(url: str) -> None:
+def navigate(
+  url: str,
+  *,
+  query_params: dict[str, str | Sequence[str]] | QueryParams | None = None,
+) -> None:
   """
   Navigates to the given URL.
 
   Args:
     url: The URL to navigate to.
+    query_params: A dictionary of query parameters to include in the URL, or `me.query_params`. If not provided, all current query parameters will be removed.
   """
-  runtime().context().navigate(url)
+  cleaned_url = remove_url_query_param(url)
+  if url != cleaned_url:
+    warn(
+      "Used me.navigate to navigate to a URL with query params. The query params have been removed. "
+      "Instead pass the query params using the keyword argument like this: "
+      "me.navigate(url, query_params={'key': 'value'})"
+    )
+  if isinstance(query_params, QueryParams):
+    query_params = {key: query_params.get_all(key) for key in query_params}
+
+  # Clear the query params because the query params will
+  # either be replaced with the new query_params or emptied (in server.py).
+  me_query_params.clear()
+  runtime().context().navigate(cleaned_url, query_params)

--- a/mesop/examples/__init__.py
+++ b/mesop/examples/__init__.py
@@ -28,6 +28,7 @@ from mesop.examples import on_load as on_load
 from mesop.examples import on_load_generator as on_load_generator
 from mesop.examples import playground as playground
 from mesop.examples import playground_critic as playground_critic
+from mesop.examples import query_params as query_params
 from mesop.examples import readme_app as readme_app
 from mesop.examples import scroll_into_view as scroll_into_view
 from mesop.examples import starter_kit as starter_kit

--- a/mesop/examples/query_params.py
+++ b/mesop/examples/query_params.py
@@ -1,0 +1,111 @@
+import mesop as me
+
+
+def on_load(e: me.LoadEvent):
+  me.query_params["on_load"] = "loaded"
+
+
+@me.page(path="/examples/query_params", on_load=on_load)
+def page():
+  me.text(f"query_params={me.query_params}")
+  me.button("append query param list", on_click=append_query_param_list)
+  me.button("URL-encoded query param", on_click=url_encoded_query_param)
+  me.button(
+    "navigate URL-encoded query param",
+    on_click=navigate_url_encoded_query_param,
+  )
+  me.button("increment query param directly", on_click=increment_query_param)
+  me.button("delete list query param", on_click=delete_list_query_param)
+  me.button("delete all query params", on_click=delete_all_query_params)
+  me.button("increment query param by navigate", on_click=increment_by_navigate)
+  me.button("navigate to page 2 with query params", on_click=navigate_page_2)
+  me.button("navigate to page 2 with dict", on_click=navigate_page_2_new_dict)
+  me.button(
+    "navigate to page 2 without query params",
+    on_click=navigate_page_2_without_query_params,
+  )
+
+
+@me.stateclass
+class State:
+  click_append_query_param_list: int
+
+
+def append_query_param_list(e: me.ClickEvent):
+  current_list = (
+    [] if "list" not in me.query_params else me.query_params.get_all("list")
+  )
+  state = me.state(State)
+  state.click_append_query_param_list += 1
+  me.query_params["list"] = [
+    *current_list,
+    f"val{state.click_append_query_param_list}",
+  ]
+
+
+def url_encoded_query_param(e: me.ClickEvent):
+  me.query_params["url_encoded"] = ["&should-be-escaped=true"]
+
+
+def navigate_url_encoded_query_param(e: me.ClickEvent):
+  me.navigate(
+    "/examples/query_params/page_2",
+    query_params={
+      "url_encoded": "&should-be-escaped=true",
+      "url_encoded_values": ["value1&a=1", "value2&a=2"],
+    },
+  )
+
+
+def increment_query_param(e: me.ClickEvent):
+  if "counter" not in me.query_params:
+    me.query_params["counter"] = "0"
+
+  me.query_params["counter"] = str(int(me.query_params["counter"]) + 1)
+
+
+def delete_list_query_param(e: me.ClickEvent):
+  del me.query_params["list"]
+
+
+def delete_all_query_params(e: me.ClickEvent):
+  for key in list(me.query_params.keys()):
+    del me.query_params[key]
+
+
+def navigate_page_2(e: me.ClickEvent):
+  me.navigate("/examples/query_params/page_2", query_params=me.query_params)
+
+
+def navigate_page_2_new_dict(e: me.ClickEvent):
+  me.navigate(
+    "/examples/query_params/page_2",
+    query_params={"page2": ["1", "2"], "single": "a"},
+  )
+
+
+def navigate_page_2_without_query_params(e: me.ClickEvent):
+  me.navigate("/examples/query_params/page_2")
+
+
+def increment_by_navigate(e: me.ClickEvent):
+  if "counter" not in me.query_params:
+    me.query_params["counter"] = "0"
+
+  counter = int(me.query_params["counter"]) + 1
+  me.query_params["counter"] = str(counter)
+
+  me.navigate(
+    "/examples/query_params",
+    query_params=me.query_params,
+  )
+
+
+@me.page(path="/examples/query_params/page_2")
+def page_2():
+  me.text(f"query_params(page_2)={me.query_params}")
+  me.button("Navigate back", on_click=navigate_back)
+
+
+def navigate_back(e: me.ClickEvent):
+  me.navigate("/examples/query_params", query_params=me.query_params)

--- a/mesop/features/BUILD
+++ b/mesop/features/BUILD
@@ -1,4 +1,4 @@
-load("//build_defs:defaults.bzl", "py_library")
+load("//build_defs:defaults.bzl", "THIRD_PARTY_PY_PYTEST", "py_library", "py_test")
 
 package(
     default_visibility = ["//build_defs:mesop_internal"],
@@ -6,8 +6,19 @@ package(
 
 py_library(
     name = "features",
-    srcs = glob(["*.py"]),
+    srcs = glob(
+        ["*.py"],
+        exclude = ["*_test.py"],
+    ),
     deps = [
         "//mesop/runtime",
     ],
+)
+
+py_test(
+    name = "query_params_test",
+    srcs = ["query_params_test.py"],
+    deps = [
+        ":features",
+    ] + THIRD_PARTY_PY_PYTEST,
 )

--- a/mesop/features/query_params.py
+++ b/mesop/features/query_params.py
@@ -1,0 +1,38 @@
+from typing import Callable, Iterator, MutableMapping, Sequence
+
+from mesop.runtime import runtime
+from mesop.runtime.context import Context
+
+
+class QueryParams(MutableMapping[str, str]):
+  def __init__(self, get_context: Callable[[], Context]):
+    self._get_context = get_context
+
+  def __iter__(self) -> Iterator[str]:
+    return iter(self._get_context().query_params())
+
+  def __len__(self) -> int:
+    return len(self._get_context().query_params())
+
+  def __str__(self) -> str:
+    return str(self._get_context().query_params())
+
+  def __getitem__(self, key: str) -> str:
+    # Returns the first value associated with the key to match
+    # the web API:
+    # https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/get
+    return self._get_context().query_params()[key][0]
+
+  def get_all(self, key: str) -> Sequence[str]:
+    if key not in self._get_context().query_params():
+      return tuple()
+    return tuple(self._get_context().query_params()[key])
+
+  def __delitem__(self, key: str) -> None:
+    self._get_context().set_query_param(key=key, value=None)
+
+  def __setitem__(self, key: str, value: str | Sequence[str]) -> None:
+    self._get_context().set_query_param(key=key, value=value)
+
+
+query_params = QueryParams(runtime().context)

--- a/mesop/features/query_params_test.py
+++ b/mesop/features/query_params_test.py
@@ -1,0 +1,96 @@
+# pyright: reportPrivateUsage=false
+
+import pytest
+
+from mesop.features.query_params import QueryParams
+from mesop.runtime.context import Context
+
+
+def test_query_params_iter():
+  context = Context(get_handler=lambda x: None, states={})
+  context._query_params = {
+    "key1": ["k1value1", "k1value2"],
+    "key2": ["value2"],
+  }
+  query_params = QueryParams(lambda: context)
+
+  assert list(query_params) == ["key1", "key2"]
+  assert {**query_params} == {
+    "key1": "k1value1",
+    "key2": "value2",
+  }
+
+
+def test_query_params_len():
+  context = Context(get_handler=lambda x: None, states={})
+  context._query_params = {
+    "key1": ["value1"],
+    "key2": ["value2"],
+  }
+  query_params = QueryParams(lambda: context)
+
+  assert len(query_params) == 2
+
+
+def test_query_params_str():
+  context = Context(get_handler=lambda x: None, states={})
+  context._query_params = {
+    "key1": ["value1"],
+    "key2": ["value2"],
+  }
+  query_params = QueryParams(lambda: context)
+
+  assert str(query_params) == str({"key1": ["value1"], "key2": ["value2"]})
+
+
+def test_query_params_getitem():
+  context = Context(get_handler=lambda x: None, states={})
+  context._query_params = {
+    "key1": ["value1"],
+    "key2": ["value2", "value3"],
+  }
+  query_params = QueryParams(lambda: context)
+
+  assert query_params["key1"] == "value1"
+  assert query_params["key2"] == "value2"
+
+  assert "non-existent" not in query_params
+  with pytest.raises(KeyError):
+    query_params["non-existent"]
+
+
+def test_query_params_get_all():
+  context = Context(get_handler=lambda x: None, states={})
+  context._query_params = {
+    "key1": ["value1"],
+    "key2": ["value2", "value3"],
+  }
+  query_params = QueryParams(lambda: context)
+
+  assert query_params.get_all("key1") == ("value1",)
+  assert query_params.get_all("key2") == ("value2", "value3")
+  assert query_params.get_all("non-existent") == tuple()
+
+
+def test_query_params_delitem():
+  context = Context(get_handler=lambda x: None, states={})
+  context._query_params = {"key1": ["value"]}
+  query_params = QueryParams(lambda: context)
+
+  del query_params["key1"]
+  assert context._query_params.get("key1") is None
+
+
+def test_query_params_setitem():
+  context = Context(get_handler=lambda x: None, states={})
+  query_params = QueryParams(lambda: context)
+
+  query_params["key1"] = "value1"
+  assert context._query_params["key1"] == ["value1"]
+
+  query_params["key2"] = ["value2", "value3"]
+  assert context._query_params["key2"] == ["value2", "value3"]
+
+
+if __name__ == "__main__":
+  raise SystemExit(pytest.main([__file__]))

--- a/mesop/protos/ui.proto
+++ b/mesop/protos/ui.proto
@@ -15,9 +15,16 @@ message UiRequest {
 message InitRequest {
     optional ViewportSize viewport_size = 1;
     optional ThemeSettings theme_settings = 2;
+    repeated QueryParam query_params = 3;
 }
 
-// Next ID: 15
+message QueryParam {
+    optional string key = 1;
+    // Note: a query param can be repeated, which is why it can have multiple values.
+    repeated string values = 2;
+}
+
+// Next ID: 16
 message UserEvent {
     optional States states = 1;
 
@@ -28,6 +35,7 @@ message UserEvent {
 
     optional ViewportSize viewport_size = 11;
     optional ThemeSettings theme_settings = 13;
+    repeated QueryParam query_params = 15;
 
     oneof type {
         bool bool_value = 4;
@@ -151,6 +159,7 @@ message UpdateStateEvent {
 message Command {
     oneof command {
         NavigateCommand navigate = 1;
+        UpdateQueryParam update_query_param = 6;
         ScrollIntoViewCommand scroll_into_view = 2;
         SetThemeMode set_theme_mode = 3;
         SetThemeDensity set_theme_density = 4;
@@ -161,6 +170,12 @@ message Command {
 message NavigateCommand {
     // absolute route path, e.g. "/foo/bar"
     optional string url = 1;
+
+    repeated QueryParam query_params = 2;
+}
+
+message UpdateQueryParam {
+    optional QueryParam query_param = 1;
 }
 
 message ScrollIntoViewCommand {

--- a/mesop/runtime/BUILD
+++ b/mesop/runtime/BUILD
@@ -9,9 +9,11 @@ py_library(
     srcs = glob(["*.py"]),
     deps = [
         "//mesop/dataclass_utils",
+        "//mesop/events",
         "//mesop/exceptions",
         "//mesop/protos:ui_py_pb2",
         "//mesop/security",
+        "//mesop/server:state_sessions",
         "//mesop/utils",
     ] + THIRD_PARTY_PY_FLASK,
 )

--- a/mesop/server/BUILD
+++ b/mesop/server/BUILD
@@ -16,9 +16,19 @@ package(
     default_visibility = ["//build_defs:mesop_internal"],
 )
 
+STATE_SESSIONS_SRCS = [
+    "config.py",
+    "state_session.py",
+]
+
 py_library(
     name = "server",
-    srcs = glob(["*.py"]),
+    srcs = glob(
+        ["*.py"],
+        exclude = [
+            "*_test.py",
+        ] + STATE_SESSIONS_SRCS,
+    ),
     deps = [
                "//mesop/component_helpers",
                "//mesop/editor",
@@ -27,12 +37,16 @@ py_library(
                "//mesop/utils",
                "//mesop/warn",
            ] + THIRD_PARTY_PY_ABSL_PY +
-           THIRD_PARTY_PY_FLASK +
-           THIRD_PARTY_PY_DOTENV +
-           THIRD_PARTY_PY_MSGPACK,
-    # Note: prod_server.py has a runtime dependency on
-    # //mesop/web/src/app/prod:web_package, so you must include it
-    # in the consuming py_binary's data attribute.
+           THIRD_PARTY_PY_FLASK,
+)
+
+py_library(
+    name = "state_sessions",
+    srcs = STATE_SESSIONS_SRCS,
+    deps = [
+        "//mesop/dataclass_utils",
+        "//mesop/exceptions",
+    ] + THIRD_PARTY_PY_MSGPACK + THIRD_PARTY_PY_DOTENV,
 )
 
 py_test(

--- a/mesop/tests/e2e/query_params_test.ts
+++ b/mesop/tests/e2e/query_params_test.ts
@@ -1,0 +1,165 @@
+import {test, expect, Page} from '@playwright/test';
+
+test('query_param: on_load hook', async ({page}) => {
+  await page.goto('/examples/query_params');
+  expect(await page.getByText('query_params={').textContent()).toEqual(
+    `query_params={'on_load': ['loaded']}`,
+  );
+  await expect(page).toHaveURL(/\?on_load=loaded$/);
+});
+
+test('query_param: load with query param in URL', async ({page}) => {
+  await page.goto('/examples/query_params?a=1');
+  expect(await page.getByText('query_params={').textContent()).toEqual(
+    `query_params={'a': ['1'], 'on_load': ['loaded']}`,
+  );
+  await expect(page).toHaveURL(/\?a=1&on_load=loaded$/);
+});
+
+test('query_param: URL encoding', async ({page}) => {
+  await page.goto('/examples/query_params');
+  await page
+    .getByRole('button', {name: 'URL-encoded query param', exact: true})
+    .click();
+  await expect(
+    page.getByText(
+      `{'on_load': ['loaded'], 'url_encoded': ['&should-be-escaped=true']}`,
+    ),
+  ).toBeVisible();
+  await expect(page).toHaveURL(
+    /\?on_load=loaded&url_encoded=%26should-be-escaped%3Dtrue$/,
+  );
+});
+
+test('query_param: navigate w/ URL encoding', async ({page}) => {
+  await page.goto('/examples/query_params');
+  await page
+    .getByRole('button', {
+      name: 'navigate URL-encoded query param',
+      exact: true,
+    })
+    .click();
+  await expect(
+    page.getByText(
+      `query_params(page_2)={'url_encoded': ['&should-be-escaped=true'], 'url_encoded_values': ['value1&a=1', 'value2&a=2']}`,
+    ),
+  ).toBeVisible();
+  await expect(page).toHaveURL(
+    /\?url_encoded=%26should-be-escaped%3Dtrue&url_encoded_values=value1%26a%3D1&url_encoded_values=value2%26a%3D2$/,
+  );
+});
+
+test('query_param: multiple query param values for same key ', async ({
+  page,
+}) => {
+  await page.goto('/examples/query_params');
+
+  // Add a value for "list" key
+  await page.getByRole('button', {name: 'append query param list'}).click();
+  await expect(
+    page.getByText(`query_params={'on_load': ['loaded'], 'list': ['val1']}`),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\?on_load=loaded&list=val1$/);
+
+  // Add another value for "list" key
+  await page.getByRole('button', {name: 'append query param list'}).click();
+  await expect(
+    page.getByText(
+      `query_params={'on_load': ['loaded'], 'list': ['val1', 'val2']}`,
+    ),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\?on_load=loaded&list=val1&list=val2$/);
+
+  // Delete "list" query param
+  await page.getByRole('button', {name: 'delete list query param'}).click();
+  await expect(
+    page.getByText(`query_params={'on_load': ['loaded']`),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\?on_load=loaded$/);
+});
+
+test('query_param: increment query param ', async ({page}) => {
+  await page.goto('/examples/query_params');
+
+  await page
+    .getByRole('button', {name: 'increment query param directly'})
+    .click();
+  await expect(
+    page.getByText(`query_params={'on_load': ['loaded'], 'counter': ['1']}`),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\?on_load=loaded&counter=1/);
+
+  await page
+    .getByRole('button', {name: 'increment query param directly'})
+    .click();
+  await expect(
+    page.getByText(`query_params={'on_load': ['loaded'], 'counter': ['2']}`),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\?on_load=loaded&counter=2/);
+
+  await page
+    .getByRole('button', {name: 'increment query param by navigate'})
+    .click();
+  await expect(
+    page.getByText(`query_params={'on_load': ['loaded'], 'counter': ['3']}`),
+  ).toBeVisible();
+  await expect(page).toHaveURL(/\?on_load=loaded&counter=3/);
+});
+
+test('query_param: delete all query params ', async ({page}) => {
+  await page.goto('/examples/query_params');
+  await page.getByRole('button', {name: 'append query param list'}).click();
+  await page
+    .getByRole('button', {name: 'increment query param directly'})
+    .click();
+
+  await page.getByRole('button', {name: 'delete all query params'}).click();
+  await expect(page.getByText('query_params={}')).toBeVisible();
+  await expect(page).toHaveURL(/^[^?]+$/); // Matches any URL without query parameters
+});
+
+test('query_param: navigate to another page with query params', async ({
+  page,
+}) => {
+  await page.goto('/examples/query_params');
+  await page
+    .getByRole('button', {name: 'navigate to page 2 with query params'})
+    .click();
+
+  await expect(
+    page.getByText(`query_params(page_2)={'on_load': ['loaded']}`),
+  ).toBeVisible();
+  // This isn't flaky because the page has finished navigated since we're checking
+  // the page text above.
+  expect(new URL(page.url()).search).toEqual('?on_load=loaded');
+});
+
+test('query_param: navigate to another page with dict', async ({page}) => {
+  await page.goto('/examples/query_params');
+  await page
+    .getByRole('button', {name: 'navigate to page 2 with dict'})
+    .click();
+
+  await expect(
+    page.getByText(
+      `query_params(page_2)={'page2': ['1', '2'], 'single': ['a']}`,
+    ),
+  ).toBeVisible();
+  // This isn't flaky because the page has finished navigated since we're checking
+  // the page text above.
+  expect(new URL(page.url()).search).toEqual('?page2=1&page2=2&single=a');
+});
+
+test('query_param: navigate to another page without query params', async ({
+  page,
+}) => {
+  await page.goto('/examples/query_params');
+  await page
+    .getByRole('button', {name: 'navigate to page 2 without query params'})
+    .click();
+
+  await expect(page.getByText(`query_params(page_2)={}`)).toBeVisible();
+  // This isn't flaky because the page has finished navigated since we're checking
+  // the page text above.
+  expect(new URL(page.url()).search).toEqual('');
+});

--- a/mesop/utils/url_utils.py
+++ b/mesop/utils/url_utils.py
@@ -1,7 +1,9 @@
 from urllib.parse import urlparse, urlunparse
 
+import mesop.protos.ui_pb2 as pb
 
-def _remove_url_query_param(url: str) -> str:
+
+def remove_url_query_param(url: str) -> str:
   """
   Remove query parameters from a URL.
 
@@ -18,4 +20,25 @@ def _escape_url_for_csp(url: str) -> str:
 
 
 def sanitize_url_for_csp(url: str) -> str:
-  return _escape_url_for_csp(_remove_url_query_param(url))
+  return _escape_url_for_csp(remove_url_query_param(url))
+
+
+def get_url_query_params(url: str) -> list[pb.QueryParam]:
+  query_param = urlparse(url).query
+  param_dict: dict[str, list[str]] = {}
+  if query_param:
+    for param in query_param.split("&"):
+      if "=" in param:
+        key, value = param.split("=", 1)
+        if key in param_dict:
+          param_dict[key].append(value)
+        else:
+          param_dict[key] = [value]
+      else:
+        # Handle cases where there's a key without a value
+        param_dict[param] = []
+
+  param_list: list[pb.QueryParam] = [
+    pb.QueryParam(key=key, values=values) for key, values in param_dict.items()
+  ]
+  return param_list

--- a/mesop/web/src/services/channel.ts
+++ b/mesop/web/src/services/channel.ts
@@ -18,6 +18,7 @@ import {SSE} from '../utils/sse';
 import {applyComponentDiff, applyStateDiff} from '../utils/diff';
 import {getViewportSize} from '../utils/viewport_size';
 import {ThemeService} from './theme_service';
+import {getQueryParams} from '../utils/query_params';
 
 // Pick 500ms as the minimum duration before showing a progress/busy indicator
 // for the channel.
@@ -239,8 +240,6 @@ export class Channel {
   }
 
   dispatch(userEvent: UserEvent) {
-    userEvent.setViewportSize(getViewportSize());
-    userEvent.setThemeSettings(this.themeService.getThemeSettings());
     // Every user event should have an event handler,
     // except for the ones below:
     if (
@@ -258,6 +257,12 @@ export class Channel {
       } else {
         userEvent.setStates(this.states);
       }
+      // Make sure we compute these properties right before the user
+      // event is dispatched, otherwise this can cause a weird
+      // race condition.
+      userEvent.setViewportSize(getViewportSize());
+      userEvent.setThemeSettings(this.themeService.getThemeSettings());
+      userEvent.setQueryParamsList(getQueryParams());
 
       const request = new UiRequest();
       request.setUserEvent(userEvent);
@@ -319,6 +324,7 @@ export class Channel {
     const navigationEvent = new NavigationEvent();
     userEvent.setViewportSize(getViewportSize());
     userEvent.setNavigation(navigationEvent);
+    userEvent.setQueryParamsList(getQueryParams());
     request.setUserEvent(userEvent);
     this.init(this.initParams, request);
   }

--- a/mesop/web/src/utils/query_params.ts
+++ b/mesop/web/src/utils/query_params.ts
@@ -1,0 +1,26 @@
+import {QueryParam} from 'mesop/mesop/protos/ui_jspb_proto_pb/mesop/protos/ui_pb';
+
+export function getQueryParams() {
+  return getQueryParamsForTesting(window.location.search);
+}
+
+/** Only exported for unit testing. */
+export function getQueryParamsForTesting(queryString: string): QueryParam[] {
+  const urlParams = new URLSearchParams(queryString);
+  const params: Record<string, string[]> = {};
+  urlParams.forEach((value, key) => {
+    if (!params[key]) {
+      params[key] = [value];
+    } else {
+      params[key].push(value);
+    }
+  });
+  const queryParams: QueryParam[] = [];
+  for (const [key, values] of Object.entries(params)) {
+    const queryParam = new QueryParam();
+    queryParam.setKey(key);
+    queryParam.setValuesList(values);
+    queryParams.push(queryParam);
+  }
+  return queryParams;
+}

--- a/mesop/web/src/utils/query_params_spec.ts
+++ b/mesop/web/src/utils/query_params_spec.ts
@@ -1,0 +1,30 @@
+import {getQueryParams, getQueryParamsForTesting} from './query_params';
+import {QueryParam} from 'mesop/mesop/protos/ui_jspb_proto_pb/mesop/protos/ui_pb';
+
+describe('getQueryParams', () => {
+  it('should parse query parameters correctly', () => {
+    const result = getQueryParamsForTesting(
+      '?param1=value1&param2=value2&param3=value3a&param3=value3b',
+    );
+
+    expect(result.length).toBe(3);
+
+    const param1 = result.find((p) => p.getKey() === 'param1');
+    expect(param1).toBeDefined();
+    expect(param1?.getValuesList()).toEqual(['value1']);
+
+    const param2 = result.find((p) => p.getKey() === 'param2');
+    expect(param2).toBeDefined();
+    expect(param2?.getValuesList()).toEqual(['value2']);
+
+    const param3 = result.find((p) => p.getKey() === 'param3');
+    expect(param3).toBeDefined();
+    expect(param3?.getValuesList()).toEqual(['value3a', 'value3b']);
+  });
+
+  it('should return an empty array for no query parameters', () => {
+    const result = getQueryParamsForTesting('');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,11 +75,13 @@ nav:
           - Plot: components/plot.md
   - API:
       - Page: api/page.md
+      - URLs & Navigation:
+          - Navigate: api/commands/navigate.md
+          - Query params: api/query_params.md
       - UI Customization:
           - Style: api/style.md
           - Viewport Size: api/viewport-size.md
       - Commands:
-          - Navigate: api/commands/navigate.md
           - Scroll into view: api/commands/scroll-into-view.md
           - Focus component: api/commands/focus-component.md
       - Config: api/config.md

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ import {defineConfig, devices} from '@playwright/test';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  timeout: process.env.CI ? 50000 : 25000, // Budget more time for CI since tests run slower there.
+  timeout: process.env.CI ? 75_000 : 30_000, // Budget more time for CI since tests run slower there.
   testDir: '.',
   // Use a custom snapshot path template because Playwright's default
   // is platform-specific which isn't necessary for Mesop e2e tests


### PR DESCRIPTION
Fixes #340.

This provides query param support using a dict-like API with inspiration from the [Web API](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) and [Streamlit's API](https://docs.streamlit.io/develop/api-reference/caching-and-state/st.query_params#stquery_paramsget_all).