### PR TITLE
Support non-generating coroutines as event handlers.

### DIFF
--- a/mesop/examples/async_await.py
+++ b/mesop/examples/async_await.py
@@ -30,4 +30,3 @@ async def click_async(e: me.ClickEvent):
   me.state(State).val1, me.state(State).val2 = await asyncio.gather(
     val1_task, val2_task
   )
-  yield

--- a/mesop/examples/async_await.py
+++ b/mesop/examples/async_await.py
@@ -8,7 +8,8 @@ def page():
   s = me.state(State)
   me.text("val1=" + s.val1)
   me.text("val2=" + s.val2)
-  me.button("async", on_click=click_async)
+  me.button("async with yield", on_click=click_async_with_yield)
+  me.button("async without yield", on_click=click_async_no_yield)
 
 
 @me.stateclass
@@ -23,7 +24,17 @@ async def fetch_dummy_values():
   return "<async_value>"
 
 
-async def click_async(e: me.ClickEvent):
+async def click_async_with_yield(e: me.ClickEvent):
+  val1_task = asyncio.create_task(fetch_dummy_values())
+  val2_task = asyncio.create_task(fetch_dummy_values())
+
+  me.state(State).val1, me.state(State).val2 = await asyncio.gather(
+    val1_task, val2_task
+  )
+  yield
+
+
+async def click_async_no_yield(e: me.ClickEvent):
   val1_task = asyncio.create_task(fetch_dummy_values())
   val2_task = asyncio.create_task(fetch_dummy_values())
 

--- a/mesop/runtime/context.py
+++ b/mesop/runtime/context.py
@@ -270,6 +270,8 @@ Did you forget to decorate your state class `{state.__name__}` with @stateclass?
       if result is not None:
         if isinstance(result, types.AsyncGeneratorType):
           yield from _run_async_generator(result)
+        elif isinstance(result, types.CoroutineType):
+          yield _run_coroutine(result)
         else:
           yield from result
       else:
@@ -287,6 +289,11 @@ def _run_async_generator(agen: types.AsyncGeneratorType[None, None]):
       yield loop.run_until_complete(agen.__anext__())
   except StopAsyncIteration:
     pass
+
+
+def _run_coroutine(coroutine: types.CoroutineType):
+  loop = _get_or_create_event_loop()
+  return loop.run_until_complete(coroutine)
 
 
 def _get_or_create_event_loop():

--- a/mesop/tests/e2e/async_await_test.ts
+++ b/mesop/tests/e2e/async_await_test.ts
@@ -2,7 +2,20 @@ import {test, expect} from '@playwright/test';
 
 test('async await', async ({page}) => {
   await page.goto('/async_await');
-  await page.getByRole('button', {name: 'async'}).click();
+  await page.getByRole('button', {name: 'async with yield'}).click();
+  await expect(page.getByText('val1=<async_value>')).toBeVisible({
+    // Intentionally set timeout at 3 seconds to make sure the
+    // async work is happening in parallel.
+    timeout: 3000,
+  });
+  expect(await page.getByText('val2=').textContent()).toEqual(
+    'val2=<async_value>',
+  );
+});
+
+test('async await no yield', async ({page}) => {
+  await page.goto('/async_await');
+  await page.getByRole('button', {name: 'async without yield'}).click();
   await expect(page.getByText('val1=<async_value>')).toBeVisible({
     // Intentionally set timeout at 3 seconds to make sure the
     // async work is happening in parallel.


### PR DESCRIPTION
Allows you to elide a solitary final 'yield' from async event handlers that don't stream responses, which seems more ergonomic. 