### PR TITLE
Remove require_selection from autocomplete

### DIFF
--- a/mesop/components/autocomplete/autocomplete.py
+++ b/mesop/components/autocomplete/autocomplete.py
@@ -44,11 +44,6 @@ class AutocompleteOptionGroup:
 class AutocompleteEnterEvent(MesopEvent):
   """Represents an "Enter" keyboard event on an autocomplete component.
 
-  This will return the raw value if `require_selection` is False.
-
-  If `require_selection` is True, then only a valid selection will be returned. An empty
-  string will be return if not valid selection has been made.
-
   Attributes:
     value: Input/selected value.
     key (str): key of the component that emitted this event.
@@ -99,7 +94,6 @@ def autocomplete(
   appearance: Literal["fill", "outline"] = "fill",
   disabled: bool = False,
   placeholder: str = "",
-  require_selection: bool = False,
   value: str = "",
   readonly: bool = False,
   hide_required_marker: bool = False,

--- a/mesop/components/autocomplete/e2e/autocomplete_app.py
+++ b/mesop/components/autocomplete/e2e/autocomplete_app.py
@@ -15,7 +15,6 @@ def app():
     me.autocomplete(
       label="Select state",
       options=_make_autocomplete_options(),
-      require_selection=True,
       on_selection_change=on_value_change,
       on_enter=on_value_change,
       on_input=on_input,


### PR DESCRIPTION
Forgot to remove this when creating the autocomplete component initially.

The require_selection property overall is not too helpful for Mesop. The require_selection can be implemented in Mesop by just using the AutocompleteSelectionChangeEvent when populating valid option values.