### PR TITLE
Fix cutoff content for history prompt list / code diff viewer

### DIFF
--- a/mesop/web/src/editor_toolbar/editor_toolbar.ts
+++ b/mesop/web/src/editor_toolbar/editor_toolbar.ts
@@ -414,7 +414,7 @@ class EditorPromptResponseDialog {
         display: flex;
         flex-direction: column;
         gap: 12px;
-        max-height: 80vh;
+        max-height: 65vh;
         overflow-y: auto;
       }
       .prompt-item {
@@ -429,7 +429,7 @@ class EditorPromptResponseDialog {
       }
       .code-display {
         flex: 1;
-        max-height: 80vh;
+        max-height: 65vh;
         overflow-y: auto;
       }
       .save-interaction-button {


### PR DESCRIPTION
I noticed that the Angular dialog sets a 65vh. But our code is using 80vh. So I set it to 65vh to match.

One consideration though is whether this 65vh changes dynamically or not. I did try adjusting viewport sizes in Chrome dev tools and it seemed like it stayed at 65vh but not sure.

Closes #908