### PR TITLE
Update some usages of scroll-to

### DIFF
--- a/ai/src/ai/offline_common/inputs/chat.py
+++ b/ai/src/ai/offline_common/inputs/chat.py
@@ -212,10 +212,7 @@ def chat(
       output = []
     output.append(ChatMessage(role=_ROLE_USER, content=input))
     state.in_progress = True
-    yield
-
     me.scroll_into_view(key="scroll-to")
-    time.sleep(0.15)
     yield
 
     start_time = time.time()
@@ -262,7 +259,7 @@ def chat(
                 me.markdown(msg.content)
 
         if state.in_progress:
-          with me.box(key="scroll-to", style=me.Style(height=300)):
+          with me.box(key="scroll-to", style=me.Style(height=250)):
             pass
 
       with me.box(style=_STYLE_CHAT_INPUT_BOX):

--- a/demo/fancy_chat.py
+++ b/demo/fancy_chat.py
@@ -558,10 +558,7 @@ def on_click_submit_chat_msg(e: me.ClickEvent):
     output = []
   output.append(ChatMessage(role="user", content=input))
   state.in_progress = True
-  yield
-
   me.scroll_into_view(key="scroll-to")
-  time.sleep(0.15)
   yield
 
   start_time = time.time()

--- a/demo/llm_rewriter.py
+++ b/demo/llm_rewriter.py
@@ -93,7 +93,7 @@ def page():
                 me.icon(icon="edit_note")
 
       if state.in_progress:
-        with me.box(key="scroll-to", style=me.Style(height=300)):
+        with me.box(key="scroll-to", style=me.Style(height=250)):
           pass
     with me.box(style=_STYLE_CHAT_INPUT_BOX):
       with me.box(style=me.Style(flex_grow=1)):
@@ -187,10 +187,7 @@ def on_click_submit_chat_msg(e: me.ClickEvent | me.InputEnterEvent):
     output = []
   output.append(ChatMessage(role=_ROLE_USER, content=input))
   state.in_progress = True
-  yield
-
   me.scroll_into_view(key="scroll-to")
-  time.sleep(0.15)
   yield
 
   start_time = time.time()
@@ -240,6 +237,7 @@ def respond_to_chat(input: str, history: list[ChatMessage]):
     "Habitant morbi tristique senectus et netus et malesuada.",
   ]
   for line in random.sample(lines, random.randint(3, len(lines) - 1)):
+    time.sleep(0.25)
     yield line + " "
 
 

--- a/mesop/examples/inlined_chat.py
+++ b/mesop/examples/inlined_chat.py
@@ -196,10 +196,7 @@ def chat(
       output = []
     output.append(ChatMessage(role=_ROLE_USER, content=input))
     state.in_progress = True
-    yield
-
     me.scroll_into_view(key="scroll-to")
-    time.sleep(0.15)
     yield
 
     start_time = time.time()
@@ -247,7 +244,7 @@ def chat(
               me.markdown(msg.content)
 
       if state.in_progress:
-        with me.box(key="scroll-to", style=me.Style(height=300)):
+        with me.box(key="scroll-to", style=me.Style(height=250)):
           pass
 
     with me.box(style=_STYLE_CHAT_INPUT_BOX):

--- a/mesop/labs/chat.py
+++ b/mesop/labs/chat.py
@@ -165,10 +165,7 @@ def chat(
       output = []
     output.append(ChatMessage(role=_ROLE_USER, content=input))
     state.in_progress = True
-    yield
-
     me.scroll_into_view(key="scroll-to")
-    time.sleep(0.15)
     yield
 
     start_time = time.time()


### PR DESCRIPTION
We can remove the intentional delay on scroll-to now.

There is one case where this does not work as expected though. When the chat message is not streamed, the scroll to with hidden box strategy does not work since the output is too fast. This occurred on LLM Rewriter example. But I updated it to fake the streaming.

Also decreases the size of the hidden box, so it is less jarring when the box disappears.