### PR TITLE
[UI change] Remove label for uploader button.

### DIFF
--- a/mesop/components/uploader/uploader.ng.html
+++ b/mesop/components/uploader/uploader.ng.html
@@ -53,5 +53,5 @@
     {{ config().getLabel() }}
   </button>
 
-  } {{ filename() || "No file chosen" }}
+  }
 </div>

--- a/mesop/components/uploader/uploader.ts
+++ b/mesop/components/uploader/uploader.ts
@@ -26,7 +26,6 @@ export class UploaderComponent {
   @Input() key!: Key;
   @Input() style!: Style;
   private _config!: UploaderType;
-  private _filename = '';
 
   constructor(private readonly channel: Channel) {}
 

--- a/mesop/components/uploader/uploader.ts
+++ b/mesop/components/uploader/uploader.ts
@@ -46,10 +46,6 @@ export class UploaderComponent {
     return this._config.getAcceptedFileTypeList().join(',');
   }
 
-  filename(): string {
-    return this._filename;
-  }
-
   async onFileSelected(event: Event) {
     const target = event.target as HTMLInputElement;
     const files = target.files as FileList;
@@ -65,12 +61,6 @@ export class UploaderComponent {
       uploaded_file.setMimeType(files[i].type);
       uploaded_file.setContents(new Uint8Array(buffer));
       uploadEvent.addFile(uploaded_file);
-
-      if (i === 0) {
-        this._filename = files[i].name;
-      } else {
-        this._filename = 'Multiple files selected.';
-      }
     }
 
     const userEvent = new UserEvent();


### PR DESCRIPTION
- Slight breaking UI change since the "No file chosen" and filename labels have been removed. They were kind of redundant
- The user can add the labels themselves if necessary. This gives more flexibility
- Also resolves the issue of the filename not being reset.


- Closes #764 (User mainly wanted to change the label to remove it)
- Closes #739 (User wanted to reset the file chosen label after a file was selected)