### PR TITLE
Fix sandbox_iframe.html to not have CSP

### DIFF
--- a/mesop/components/html/e2e/html_test.ts
+++ b/mesop/components/html/e2e/html_test.ts
@@ -52,6 +52,6 @@ test('test sandboxed html - origin is null', async ({page}) => {
 
 test('sandbox_iframe.html csp', async ({page}) => {
   const response = await page.goto('/sandbox_iframe.html');
-  const csp = response?.headers()['content-security-policy']!;
-  expect(csp).toMatchSnapshot('sandbox_iframe.html-csp.txt');
+  const csp = response?.headers()['content-security-policy'];
+  expect(csp).toBeUndefined();
 });

--- a/mesop/server/static_file_serving.py
+++ b/mesop/server/static_file_serving.py
@@ -257,15 +257,11 @@ def configure_static_file_serving(
       if livereload_origin:
         csp["connect-src"] = f"'self' {livereload_origin}"
 
-    if request.path == "/sandbox_iframe.html":
-      # Set a minimal CSP to not restrict Mesop app developers.
-      # Need frame-ancestors to ensure other sites do not iframe
-      # this page and exploit it.
-      csp_subset = OrderedDict({"frame-ancestors": csp["frame-ancestors"]})
-      response.headers["Content-Security-Policy"] = "; ".join(
-        [key + " " + value for key, value in csp_subset.items()]
-      )
-    else:
+    # sandbox_iframe.html is an exception: we do not set a CSP on it
+    # because it needs to be able to execute arbitrary code within
+    # the sandboxed iframe and setting a CSP would be inherited by
+    # the iframe since it's using srcdoc.
+    if request.path != "/sandbox_iframe.html":
       # Set Content-Security-Policy header to restrict resource loading
       # Based on https://angular.io/guide/security#content-security-policy
       response.headers["Content-Security-Policy"] = "; ".join(


### PR DESCRIPTION
Right now sandbox_iframe.html has a minimal CSP which includes frame-ancestors which was an extra security measure, but shouldn't be necessary since sandbox_iframe.html itself does all execution inside a sandboxed iframe with a null origin.

The problem with setting frame-ancestors is then legitimate iframe parents get blocked, e.g. [HTML demo ](https://google.github.io/mesop/components/html/#examples). Since we normally look up the security policy for the page (e.g. path) that you're loading from, this doesn't work sandbox_iframe.html since the path is just sandbox_iframe.html and not the regular Mesop page.

For more context, see: https://github.com/google/mesop/pull/544

Even though this should be safe, I'm still a little concerned about lifting this frame-ancestors protection.