### PR TITLE
Provide helpful terminal messages to fix web component CSP errors

### DIFF
--- a/mesop/tests/e2e/snapshots/web_security_test.ts_csp-allowed-iframe-parents.txt
+++ b/mesop/tests/e2e/snapshots/web_security_test.ts_csp-allowed-iframe-parents.txt
@@ -7,4 +7,5 @@ style-src 'self' 'unsafe-inline' fonts.googleapis.com
 script-src 'self' 'nonce-{{NONCE}}'
 trusted-types angular angular#unsafe-bypass lit-html
 require-trusted-types-for 'script'
+report-uri /__csp__
 frame-ancestors 'self' google.com

--- a/mesop/tests/e2e/snapshots/web_security_test.ts_csp-escaping.txt
+++ b/mesop/tests/e2e/snapshots/web_security_test.ts_csp-escaping.txt
@@ -7,5 +7,6 @@ style-src 'self' 'unsafe-inline' fonts.googleapis.com http://google.com/styleshe
 script-src 'self' 'nonce-{{NONCE}}' http://google.com/allowed_script_srcs/1%2C1%3B2 http://google.com/allowed_script_srcs/2%2C1%3B2
 trusted-types angular angular#unsafe-bypass lit-html
 require-trusted-types-for 'script'
+report-uri /__csp__
 connect-src 'self' http://google.com/allowed_connect_srcs/1%2C1%3B2 http://google.com/allowed_connect_srcs/2%2C1%3B2
 frame-ancestors 'self' http://google.com/allowed_iframe_parents/1%2C1%3B2 http://google.com/allowed_iframe_parents/2%2C1%3B2

--- a/mesop/tests/e2e/snapshots/web_security_test.ts_csp.txt
+++ b/mesop/tests/e2e/snapshots/web_security_test.ts_csp.txt
@@ -7,4 +7,5 @@ style-src 'self' 'unsafe-inline' fonts.googleapis.com
 script-src 'self' 'nonce-{{NONCE}}'
 trusted-types angular angular#unsafe-bypass lit-html
 require-trusted-types-for 'script'
+report-uri /__csp__
 frame-ancestors 'self' https://google.github.io

--- a/mesop/utils/terminal_colors.py
+++ b/mesop/utils/terminal_colors.py
@@ -1,0 +1,7 @@
+RED = "\033[31m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+BLUE = "\033[34m"
+MAGENTA = "\033[35m"
+CYAN = "\033[36m"
+RESET = "\033[0m"


### PR DESCRIPTION
Fixes #566. This makes it a lot easier to fix CSP errors by printing a helpful message in the terminal. Particularly helpful with #723. 

**Screenshot:**

<img width="754" alt="image" src="https://github.com/user-attachments/assets/77e6b073-ef08-4532-b42b-ee066b66ca3e">

