### PR TITLE
Deep copy page configurations to prevent security-sensitive mutations

### DIFF
--- a/mesop/features/page.py
+++ b/mesop/features/page.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Callable
 
 from mesop.runtime import OnLoadHandler, PageConfig, runtime
@@ -39,8 +40,8 @@ def page(
       page_config=PageConfig(
         page_fn=wrapper,
         title=title or f"Mesop: {path}",
-        stylesheets=stylesheets or default_stylesheets,
-        security_policy=security_policy
+        stylesheets=deepcopy(stylesheets or default_stylesheets),
+        security_policy=deepcopy(security_policy)
         if security_policy
         else SecurityPolicy(),
         on_load=on_load,


### PR DESCRIPTION
This prevents mutating security-sensitive configurations based on user input, e.g.

```py
security_policy = me.SecurityPolicy(...)

@me.page(security_policy=security_policy):
def page():
  me.button(on_click=on_click)

def on_click(e):
  security_policy.allowed_script_srcs = me.state(State).user_inputs
```