### PR TITLE
Add copy to clipboard web component

### DIFF
--- a/mesop/examples/web_component/BUILD
+++ b/mesop/examples/web_component/BUILD
@@ -11,6 +11,7 @@ py_library(
     deps = [
         "//mesop",
         "//mesop/examples/web_component/code_mirror_editor",
+        "//mesop/examples/web_component/copy_to_clipboard",
         "//mesop/examples/web_component/custom_font_csp_repro",
         "//mesop/examples/web_component/firebase_auth",
         "//mesop/examples/web_component/markedjs",

--- a/mesop/examples/web_component/__init__.py
+++ b/mesop/examples/web_component/__init__.py
@@ -1,6 +1,9 @@
 from mesop.examples.web_component.code_mirror_editor import (
   code_mirror_editor_app as code_mirror_editor_app,
 )
+from mesop.examples.web_component.copy_to_clipboard import (
+  copy_to_clipboard_app as copy_to_clipboard_app,
+)
 from mesop.examples.web_component.custom_font_csp_repro import (
   custom_font_app as custom_font_app,
 )

--- a/mesop/examples/web_component/copy_to_clipboard/BUILD
+++ b/mesop/examples/web_component/copy_to_clipboard/BUILD
@@ -1,0 +1,14 @@
+load("//build_defs:defaults.bzl", "py_library")
+
+package(
+    default_visibility = ["//build_defs:mesop_examples"],
+)
+
+py_library(
+    name = "copy_to_clipboard",
+    srcs = glob(["*.py"]),
+    data = glob(["*.js"]),
+    deps = [
+        "//mesop",
+    ],
+)

--- a/mesop/examples/web_component/copy_to_clipboard/copy_to_clipboard_app.py
+++ b/mesop/examples/web_component/copy_to_clipboard/copy_to_clipboard_app.py
@@ -1,0 +1,36 @@
+import mesop as me
+from mesop.examples.web_component.copy_to_clipboard.copy_to_clipboard_component import (
+  copy_to_clipboard_component,
+)
+
+TEXT = """
+Lorem ipsum odor amet, consectetuer adipiscing elit. Libero maecenas curae
+porttitor laoreet quam proin phasellus. Efficitur hendrerit magnis volutpat sed
+nascetur; turpis vitae dis. Phasellus suspendisse eleifend mus arcu scelerisque
+quis. Eget venenatis diam dui mattis eleifend porttitor risus. Mollis eros
+fermentum lectus magnis enim dapibus magna elit. Sapien gravida arcu fusce;
+lacinia magnis donec. Nostra vulputate litora luctus id ut.
+""".strip()
+
+
+@me.page(
+  path="/web_component/copy_to_clipboard/copy_to_clipboard_app",
+)
+def page():
+  with me.box(
+    style=me.Style(
+      width=300,
+      margin=me.Margin.all(15),
+      padding=me.Margin.all(10),
+      border=me.Border.all(
+        me.BorderSide(
+          width=1, color=me.theme_var("outline-variant"), style="solid"
+        )
+      ),
+    )
+  ):
+    with me.box(style=me.Style(display="flex", justify_content="end")):
+      with copy_to_clipboard_component(text=TEXT):
+        with me.content_button():
+          me.icon("content_copy")
+    me.text(TEXT)

--- a/mesop/examples/web_component/copy_to_clipboard/copy_to_clipboard_app.py
+++ b/mesop/examples/web_component/copy_to_clipboard/copy_to_clipboard_app.py
@@ -21,7 +21,7 @@ def page():
     style=me.Style(
       width=300,
       margin=me.Margin.all(15),
-      padding=me.Margin.all(10),
+      padding=me.Padding.all(10),
       border=me.Border.all(
         me.BorderSide(
           width=1, color=me.theme_var("outline-variant"), style="solid"

--- a/mesop/examples/web_component/copy_to_clipboard/copy_to_clipboard_component.js
+++ b/mesop/examples/web_component/copy_to_clipboard/copy_to_clipboard_component.js
@@ -1,0 +1,31 @@
+import {
+  LitElement,
+  html,
+} from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
+
+class CopyToClipboard extends LitElement {
+  static properties = {
+    text: {type: String},
+  };
+
+  constructor() {
+    super();
+    this.text = '';
+  }
+
+  render() {
+    return html`
+      <div @click="${this._onClick}">
+        <slot></slot>
+      </div>
+    `;
+  }
+
+  _onClick() {
+    navigator.clipboard
+      .writeText(this.text)
+      .catch((err) => console.error('Failed to copy text: ', err));
+  }
+}
+
+customElements.define('copy-to-clipboard-component', CopyToClipboard);

--- a/mesop/examples/web_component/copy_to_clipboard/copy_to_clipboard_component.py
+++ b/mesop/examples/web_component/copy_to_clipboard/copy_to_clipboard_component.py
@@ -1,0 +1,16 @@
+import mesop.labs as mel
+
+
+@mel.web_component(path="./copy_to_clipboard_component.js")
+def copy_to_clipboard_component(
+  *,
+  text: str = "",
+  key: str | None = None,
+):
+  return mel.insert_web_component(
+    name="copy-to-clipboard-component",
+    key=key,
+    properties={
+      "text": text,
+    },
+  )


### PR DESCRIPTION
One issue trying to implement a copy command is that it does not work in Safari. Safari requires a user action, such as a click unfortunately.

The other option here is to use web component with a slot and click event, which apparently does work in Safari.

This web component also expects the browser has the  navigator.clipboard function.

Ref: https://github.com/google/mesop/issues/224
Ref: https://github.com/google/mesop/issues/275