### PR TITLE
Remove catch clause for dynamic import promise (use default browser console error messages)

### DIFF
--- a/mesop/web/src/shell/shell.ts
+++ b/mesop/web/src/shell/shell.ts
@@ -92,18 +92,9 @@ export class Shell {
           // Import all JS modules concurrently
           await Promise.all(
             jsModules.map((modulePath) =>
-              import(modulePath)
-                .then(() =>
-                  console.debug(
-                    `Successfully imported JS module: ${modulePath}`,
-                  ),
-                )
-                .catch((error) =>
-                  console.error(
-                    `Failed to import JS module: ${modulePath}`,
-                    error,
-                  ),
-                ),
+              import(modulePath).then(() =>
+                console.debug(`Successfully imported JS module: ${modulePath}`),
+              ),
             ),
           ).then(() => {
             console.debug('All JS modules imported');


### PR DESCRIPTION
This makes the downstream sync easier