### PR TITLE
Fix up docbot - pass llm arg for QueryFusionRetriever

### DIFF
--- a/ai/docbot/docs_index.py
+++ b/ai/docbot/docs_index.py
@@ -145,6 +145,7 @@ else:
       index.as_retriever(similarity_top_k=5),
       bm25_retriever,
     ],
+    llm=llm,
     num_queries=1,
     use_async=True,
     similarity_top_k=5,

--- a/ai/docbot/eval_viewer.py
+++ b/ai/docbot/eval_viewer.py
@@ -110,7 +110,7 @@ def index():
       with me.box(
         style=me.Style(
           display="grid",
-          grid_template_columns="160px 1fr 1fr 1fr 1fr"
+          grid_template_columns="160px 300px 1fr 300px 1fr"
           if state.group_2.items
           else "160px 1fr 1fr",
           gap=16,


### PR DESCRIPTION
drive-by: make eval viewer easier to view for large inputs