### PR TITLE
Proper child reconciliation for web components with slots.

### DIFF
--- a/mesop/examples/web_component/slot/counter_component.js
+++ b/mesop/examples/web_component/slot/counter_component.js
@@ -22,6 +22,7 @@ class CounterComponent extends LitElement {
         <button id="decrement-btn" @click="${this._onDecrement}">
           Decrement
         </button>
+        <input type="text" />
       </div>
     `;
   }

--- a/mesop/examples/web_component/slot/outer_component.js
+++ b/mesop/examples/web_component/slot/outer_component.js
@@ -19,7 +19,7 @@ class OuterComponent extends LitElement {
   render() {
     return html`
       <div class="container">
-        <span>Value: ${this.value}</span>
+        <span id="outer-value">Value: ${this.value}</span>
         <button id="increment-btn" @click="${this._onIncrement}">
           increment
         </button>

--- a/mesop/examples/web_component/slot/slot_app.py
+++ b/mesop/examples/web_component/slot/slot_app.py
@@ -10,6 +10,10 @@ from mesop.examples.web_component.slot.outer_component import (
 )
 
 
+def on_add_checkbox_slot(e: me.ClickEvent):
+  me.state(State).checkbox_slot = True
+
+
 @me.page(
   path="/web_component/slot/slot_app",
   security_policy=me.SecurityPolicy(
@@ -19,6 +23,8 @@ from mesop.examples.web_component.slot.outer_component import (
   ),
 )
 def page():
+  s = me.state(State)
+  me.button("add checkbox slot", on_click=on_add_checkbox_slot)
   with outer_component(
     value=me.state(State).value,
     on_increment=on_increment,
@@ -27,18 +33,22 @@ def page():
       me.text(
         "You can use built-in components inside the slot of a web component."
       )
-      #
-      me.checkbox(
-        # Need to set |checked| because of https://github.com/google/mesop/issues/449
-        checked=me.state(State).checked,
-        label="Checked?",
-        on_change=on_checked,
-      )
+      if s.checkbox_slot:
+        me.checkbox(
+          label="Checked?",
+          on_change=on_checked,
+        )
+      me.input(key="input", label="input slot", on_input=on_input)
       counter_component(
+        key="counter",
         value=me.state(State).value,
         on_decrement=on_decrement,
       )
   me.text(f"Checked? {me.state(State).checked}")
+
+
+def on_input(e: me.InputEvent):
+  me.state(State).input = e.value
 
 
 def on_checked(e: me.CheckboxChangeEvent):
@@ -47,6 +57,8 @@ def on_checked(e: me.CheckboxChangeEvent):
 
 @me.stateclass
 class State:
+  checkbox_slot: bool = False
+  input: str
   checked: bool
   value: int = 10
 

--- a/mesop/tests/e2e/web_components/slot_test.ts
+++ b/mesop/tests/e2e/web_components/slot_test.ts
@@ -1,39 +1,61 @@
 import {test, expect, Page} from '@playwright/test';
 
-test.describe(() => {
-  // All tests in this describe group will get 2 retry attempts.
-  test.describe.configure({retries: 2});
-  test('web components - slot', async ({page}) => {
-    await page.goto('http://localhost:32123/web_component/slot/slot_app');
-    // Make sure the page has loaded:
-    expect(page.getByRole('button', {name: 'Decrement'})).toBeVisible();
+test('web components - slot', async ({page}) => {
+  await page.goto('/web_component/slot/slot_app');
 
-    assertValue(10);
-    await page.getByRole('button', {name: 'increment'}).click();
-    assertValue(11);
-    await page.getByRole('button', {name: 'increment'}).click();
-    assertValue(12);
-    await page.getByRole('button', {name: 'Decrement'}).click();
-    assertValue(11);
-    await page.getByRole('button', {name: 'Decrement'}).click();
-    assertValue(10);
+  // Make sure the page has loaded:
+  expect(page.getByRole('button', {name: 'Decrement'})).toBeVisible();
 
-    async function assertValue(value: number) {
-      // Check that the outer component is displaying the right value.
-      expect(
-        await page
-          .locator('div')
-          .filter({hasText: `Value: ${value} increment Start of`})
-          .textContent(),
-      ).toContain(value.toString());
+  await assertValue(10);
+  await page.getByRole('button', {name: 'increment'}).click();
+  await assertValue(11);
+  await page.getByRole('button', {name: 'increment'}).click();
+  await assertValue(12);
+  await page.getByRole('button', {name: 'Decrement'}).click();
+  await assertValue(11);
+  await page.getByRole('button', {name: 'Decrement'}).click();
+  await assertValue(10);
 
-      // Check that the inner component is displaying the right value.
-      expect(
-        await page
-          .locator('slot-counter-component')
-          .getByText('Value:')
-          .textContent(),
-      ).toContain(value.toString());
-    }
-  });
+  async function assertValue(value: number) {
+    // Check that the outer component is displaying the right value.
+    expect(
+      await page
+        .locator('#outer-value')
+        .filter({hasText: `Value: ${value}`})
+        .textContent(),
+    ).toContain(value.toString());
+
+    // Check that the inner component is displaying the right value.
+    expect(
+      await page
+        .locator('slot-counter-component')
+        .getByText('Value:')
+        .textContent(),
+    ).toContain(value.toString());
+  }
+});
+
+test('web components - slot child reconciliation', async ({page}) => {
+  await page.goto('/web_component/slot/slot_app');
+  await page.getByLabel('input slot').click();
+  await page.getByLabel('input slot').fill('abc');
+
+  await page.locator('slot-counter-component').getByRole('textbox').click();
+  await page.locator('slot-counter-component').getByRole('textbox').fill('def');
+
+  await page.getByRole('button', {name: 'Decrement'}).click();
+  await page.getByRole('button', {name: 'add checkbox slot'}).click();
+
+  await page.getByRole('checkbox').click();
+
+  // Assertions
+  await expect(page.getByRole('checkbox')).toBeChecked();
+  await expect(page.getByText('Checked? true')).toBeVisible();
+  expect(await page.getByLabel('input slot').inputValue()).toEqual('abc');
+  expect(
+    await page
+      .locator('slot-counter-component')
+      .getByRole('textbox')
+      .inputValue(),
+  ).toEqual('def');
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ import {defineConfig, devices} from '@playwright/test';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  timeout: process.env.CI ? 75_000 : 30_000, // Budget more time for CI since tests run slower there.
+  timeout: process.env.CI ? 75_000 : 40_000, // Budget more time for CI since tests run slower there.
   testDir: '.',
   // Use a custom snapshot path template because Playwright's default
   // is platform-specific which isn't necessary for Mesop e2e tests


### PR DESCRIPTION
Fixes #449.

Drive-by: deflake the existing slot test by adding in `await`.