### PR TITLE
Remove unused imports from theme_service.ts

### DIFF
--- a/mesop/web/src/services/BUILD
+++ b/mesop/web/src/services/BUILD
@@ -1,4 +1,4 @@
-load("//build_defs:defaults.bzl", "ANGULAR_CORE_DEPS", "THIRD_PARTY_JS_RXJS", "ng_module")
+load("//build_defs:defaults.bzl", "ANGULAR_CORE_DEPS", "ng_module")
 
 package(
     default_visibility = ["//build_defs:mesop_internal"],
@@ -13,5 +13,5 @@ ng_module(
         "//mesop/protos:ui_jspb_proto",
         "//mesop/web/src/dev_tools/services",
         "//mesop/web/src/utils",
-    ] + ANGULAR_CORE_DEPS + THIRD_PARTY_JS_RXJS,
+    ] + ANGULAR_CORE_DEPS,
 )

--- a/mesop/web/src/services/theme_service.ts
+++ b/mesop/web/src/services/theme_service.ts
@@ -1,13 +1,7 @@
-import {Injectable, Renderer2, RendererFactory2} from '@angular/core';
-import {BehaviorSubject} from 'rxjs';
-import {Channel} from './channel';
+import {Injectable} from '@angular/core';
 import {
-  ChangePrefersColorScheme,
-  ResizeEvent,
   ThemeMode,
   SetThemeMode,
-  UserEvent,
-  ThemeModeMap,
   ThemeSettings,
 } from 'mesop/mesop/protos/ui_jspb_proto_pb/mesop/protos/ui_pb';
 


### PR DESCRIPTION
Turns out https://github.com/google/mesop/commit/f23e8b39918c59c04ef9b62fc8272e512c7d9d61 wasn't needed and I just needed to clean up unused imports