### PR TITLE
Change internal routes to prefix and postfix with "__"

### DIFF
--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -210,7 +210,7 @@ def configure_flask_app(
         error=pb.ServerError(exception=str(e), traceback=format_traceback())
       )
 
-  @flask_app.route("/ui", methods=["POST"])
+  @flask_app.route("/__ui__", methods=["POST"])
   def ui_stream() -> Response:
     # Prevent CSRF by checking the request site matches the site
     # of the URL root (where the Flask app is being served from)
@@ -220,7 +220,7 @@ def configure_flask_app(
     if not runtime().debug_mode and not is_same_site(
       request.headers.get("Origin"), request.url_root
     ):
-      abort(403, "Rejecting cross-site POST request to /ui")
+      abort(403, "Rejecting cross-site POST request to /__ui__")
     data = request.data
     if not data:
       raise Exception("Missing request payload")

--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -249,7 +249,7 @@ def configure_flask_app(
 
   if not prod_mode:
 
-    @flask_app.route("/hot-reload")
+    @flask_app.route("/__hot-reload__")
     def hot_reload() -> Response:
       counter = int(request.args["counter"])
       while True:

--- a/mesop/web/src/services/channel.ts
+++ b/mesop/web/src/services/channel.ts
@@ -94,7 +94,7 @@ export class Channel {
   }
 
   init(initParams: InitParams, request: UiRequest) {
-    this.eventSource = new SSE('/ui', {
+    this.eventSource = new SSE('/__ui__', {
       payload: generatePayloadString(request),
     });
     this.status = ChannelStatus.OPEN;

--- a/mesop/web/src/services/channel.ts
+++ b/mesop/web/src/services/channel.ts
@@ -277,7 +277,7 @@ export class Channel {
     const pollHotReloadEndpoint = async () => {
       try {
         const response = await fetch(
-          `/hot-reload?counter=${this.hotReloadCounter}`,
+          `/__hot-reload__?counter=${this.hotReloadCounter}`,
         );
         if (response.status === 200) {
           const text = await response.text();


### PR DESCRIPTION
This avoids potential naming collisions and establishes a convention that routes Mesop sets up are named: `/__{MESOP_ROUTE}__`.