### PR TITLE
Polish editor toolbar and AI service

### DIFF
--- a/ai/src/service.py
+++ b/ai/src/service.py
@@ -34,7 +34,7 @@ def save_interaction_endpoint() -> Response | dict[str, str]:
   else:
     metadata = None
   folder_name = generate_folder_name(prompt)
-  base_path = "../ft/goldens"
+  base_path = "ft/goldens"
   folder_path = os.path.join(base_path, folder_name)
 
   os.makedirs(folder_path, exist_ok=True)
@@ -88,6 +88,9 @@ def adjust_mesop_app_endpoint():
 
 
 def generate_folder_name(prompt: str) -> str:
+  prompt = prompt.replace(
+    " ", "_"
+  )  # Replace spaces with underscores to avoid %20
   # Generate a unique 4-character suffix to avoid naming collisions
   suffix = secrets.token_urlsafe(4)
   cleaned_prompt = urllib.parse.quote(prompt)[:50]

--- a/mesop/web/src/editor_toolbar/editor_history_dialog.ng.html
+++ b/mesop/web/src/editor_toolbar/editor_history_dialog.ng.html
@@ -31,6 +31,7 @@
   </div>
 </mat-dialog-content>
 <mat-dialog-actions>
+  <button mat-button [mat-dialog-close]="false">Cancel</button>
   <button
     mat-button
     [mat-dialog-close]="selectedInteraction"
@@ -39,5 +40,4 @@
   >
     Revert
   </button>
-  <button mat-button [mat-dialog-close]="false">Cancel</button>
 </mat-dialog-actions>

--- a/mesop/web/src/editor_toolbar/editor_response_dialog.ng.html
+++ b/mesop/web/src/editor_toolbar/editor_response_dialog.ng.html
@@ -1,4 +1,4 @@
-<h3 mat-dialog-title>Mesop Editor Response</h3>
+<h3 mat-dialog-title>Review generated code</h3>
 <mat-dialog-content class="mat-typography">
   <mesop-code-mirror-diff
     [beforeCode]="data.response.beforeCode"
@@ -6,6 +6,6 @@
   />
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-button [mat-dialog-close]="true">OK</button>
-  <button mat-button [mat-dialog-close]="false" cdkFocusInitial>Cancel</button>
+  <button mat-button [mat-dialog-close]="false">Cancel</button>
+  <button mat-button [mat-dialog-close]="true" cdkFocusInitial>Apply</button>
 </mat-dialog-actions>

--- a/mesop/web/src/editor_toolbar/editor_toolbar.ng.html
+++ b/mesop/web/src/editor_toolbar/editor_toolbar.ng.html
@@ -11,9 +11,6 @@
   </button>
 
   @if (!isToolbarMinimized) {
-  <div class="drag-handle" cdkDragHandle>
-    <mat-icon>drag_indicator</mat-icon>
-  </div>
 
   <button
     mat-icon-button
@@ -27,7 +24,7 @@
   <textarea
     #textarea
     disabled="{{isLoading}}"
-    placeholder="{{isLoading ? 'Generating...' : 'Type in the UI change you want...' }}"
+    placeholder="{{isLoading ? 'Generating...' : 'Type in the UI change... ' + getToolbarShortcutText() }}"
     class="floating-editor-toolbar-textarea"
     [(ngModel)]="prompt"
     (ngModelChange)="onPromptChange($event)"

--- a/mesop/web/src/editor_toolbar/editor_toolbar.scss
+++ b/mesop/web/src/editor_toolbar/editor_toolbar.scss
@@ -49,7 +49,7 @@
     color: var(--sys-on-surface-variant);
   }
   height: 30px;
-  width: min(80vw, 480px);
+  width: max(min(60vw, 480px), 180px);
   outline: none;
   resize: none;
   overflow: hidden;

--- a/mesop/web/src/editor_toolbar/editor_toolbar.ts
+++ b/mesop/web/src/editor_toolbar/editor_toolbar.ts
@@ -202,8 +202,11 @@ export class EditorToolbar implements OnInit {
         width: '90%',
       });
       const response = await responsePromise;
+      progressDialogRef.afterClosed().subscribe(() => {
+        this.autocompleteTrigger.closePanel();
+      });
       progressDialogRef.close();
-      this.autocompleteTrigger.closePanel();
+
       const dialogRef = this.dialog.open(EditorPromptResponseDialog, {
         data: {response: response, responseTime: this.responseTime},
         width: '90%',

--- a/mesop/web/src/editor_toolbar/editor_toolbar.ts
+++ b/mesop/web/src/editor_toolbar/editor_toolbar.ts
@@ -1,4 +1,11 @@
-import {Component, ElementRef, Inject, OnInit, ViewChild} from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  HostListener,
+  Inject,
+  OnInit,
+  ViewChild,
+} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {CdkDrag, CdkDragEnd} from '@angular/cdk/drag-drop';
 import {MatButtonModule} from '@angular/material/button';
@@ -110,6 +117,27 @@ export class EditorToolbar implements OnInit {
       return 'Select component - ⌘ ⇧ E';
     }
     return 'Select component - Ctrl ⇧ E';
+  }
+
+  @HostListener('window:keydown', ['$event'])
+  handleKeyDown(event: KeyboardEvent) {
+    // Hotkey for focusing on editor toolbar textarea
+    //
+    // Binds:
+    // cmd + k (MacOs)
+    // ctrl + k (Other platforms)
+    if (event.key === 'k' && (isMac() ? event.metaKey : event.ctrlKey)) {
+      this.textarea.nativeElement.focus();
+      event.preventDefault();
+      return;
+    }
+  }
+
+  getToolbarShortcutText(): string {
+    if (isMac()) {
+      return '⌘ K';
+    }
+    return 'Ctrl K';
   }
 
   isSelectingMode(): boolean {
@@ -253,6 +281,15 @@ export class EditorToolbar implements OnInit {
       if (Number.isInteger(result)) {
         const interaction = this.editorToolbarService.getHistory()[result];
         this.editorToolbarService.commit(interaction.beforeCode);
+        this.editorToolbarService.addHistoryEntry({
+          prompt: `Revert: ${interaction.prompt}`,
+          path: interaction.path,
+          // Swap before and after code to represent the revert
+          beforeCode: interaction.afterCode,
+          afterCode: interaction.beforeCode,
+          diff: '<revert>',
+          lineNumber: undefined,
+        });
       }
     });
   }

--- a/mesop/web/src/editor_toolbar/editor_toolbar_service.ts
+++ b/mesop/web/src/editor_toolbar/editor_toolbar_service.ts
@@ -58,7 +58,7 @@ export class EditorToolbarService {
     }
   }
 
-  private addHistoryEntry(entry: PromptInteraction) {
+  addHistoryEntry(entry: PromptInteraction) {
     this.history.unshift(entry);
     this.saveHistoryToStorage();
   }


### PR DESCRIPTION
Minor fixes in service.py:
 - Fix path issue after refactoring
 - Make the saved interaction folder name nicer

Many smallish changes for editor toolbar:
- Update response dialog title and swap buttons so OK/apply is default
- Close the autocomplete panel correctly after the progress dialog is closed
- Swap button order for revert dialog to be consistent
- Add history entry after reverting
- Remove drag icon (the whole toolbar is draggable)
- Make the toolbar more reasonably sized
- Add keyboard shortcut (command/ctrl+K) for editor toolbar textarea
