### PR TITLE
Fix selected component logic in editor toolbar

### DIFF
--- a/mesop/web/src/editor_toolbar/editor_toolbar.ts
+++ b/mesop/web/src/editor_toolbar/editor_toolbar.ts
@@ -77,7 +77,6 @@ export class EditorToolbar implements OnInit {
   @ViewChild(MatAutocomplete)
   autocomplete!: MatAutocomplete;
   @ViewChild('textarea', {static: false}) textarea!: ElementRef;
-  selectedComponent: ComponentProto | undefined;
 
   constructor(
     private editorToolbarService: EditorToolbarService,
@@ -90,9 +89,7 @@ export class EditorToolbar implements OnInit {
     const savedState = localStorage.getItem('isToolbarExpanded');
     this.isToolbarExpanded = savedState === 'true';
 
-    this.editorService.setOnSelectedComponent((component) => {
-      this.selectedComponent = component;
-      // Focus on the textarea
+    this.editorService.setOnSelectedComponent(() => {
       this.textarea.nativeElement.focus();
     });
   }
@@ -166,6 +163,13 @@ export class EditorToolbar implements OnInit {
     await this.sendPrompt();
   }
 
+  getSelectedComponent(): ComponentProto | undefined {
+    if (this.editorService.getSelectionMode() === SelectionMode.SELECTED) {
+      return this.editorService.getFocusedComponent();
+    }
+    return undefined;
+  }
+
   async sendPrompt() {
     const prompt = this.prompt;
     this.autocompleteService.addHistoryOption(prompt);
@@ -179,7 +183,7 @@ export class EditorToolbar implements OnInit {
     try {
       const responsePromise = this.editorToolbarService.sendPrompt(
         prompt,
-        this.selectedComponent?.getSourceCodeLocation(),
+        this.getSelectedComponent()?.getSourceCodeLocation(),
       );
       const progressDialogRef = this.dialog.open(
         EditorSendPromptProgressDialog,


### PR DESCRIPTION
Previously there was a bug where if you unselected a component (e.g. using ESC hotkey), then the editor toolbar would erroneously continue to use the previously selected component for the prompt context.