### PR TITLE
Support async await in event handlers

### DIFF
--- a/docs/guides/interactivity.md
+++ b/docs/guides/interactivity.md
@@ -28,6 +28,14 @@ This example builds off the previous Loading example and makes our event handler
 --8<-- "mesop/examples/docs/streaming.py"
 ```
 
+## Async
+
+If you want to do multiple long-running operations concurrently, then we recommend you to use Python's `async` and `await`.
+
+```python
+--8<-- "mesop/examples/async_await.py"
+```
+
 ## Troubleshooting
 
 ### User input race condition

--- a/mesop/examples/__init__.py
+++ b/mesop/examples/__init__.py
@@ -2,6 +2,7 @@ from demo import main as main
 from mesop.examples import (
   allowed_iframe_parents as allowed_iframe_parents,
 )
+from mesop.examples import async_await as async_await
 from mesop.examples import box as box
 from mesop.examples import buttons as buttons
 from mesop.examples import checkbox_and_radio as checkbox_and_radio

--- a/mesop/examples/async_await.py
+++ b/mesop/examples/async_await.py
@@ -1,0 +1,33 @@
+import asyncio
+
+import mesop as me
+
+
+@me.page(path="/async_await")
+def page():
+  s = me.state(State)
+  me.text("val1=" + s.val1)
+  me.text("val2=" + s.val2)
+  me.button("async", on_click=click_async)
+
+
+@me.stateclass
+class State:
+  val1: str
+  val2: str
+
+
+async def fetch_dummy_values():
+  # Simulate an asynchronous operation
+  await asyncio.sleep(2)
+  return "<async_value>"
+
+
+async def click_async(e: me.ClickEvent):
+  val1_task = asyncio.create_task(fetch_dummy_values())
+  val2_task = asyncio.create_task(fetch_dummy_values())
+
+  me.state(State).val1, me.state(State).val2 = await asyncio.gather(
+    val1_task, val2_task
+  )
+  yield

--- a/mesop/runtime/context.py
+++ b/mesop/runtime/context.py
@@ -1,4 +1,6 @@
+import asyncio
 import copy
+import types
 import urllib.parse as urlparse
 from typing import Any, Callable, Generator, Sequence, TypeVar, cast
 
@@ -266,10 +268,29 @@ Did you forget to decorate your state class `{state.__name__}` with @stateclass?
     if handler:
       result = handler(payload)
       if result is not None:
-        yield from result
+        if isinstance(result, types.AsyncGeneratorType):
+          yield from self._run_async_generator(result)
+        else:
+          yield from result
       else:
         yield
     else:
       raise MesopException(
         f"Unknown handler id: {event.handler_id} from event {event}"
       )
+
+  def _run_async_generator(self, agen: types.AsyncGeneratorType[None, None]):
+    loop = self._get_or_create_event_loop()
+    try:
+      while True:
+        yield loop.run_until_complete(agen.__anext__())
+    except StopAsyncIteration:
+      pass
+
+  def _get_or_create_event_loop(self):
+    try:
+      return asyncio.get_event_loop()
+    except RuntimeError:
+      loop = asyncio.new_event_loop()
+      asyncio.set_event_loop(loop)
+      return loop

--- a/mesop/runtime/context.py
+++ b/mesop/runtime/context.py
@@ -269,7 +269,7 @@ Did you forget to decorate your state class `{state.__name__}` with @stateclass?
       result = handler(payload)
       if result is not None:
         if isinstance(result, types.AsyncGeneratorType):
-          yield from self._run_async_generator(result)
+          yield from _run_async_generator(result)
         else:
           yield from result
       else:
@@ -279,18 +279,20 @@ Did you forget to decorate your state class `{state.__name__}` with @stateclass?
         f"Unknown handler id: {event.handler_id} from event {event}"
       )
 
-  def _run_async_generator(self, agen: types.AsyncGeneratorType[None, None]):
-    loop = self._get_or_create_event_loop()
-    try:
-      while True:
-        yield loop.run_until_complete(agen.__anext__())
-    except StopAsyncIteration:
-      pass
 
-  def _get_or_create_event_loop(self):
-    try:
-      return asyncio.get_event_loop()
-    except RuntimeError:
-      loop = asyncio.new_event_loop()
-      asyncio.set_event_loop(loop)
-      return loop
+def _run_async_generator(agen: types.AsyncGeneratorType[None, None]):
+  loop = _get_or_create_event_loop()
+  try:
+    while True:
+      yield loop.run_until_complete(agen.__anext__())
+  except StopAsyncIteration:
+    pass
+
+
+def _get_or_create_event_loop():
+  try:
+    return asyncio.get_running_loop()
+  except RuntimeError:
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop

--- a/mesop/tests/e2e/async_await_test.ts
+++ b/mesop/tests/e2e/async_await_test.ts
@@ -4,7 +4,7 @@ test('async await', async ({page}) => {
   await page.goto('/async_await');
   await page.getByRole('button', {name: 'async'}).click();
   await expect(page.getByText('val1=<async_value>')).toBeVisible({
-    // Intentionally set timeout at 5 seconds to make sure the
+    // Intentionally set timeout at 3 seconds to make sure the
     // async work is happening in parallel.
     timeout: 3000,
   });

--- a/mesop/tests/e2e/async_await_test.ts
+++ b/mesop/tests/e2e/async_await_test.ts
@@ -1,0 +1,14 @@
+import {test, expect} from '@playwright/test';
+
+test('async await', async ({page}) => {
+  await page.goto('/async_await');
+  await page.getByRole('button', {name: 'async'}).click();
+  await expect(page.getByText('val1=<async_value>')).toBeVisible({
+    // Intentionally set timeout at 5 seconds to make sure the
+    // async work is happening in parallel.
+    timeout: 3000,
+  });
+  expect(await page.getByText('val2=').textContent()).toEqual(
+    'val2=<async_value>',
+  );
+});


### PR DESCRIPTION
Partially addresses #623. 

This allows using defining event handlers as async generators so that Mesop app developers can use `await`.