### PR TITLE
Use py_library from defaults.bzl

### DIFF
--- a/mesop/components/uploader/BUILD
+++ b/mesop/components/uploader/BUILD
@@ -1,5 +1,5 @@
+load("//build_defs:defaults.bzl", "py_library", "sass_binary")
 load("//mesop/components:defs.bzl", "mesop_component")
-load("//build_defs:defaults.bzl", "sass_binary")
 
 package(
     default_visibility = ["//build_defs:mesop_internal"],


### PR DESCRIPTION
Otherwise, this breaks the downstream sync.

FYI: @richard-to 