### PR TITLE
Align dataclass_utils.py mutable type error message with py 3.11 standard lib error message

### DIFF
--- a/mesop/dataclass_utils/dataclass_utils.py
+++ b/mesop/dataclass_utils/dataclass_utils.py
@@ -56,8 +56,7 @@ def dataclass_with_defaults(cls: Type[C]) -> Type[C]:
         hash(classVar)
       except TypeError as exc:
         error_message = (
-          f"Detected mutable default value for non-hashable type={type(classVar).__name__} "
-          f"for attribute={name} in class={cls.__name__}. "
+          f"mutable default {type(classVar)} for field {name} is not allowed: use default_factory for state class {cls.__name__}. "
           "See: https://google.github.io/mesop/guides/state_management/#use-immutable-default-values"
         )
         raise MesopDeveloperException(error_message) from exc

--- a/mesop/dataclass_utils/dataclass_utils_test.py
+++ b/mesop/dataclass_utils/dataclass_utils_test.py
@@ -362,7 +362,7 @@ def test_dataclass_default_value_throws():
       value: MutableDataclass = MutableDataclass(str_value="abc")
 
   assert (
-    "Detected mutable default value for non-hashable type=MutableDataclass for attribute=value in class=StateWithMutableDefaultDataclassValue"
+    "mutable default <class 'dataclass_utils.dataclass_utils_test.test_dataclass_default_value_throws.<locals>.MutableDataclass'> for field value is not allowed"
     in str(exc_info.value)
   )
 
@@ -380,7 +380,10 @@ def test_proto_with_default_throws():
     class StateWithMutableProto:
       proto: pb.Style = pb.Style()
 
-  assert "Detected mutable default value" in str(exc_info.value)
+  assert (
+    "mutable default <class 'mesop.protos.ui_pb2.Style'> for field proto is not allowed"
+    in str(exc_info.value)
+  )
 
 
 def test_proto_in_dataclass_without_default_does_not_throw():
@@ -405,7 +408,7 @@ def test_proto_in_dataclass_with_default_throws():
       dataclass: DataclassWithProto
 
   assert (
-    "Detected mutable default value for non-hashable type=Style for attribute=style in class=DataclassWithProto"
+    "mutable default <class 'mesop.protos.ui_pb2.Style'> for field style is not allowed"
     in str(exc_info.value)
   )
 
@@ -430,7 +433,7 @@ def test_proto_in_unannotated_class_with_default_throws():
       dataclass: UnannotatedClassWithProto
 
   assert (
-    "Detected mutable default value for non-hashable type=Style for attribute=style in class=UnannotatedClassWithProto"
+    "mutable default <class 'mesop.protos.ui_pb2.Style'> for field style is not allowed"
     in str(exc_info.value)
   )
 
@@ -462,4 +465,4 @@ def test_has_parent_child_class():
 
 
 if __name__ == "__main__":
-  raise SystemExit(pytest.main([__file__]))
+  raise SystemExit(pytest.main(["-vv", __file__]))


### PR DESCRIPTION
Aligns the error message with https://github.com/python/cpython/blob/7797182b78baf78f64fe16f436aa2279cf6afc23/Lib/dataclasses.py#L861

> Note: should investigate whether to make the hashable check the same.

This makes the downstream sync smoother but seems like a good general improvement.