### PR TITLE
Tighten event type in `register_event_handler`

### DIFF
--- a/mesop/component_helpers/helper.py
+++ b/mesop/component_helpers/helper.py
@@ -364,7 +364,7 @@ def wrap_handler_with_event(func: Handler[E], actionType: Type[E]):
 
 
 def register_event_handler(
-  handler_fn: Callable[..., Any], event: Type[Any]
+  handler_fn: Callable[..., Any], event: Type[E]
 ) -> str:
   fn_id = compute_fn_id(handler_fn)
 


### PR DESCRIPTION
pylance was complaining about the type of `handler_fn` not being compatible with `wrap_handler_with_event`. 