### PR TITLE
Add docs for mounting Mesop app

### DIFF
--- a/docs/guides/server-integration.md
+++ b/docs/guides/server-integration.md
@@ -1,0 +1,21 @@
+# Server integration
+
+Mesop allows you to integrate Mesop with other Python web servers like FastAPI or Flask by mounting the Mesop app which is a [WSGI](https://wsgi.readthedocs.io/en/latest/what.html) app.
+
+This enables you to do things like:
+
+- Serve local files (e.g. images)
+- Provide API endpoints (which can be called by the web component, etc.)
+
+## API
+
+The main API for doing this integration is the `create_wsgi_app` function.
+
+::: mesop.server.wsgi_app.create_wsgi_app
+
+## FastAPI example
+
+For a working example of using Mesop with FastAPI, please take a look at this repo:
+[https://github.com/wwwillchen/mesop-fastapi](https://github.com/wwwillchen/mesop-fastapi)
+
+> Note: you can apply similar steps to use any other web framework that allows you to mount a WSGI app.

--- a/mesop/server/wsgi_app.py
+++ b/mesop/server/wsgi_app.py
@@ -51,7 +51,10 @@ def create_app(
 
 def create_wsgi_app(*, debug_mode: bool = False):
   """
-  Creates a WSGI app that can be used to run Mesop in a WSGI server.
+  Creates a WSGI app that can be used to run Mesop in a WSGI server like gunicorn.
+
+  Args:
+    debug_mode: If True, enables debug mode for the Mesop app.
   """
   _app = None
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
           - Multi-Pages: guides/multi-pages.md
           - Auth: guides/auth.md
           - Theming: guides/theming.md
+          - Server integration: guides/server-integration.md
       - Development:
           - Debugging: guides/debugging.md
           - Testing: guides/testing.md


### PR DESCRIPTION
The FastAPI example seems to be working well:
https://github.com/wwwillchen/mesop-fastapi

However, I'm having trouble with the Flask example: https://github.com/wwwillchen/mesop-flask - when I try to run Mesop in debug mode, it's not loading.

All things considered though, I think encouraging people to use FastAPI is better as it reduces the likelihood of a version dependency conflict with Mesop's internal Flask usage and other people's Flask usage.

Fixes #803.