### PR TITLE
Set web component as properties, not attributes [breaking change]

### DIFF
--- a/mesop/component_helpers/helper.py
+++ b/mesop/component_helpers/helper.py
@@ -265,8 +265,8 @@ def insert_web_component(
     events = dict()
   if properties is None:
     properties = dict()
-  check_attribute_keys_is_safe(events.keys())
-  check_attribute_keys_is_safe(properties.keys())
+  check_property_keys_is_safe(events.keys())
+  check_property_keys_is_safe(properties.keys())
   event_to_ids: dict[str, str] = {}
   for event in events:
     event_handler = events[event]
@@ -288,7 +288,7 @@ def insert_web_component(
 #
 # We check here in Python to provide a better error message and
 # developer experience.
-def check_attribute_keys_is_safe(keys: KeysView[str]):
+def check_property_keys_is_safe(keys: KeysView[str]):
   """
   Follow web security best practices by ensuring dangerous attributes
   aren't used by raising an exception.

--- a/mesop/component_helpers/helper_test.py
+++ b/mesop/component_helpers/helper_test.py
@@ -1,32 +1,32 @@
 import pytest
 
-from mesop.component_helpers.helper import check_attribute_keys_is_safe
+from mesop.component_helpers.helper import check_property_keys_is_safe
 from mesop.exceptions import MesopDeveloperException
 
 
-def test_check_attribute_keys_is_safe_raises_exception():
+def test_check_property_keys_is_safe_raises_exception():
   with pytest.raises(MesopDeveloperException):
-    check_attribute_keys_is_safe({"src": None}.keys())
+    check_property_keys_is_safe({"src": None}.keys())
   with pytest.raises(MesopDeveloperException):
-    check_attribute_keys_is_safe({"SRC": None}.keys())
+    check_property_keys_is_safe({"SRC": None}.keys())
 
   with pytest.raises(MesopDeveloperException):
-    check_attribute_keys_is_safe({"srcdoc": None}.keys())
+    check_property_keys_is_safe({"srcdoc": None}.keys())
 
   with pytest.raises(MesopDeveloperException):
-    check_attribute_keys_is_safe({"on": None}.keys())
+    check_property_keys_is_safe({"on": None}.keys())
   with pytest.raises(MesopDeveloperException):
-    check_attribute_keys_is_safe({"On": None}.keys())
+    check_property_keys_is_safe({"On": None}.keys())
   with pytest.raises(MesopDeveloperException):
-    check_attribute_keys_is_safe({"ON": None}.keys())
+    check_property_keys_is_safe({"ON": None}.keys())
   with pytest.raises(MesopDeveloperException):
-    check_attribute_keys_is_safe({"onClick": None}.keys())
+    check_property_keys_is_safe({"onClick": None}.keys())
 
 
-def test_check_attribute_keys_is_safe_passes():
-  check_attribute_keys_is_safe({"a": None}.keys())
-  check_attribute_keys_is_safe({"decrement": None}.keys())
-  check_attribute_keys_is_safe({"click-on": None}.keys())
+def test_check_property_keys_is_safe_passes():
+  check_property_keys_is_safe({"a": None}.keys())
+  check_property_keys_is_safe({"decrement": None}.keys())
+  check_property_keys_is_safe({"click-on": None}.keys())
 
 
 if __name__ == "__main__":

--- a/mesop/examples/web_component/BUILD
+++ b/mesop/examples/web_component/BUILD
@@ -11,6 +11,7 @@ py_library(
     deps = [
         "//mesop",
         "//mesop/examples/web_component/code_mirror_editor",
+        "//mesop/examples/web_component/complex_props",
         "//mesop/examples/web_component/copy_to_clipboard",
         "//mesop/examples/web_component/custom_font_csp_repro",
         "//mesop/examples/web_component/firebase_auth",

--- a/mesop/examples/web_component/__init__.py
+++ b/mesop/examples/web_component/__init__.py
@@ -1,6 +1,9 @@
 from mesop.examples.web_component.code_mirror_editor import (
   code_mirror_editor_app as code_mirror_editor_app,
 )
+from mesop.examples.web_component.complex_props import (
+  complex_props_app as complex_props_app,
+)
 from mesop.examples.web_component.copy_to_clipboard import (
   copy_to_clipboard_app as copy_to_clipboard_app,
 )

--- a/mesop/examples/web_component/complex_props/BUILD
+++ b/mesop/examples/web_component/complex_props/BUILD
@@ -1,0 +1,14 @@
+load("//build_defs:defaults.bzl", "py_library")
+
+package(
+    default_visibility = ["//build_defs:mesop_examples"],
+)
+
+py_library(
+    name = "complex_props",
+    srcs = glob(["*.py"]),
+    data = glob(["*.js"]),
+    deps = [
+        "//mesop",
+    ],
+)

--- a/mesop/examples/web_component/complex_props/complex_props_app.py
+++ b/mesop/examples/web_component/complex_props/complex_props_app.py
@@ -1,0 +1,23 @@
+import mesop as me
+from mesop.examples.web_component.complex_props.web_component import (
+  web_component,
+)
+
+
+@me.page(
+  path="/web_component/complex_props/complex_props_app",
+  security_policy=me.SecurityPolicy(
+    allowed_script_srcs=[
+      "https://cdn.jsdelivr.net",
+    ]
+  ),
+)
+def page():
+  me.text("Loaded")
+  web_component(
+    array=["element1", "element2"],
+    object={
+      "key1": "value1",
+      "key2": "value2",
+    },
+  )

--- a/mesop/examples/web_component/complex_props/web_component.js
+++ b/mesop/examples/web_component/complex_props/web_component.js
@@ -1,0 +1,35 @@
+import {
+  LitElement,
+  html,
+} from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
+
+class ComplexPropComponent extends LitElement {
+  static properties = {
+    array: {type: Array},
+    object: {type: Object},
+  };
+
+  constructor() {
+    super();
+    this.array = [];
+    this.object = {};
+  }
+  render() {
+    return html`
+      <div>
+        <h3>Array Prop:</h3>
+        <ul>
+          ${this.array.map((item) => html`<li>${item}</li>`)}
+        </ul>
+        <h3>Object Prop:</h3>
+        <ul>
+          ${Object.entries(this.object).map(
+            ([key, value]) => html` <li>${key}: ${value}</li> `,
+          )}
+        </ul>
+      </div>
+    `;
+  }
+}
+
+customElements.define('complex-prop-component', ComplexPropComponent);

--- a/mesop/examples/web_component/complex_props/web_component.py
+++ b/mesop/examples/web_component/complex_props/web_component.py
@@ -1,0 +1,12 @@
+import mesop.labs as mel
+
+
+@mel.web_component(path="./web_component.js")
+def web_component(array: list[str], object: dict[str, str]):
+  return mel.insert_web_component(
+    name="complex-prop-component",
+    properties={
+      "array": array,
+      "object": object,
+    },
+  )

--- a/mesop/examples/web_component/slot/outer_component.js
+++ b/mesop/examples/web_component/slot/outer_component.js
@@ -7,13 +7,13 @@ import {
 class OuterComponent extends LitElement {
   static properties = {
     value: {type: Number},
-    incrementEventHandlerId: {attribute: 'increment-event', type: String},
+    incrementEvent: {type: String},
   };
 
   constructor() {
     super();
     this.value = 0;
-    this.incrementEventHandlerId = '';
+    this.incrementEvent = '';
   }
 
   render() {
@@ -32,7 +32,7 @@ class OuterComponent extends LitElement {
 
   _onIncrement() {
     this.dispatchEvent(
-      new MesopEvent(this.incrementEventHandlerId, {
+      new MesopEvent(this.incrementEvent, {
         value: this.value + 1,
       }),
     );

--- a/mesop/examples/web_component/slot/outer_component.py
+++ b/mesop/examples/web_component/slot/outer_component.py
@@ -14,7 +14,7 @@ def outer_component(
     name="slot-outer-component",
     key=key,
     events={
-      "increment-event": on_increment,
+      "incrementEvent": on_increment,
     },
     properties={
       "value": value,

--- a/mesop/tests/e2e/web_components/complex_props_test.ts
+++ b/mesop/tests/e2e/web_components/complex_props_test.ts
@@ -1,0 +1,14 @@
+import {test, expect} from '@playwright/test';
+
+test('web components - complex properties (array and object)', async ({
+  page,
+}) => {
+  await page.goto('/web_component/complex_props/complex_props_app');
+  // Make sure page is loaded.
+  await expect(page.getByText('Loaded')).toBeVisible();
+
+  // Make sure values from array is displayed:
+  await expect(page.getByText('element1')).toBeVisible();
+  // Make sure values from object is displayed:
+  await expect(page.getByText('key1: value1')).toBeVisible();
+});

--- a/mesop/web/src/component_renderer/component_renderer.ts
+++ b/mesop/web/src/component_renderer/component_renderer.ts
@@ -212,7 +212,7 @@ export class ComponentRenderer {
         // We should have checked this in Python, but just in case
         // we will check the attribute name right before using it.
         checkAttributeNameIsSafe(key);
-        customElement.setAttribute(key, (properties as any)[key]);
+        (customElement as any)[key] = (properties as any)[key];
       }
     }
 

--- a/mesop/web/src/component_renderer/component_renderer.ts
+++ b/mesop/web/src/component_renderer/component_renderer.ts
@@ -206,7 +206,7 @@ export class ComponentRenderer {
     for (const key of Object.keys(properties)) {
       const value = (properties as any)[key];
       // We should have checked this in Python, but just in case
-      // we will check the attribute name right before using it.
+      // we will check the property name right before using it.
       checkPropertyNameIsSafe(key);
       (customElement as any)[key] = value;
     }
@@ -214,7 +214,7 @@ export class ComponentRenderer {
     const events = jsonParse(webComponentType.getEventsJson()!) as object;
     for (const event of Object.keys(events)) {
       // We should have checked this in Python, but just in case
-      // we will check the attribute name right before using it.
+      // we will check the property name right before using it.
       checkPropertyNameIsSafe(event);
       customElement.setAttribute(event, (events as any)[event]);
     }

--- a/mesop/web/src/component_renderer/component_renderer.ts
+++ b/mesop/web/src/component_renderer/component_renderer.ts
@@ -205,22 +205,17 @@ export class ComponentRenderer {
     ) as object;
     for (const key of Object.keys(properties)) {
       const value = (properties as any)[key];
-      // Explicitly don't set attribute for boolean attribute.
-      // If you set any value to a boolean attribute, it will be treated as enabled.
-      // Source: https://lit.dev/docs/components/properties/#boolean-attributes
-      if (value !== false) {
-        // We should have checked this in Python, but just in case
-        // we will check the attribute name right before using it.
-        checkAttributeNameIsSafe(key);
-        (customElement as any)[key] = (properties as any)[key];
-      }
+      // We should have checked this in Python, but just in case
+      // we will check the attribute name right before using it.
+      checkPropertyNameIsSafe(key);
+      (customElement as any)[key] = value;
     }
 
     const events = jsonParse(webComponentType.getEventsJson()!) as object;
     for (const event of Object.keys(events)) {
       // We should have checked this in Python, but just in case
       // we will check the attribute name right before using it.
-      checkAttributeNameIsSafe(event);
+      checkPropertyNameIsSafe(event);
       customElement.setAttribute(event, (events as any)[event]);
     }
     // Always try to remove the event listener since we will attach the event listener
@@ -469,13 +464,13 @@ function isRegularComponent(component: ComponentProto) {
 }
 
 // Note: the logic here should be kept in sync with
-// helper.py's check_attribute_keys_is_safe
-export function checkAttributeNameIsSafe(attribute: string) {
-  const normalizedAttribute = attribute.toLowerCase();
+// helper.py's check_property_keys_is_safe
+export function checkPropertyNameIsSafe(propertyName: string) {
+  const normalizedName = propertyName.toLowerCase();
   if (
-    ['src', 'srcdoc'].includes(normalizedAttribute) ||
-    normalizedAttribute.startsWith('on')
+    ['src', 'srcdoc'].includes(normalizedName) ||
+    normalizedName.startsWith('on')
   ) {
-    throw new Error(`Unsafe attribute name '${attribute}' cannot be used.`);
+    throw new Error(`Unsafe property name '${propertyName}' cannot be used.`);
   }
 }

--- a/mesop/web/src/component_renderer/component_renderer.ts
+++ b/mesop/web/src/component_renderer/component_renderer.ts
@@ -216,7 +216,7 @@ export class ComponentRenderer {
       // We should have checked this in Python, but just in case
       // we will check the property name right before using it.
       checkPropertyNameIsSafe(event);
-      customElement.setAttribute(event, (events as any)[event]);
+      (customElement as any)[event] = (events as any)[event];
     }
     // Always try to remove the event listener since we will attach the event listener
     // next. If the event listener wasn't already attached, then removeEventListener is

--- a/mesop/web/src/component_renderer/component_renderer_spec.ts
+++ b/mesop/web/src/component_renderer/component_renderer_spec.ts
@@ -1,11 +1,11 @@
-import {checkAttributeNameIsSafe} from './component_renderer';
+import {checkPropertyNameIsSafe} from './component_renderer';
 
 describe('component renderer', () => {
-  describe('checkAttributeNameIsSafe', () => {
+  describe('checkPropertyNameIsSafe', () => {
     it('should raise an exception for unsafe attribute keys', () => {
       const unsafeKeys = ['src', 'SRC', 'srcdoc', 'on', 'On', 'ON', 'onClick'];
       unsafeKeys.forEach((key) => {
-        expect(() => checkAttributeNameIsSafe(key)).toThrowError(
+        expect(() => checkPropertyNameIsSafe(key)).toThrowError(
           `Unsafe attribute name '${key}' cannot be used.`,
         );
       });
@@ -14,7 +14,7 @@ describe('component renderer', () => {
     it('should pass for safe attribute keys', () => {
       const safeKeys = ['a', 'decrement', 'click-on'];
       safeKeys.forEach((key) => {
-        expect(() => checkAttributeNameIsSafe(key)).not.toThrow();
+        expect(() => checkPropertyNameIsSafe(key)).not.toThrow();
       });
     });
   });

--- a/mesop/web/src/component_renderer/component_renderer_spec.ts
+++ b/mesop/web/src/component_renderer/component_renderer_spec.ts
@@ -6,7 +6,7 @@ describe('component renderer', () => {
       const unsafeKeys = ['src', 'SRC', 'srcdoc', 'on', 'On', 'ON', 'onClick'];
       unsafeKeys.forEach((key) => {
         expect(() => checkPropertyNameIsSafe(key)).toThrowError(
-          `Unsafe attribute name '${key}' cannot be used.`,
+          `Unsafe property name '${key}' cannot be used.`,
         );
       });
     });


### PR DESCRIPTION
Fixes #730.

**Breaking change**: Web components are now set via DOM properties and not attributes. This means you can _not_ use Lit's attribute API, e.g. 

```ts
  static properties = {
    value: {type: Number},
    incrementEventHandlerId: {attribute: 'increment-event', type: String},
  };
```

I mixed up [DOM attributes and DOM properties](https://jakearchibald.com/2024/attributes-vs-properties/#value-types:~:text=elements%2C%20not%20properties.-,Value%20types,-In%20order%20to) and only primitive types, e.g. string, number, boolean, worked when I erroneously set the web component properties as DOM attributes. [Lit's default converter](https://lit.dev/docs/components/properties/#conversion-type) worked for the primitive types.