### PR TITLE
Fix deployment script for showcase

### DIFF
--- a/showcase/deploy_to_hf.sh
+++ b/showcase/deploy_to_hf.sh
@@ -26,7 +26,7 @@ fi
 DEMO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cp -R "$DEMO_DIR/" "$DEST_PATH"
 echo "Demo files have been copied to $DEST_PATH"
-cd "$DEST_PATH"
+cd "$DEST_PATH/showcase"
 echo "Changed directory to $DEST_PATH"
 
 git init


### PR DESCRIPTION
For some reason it seems like there's a difference when running locally on Mac vs. when running on GitHub Actions on Linux, not exactly sure why.