### PR TITLE
Add date picker and date range picker components.

### DIFF
--- a/demo/date_picker.py
+++ b/demo/date_picker.py
@@ -1,0 +1,48 @@
+from dataclasses import field
+from datetime import date
+
+import mesop as me
+
+
+@me.stateclass
+class State:
+  picked_date: date | None = field(default_factory=lambda: date(2024, 10, 1))
+
+
+@me.page(path="/date_picker")
+def app():
+  state = me.state(State)
+  with me.box(
+    style=me.Style(
+      display="flex",
+      flex_direction="column",
+      gap=15,
+      padding=me.Padding.all(15),
+    )
+  ):
+    me.date_picker(
+      label="Date",
+      disabled=False,
+      placeholder="9/1/2024",
+      required=True,
+      value=state.picked_date,
+      readonly=False,
+      hide_required_marker=False,
+      color="accent",
+      float_label="always",
+      appearance="outline",
+      on_change=on_date_change,
+    )
+
+    me.text("Selected date: " + _render_date(state.picked_date))
+
+
+def on_date_change(e: me.DatePickerChangeEvent):
+  state = me.state(State)
+  state.picked_date = e.date
+
+
+def _render_date(maybe_date: date | None) -> str:
+  if maybe_date:
+    return maybe_date.strftime("%Y-%m-%d")
+  return "None"

--- a/demo/date_picker.py
+++ b/demo/date_picker.py
@@ -9,7 +9,11 @@ class State:
   picked_date: date | None = field(default_factory=lambda: date(2024, 10, 1))
 
 
-@me.page(path="/date_picker")
+def on_load(e: me.LoadEvent):
+  me.set_theme_mode("system")
+
+
+@me.page(path="/date_picker", on_load=on_load)
 def app():
   state = me.state(State)
   with me.box(

--- a/demo/date_range_picker.py
+++ b/demo/date_range_picker.py
@@ -1,0 +1,57 @@
+from dataclasses import field
+from datetime import date
+
+import mesop as me
+
+
+@me.stateclass
+class State:
+  picked_start_date: date | None = field(
+    default_factory=lambda: date(2024, 10, 1)
+  )
+  picked_end_date: date | None = field(
+    default_factory=lambda: date(2024, 11, 1)
+  )
+
+
+@me.page(path="/date_range_picker")
+def app():
+  state = me.state(State)
+  with me.box(
+    style=me.Style(
+      display="flex",
+      flex_direction="column",
+      gap=15,
+      padding=me.Padding.all(15),
+    )
+  ):
+    me.date_range_picker(
+      label="Date Range",
+      disabled=False,
+      placeholder_start_date="9/1/2024",
+      placeholder_end_date="10/1/2024",
+      required=True,
+      value_start_date=state.picked_start_date,
+      value_end_date=state.picked_end_date,
+      readonly=False,
+      hide_required_marker=False,
+      color="accent",
+      float_label="always",
+      appearance="outline",
+      on_change=on_date_range_change,
+    )
+
+    me.text("Start date: " + _render_date(state.picked_start_date))
+    me.text("End date: " + _render_date(state.picked_end_date))
+
+
+def on_date_range_change(e: me.DateRangePickerChangeEvent):
+  state = me.state(State)
+  state.picked_start_date = e.start_date
+  state.picked_end_date = e.end_date
+
+
+def _render_date(maybe_date: date | None) -> str:
+  if maybe_date:
+    return maybe_date.strftime("%Y-%m-%d")
+  return "None"

--- a/demo/date_range_picker.py
+++ b/demo/date_range_picker.py
@@ -14,7 +14,11 @@ class State:
   )
 
 
-@me.page(path="/date_range_picker")
+def on_load(e: me.LoadEvent):
+  me.set_theme_mode("system")
+
+
+@me.page(path="/date_range_picker", on_load=on_load)
 def app():
   state = me.state(State)
   with me.box(

--- a/demo/main.py
+++ b/demo/main.py
@@ -30,6 +30,8 @@ import chat as chat
 import chat_inputs as chat_inputs
 import checkbox as checkbox
 import code_demo as code_demo  # cannot call it code due to python library naming conflict
+import date_picker as date_picker
+import date_range_picker as date_range_picker
 import density as density
 import dialog as dialog
 import divider as divider
@@ -155,6 +157,8 @@ COMPONENTS_SECTIONS = [
       Example(name="autocomplete"),
       Example(name="button"),
       Example(name="checkbox"),
+      Example(name="date_picker"),
+      Example(name="date_range_picker"),
       Example(name="input"),
       Example(name="textarea"),
       Example(name="radio"),

--- a/docs/components/date_picker.md
+++ b/docs/components/date_picker.md
@@ -1,0 +1,17 @@
+## Overview
+
+Date picker allows the user to enter free text or select a date from a calendar widget.
+and is based on the [Angular Material datapicker component](https://material.angular.io/components/datepicker/overview).
+
+## Examples
+
+<iframe class="component-demo" src="https://google.github.io/mesop/demo/?demo=date_picker" style="height: 200px"></iframe>
+
+```python
+--8<-- "demo/date_picker.py"
+```
+
+## API
+
+::: mesop.components.datepicker.datepicker.date_picker
+::: mesop.components.datepicker.datepicker.DatePickerChangeEvent

--- a/docs/components/date_range_picker.md
+++ b/docs/components/date_range_picker.md
@@ -1,0 +1,17 @@
+## Overview
+
+Date range picker allows the user to enter free text or select a dates from a calendar widget.
+and is based on the [Angular Material datapicker component](https://material.angular.io/components/datepicker/overview).
+
+## Examples
+
+<iframe class="component-demo" src="https://google.github.io/mesop/demo/?demo=date_range_picker" style="height: 200px"></iframe>
+
+```python
+--8<-- "demo/date_range_picker.py"
+```
+
+## API
+
+::: mesop.components.datepicker.datepicker.date_range_picker
+::: mesop.components.datepicker.datepicker.DateRangePickerChangeEvent

--- a/docs/components/date_range_picker.md
+++ b/docs/components/date_range_picker.md
@@ -13,5 +13,5 @@ and is based on the [Angular Material datapicker component](https://material.ang
 
 ## API
 
-::: mesop.components.datepicker.datepicker.date_range_picker
-::: mesop.components.datepicker.datepicker.DateRangePickerChangeEvent
+::: mesop.components.date_range_picker.date_range_picker.date_range_picker
+::: mesop.components.date_range_picker.date_range_picker.DateRangePickerChangeEvent

--- a/docs/getting-started/installing.md
+++ b/docs/getting-started/installing.md
@@ -64,6 +64,17 @@ Once you've activated the virtual environment, you will see ".venv" at the start
 pip install mesop
 ```
 
+## Upgrading
+
+To upgrade Mesop, run the following command:
+
+```sh
+pip install --upgrade mesop
+```
+
+If you are using `requirements.txt` or `pyproject.toml` to manage your dependency versions, then you should update those.
+
+
 ## Next steps
 
 Follow the quickstart guide to learn how to create and run a Mesop app:

--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %} {% block announce %} Please
+<a href="/mesop/getting-started/installing/#upgrading">upgrade</a> to the latest
+version of Mesop which addresses an important
+<a
+  href="https://github.com/google/mesop/security/advisories/GHSA-pmv9-3xqp-8w42"
+  >security issue.</a
+>{% endblock %}

--- a/mesop/BUILD
+++ b/mesop/BUILD
@@ -20,6 +20,7 @@ py_library(
     deps = [
         ":version",
         # REF(//scripts/scaffold_component.py):insert_component_import
+        "//mesop/components/date_range_picker:py",
         "//mesop/components/datepicker:py",
         "//mesop/components/autocomplete:py",
         "//mesop/components/link:py",

--- a/mesop/BUILD
+++ b/mesop/BUILD
@@ -20,6 +20,7 @@ py_library(
     deps = [
         ":version",
         # REF(//scripts/scaffold_component.py):insert_component_import
+        "//mesop/components/datepicker:py",
         "//mesop/components/autocomplete:py",
         "//mesop/components/link:py",
         "//mesop/components/html:py",

--- a/mesop/__init__.py
+++ b/mesop/__init__.py
@@ -70,6 +70,16 @@ from mesop.components.checkbox.checkbox import (
   content_checkbox as content_checkbox,
 )
 from mesop.components.code.code import code as code
+from mesop.components.datepicker.datepicker import (
+  DatePickerChangeEvent as DatePickerChangeEvent,
+)
+from mesop.components.datepicker.datepicker import (
+  DateRangePickerChangeEvent as DateRangePickerChangeEvent,
+)
+from mesop.components.datepicker.datepicker import date_picker as date_picker
+from mesop.components.datepicker.datepicker import (
+  date_range_picker as date_range_picker,
+)
 from mesop.components.divider.divider import divider as divider
 from mesop.components.embed.embed import embed as embed
 from mesop.components.html.html import html as html

--- a/mesop/__init__.py
+++ b/mesop/__init__.py
@@ -70,16 +70,16 @@ from mesop.components.checkbox.checkbox import (
   content_checkbox as content_checkbox,
 )
 from mesop.components.code.code import code as code
+from mesop.components.date_range_picker.date_range_picker import (
+  DateRangePickerChangeEvent as DateRangePickerChangeEvent,
+)
+from mesop.components.date_range_picker.date_range_picker import (
+  date_range_picker as date_range_picker,
+)
 from mesop.components.datepicker.datepicker import (
   DatePickerChangeEvent as DatePickerChangeEvent,
 )
-from mesop.components.datepicker.datepicker import (
-  DateRangePickerChangeEvent as DateRangePickerChangeEvent,
-)
 from mesop.components.datepicker.datepicker import date_picker as date_picker
-from mesop.components.datepicker.datepicker import (
-  date_range_picker as date_range_picker,
-)
 from mesop.components.divider.divider import divider as divider
 from mesop.components.embed.embed import embed as embed
 from mesop.components.html.html import html as html

--- a/mesop/components/date_range_picker/BUILD
+++ b/mesop/components/date_range_picker/BUILD
@@ -1,0 +1,9 @@
+load("//mesop/components:defs.bzl", "mesop_component")
+
+package(
+    default_visibility = ["//build_defs:mesop_internal"],
+)
+
+mesop_component(
+    name = "date_range_picker",
+)

--- a/mesop/components/date_range_picker/date_range_picker.ng.html
+++ b/mesop/components/date_range_picker/date_range_picker.ng.html
@@ -1,0 +1,36 @@
+<mat-form-field
+  [hideRequiredMarker]="config().getHideRequiredMarker()!"
+  [color]="getColor()"
+  [floatLabel]="getFloatLabel()"
+  [appearance]="getAppearance()"
+  [subscriptSizing]="getSubscriptSizing()"
+  [style]="getStyle()"
+>
+  <mat-label *ngIf="config().getLabel()">{{config().getLabel()}}</mat-label>
+  <mat-date-range-input
+    [formGroup]="dateRange"
+    [rangePicker]="dp"
+    [required]="config().getRequired()!"
+    [disabled]="config().getDisabled()!"
+  >
+    <input
+      matStartDate
+      formControlName="start"
+      [readonly]="config().getReadonly()!"
+      [placeholder]="config().getPlaceholderStartDate()!"
+      (dateChange)="onChange($event)"
+    />
+    <input
+      matEndDate
+      formControlName="end"
+      [readonly]="config().getReadonly()!"
+      [placeholder]="config().getPlaceholderEndDate()!"
+      (dateChange)="onChange($event)"
+    />
+  </mat-date-range-input>
+  <mat-hint *ngIf="config().getHintLabel()">
+    {{ config().getHintLabel() }}
+  </mat-hint>
+  <mat-datepicker-toggle matIconSuffix [for]="dp"></mat-datepicker-toggle>
+  <mat-date-range-picker #dp></mat-date-range-picker>
+</mat-form-field>

--- a/mesop/components/date_range_picker/date_range_picker.proto
+++ b/mesop/components/date_range_picker/date_range_picker.proto
@@ -1,0 +1,22 @@
+syntax = "proto2";
+
+package mesop.components.date_range_picker;
+
+// Next ID: 16
+message DateRangePickerType {
+  optional string start_date = 1;
+  optional string end_date = 2;
+  optional string placeholder_start_date = 3;
+  optional string placeholder_end_date = 4;
+  optional bool disabled = 5;
+  optional bool required = 6;
+  optional bool readonly = 7;
+  optional bool hide_required_marker = 8;
+  optional string color = 9;
+  optional string float_label = 10;
+  optional string appearance = 11;
+  optional string subscript_sizing = 12;
+  optional string hint_label = 13;
+  optional string label = 14;
+  optional string on_change_handler_id = 15;
+}

--- a/mesop/components/date_range_picker/date_range_picker.py
+++ b/mesop/components/date_range_picker/date_range_picker.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Any, Callable, Literal
 
-import mesop.components.datepicker.datepicker_pb2 as datepicker_pb
+import mesop.components.date_range_picker.date_range_picker_pb2 as date_range_picker_pb
 from mesop.component_helpers import (
   Style,
   insert_component,
@@ -16,39 +16,44 @@ _DATE_FORMAT = "%Y-%m-%d"
 
 
 @dataclass(kw_only=True)
-class DatePickerChangeEvent(MesopEvent):
-  """Represents a date picker change event.
+class DateRangePickerChangeEvent(MesopEvent):
+  """Represents a date range picker change event.
 
-  This event will only fire if a valid date is specified.
+  This event will only fire if start and end dates are valid dates.
 
   Attributes:
-      date: Date value
+      start_date: Start date
+      end_date: End date
       key (str): key of the component that emitted this event.
   """
 
-  date: date
+  start_date: date
+  end_date: date
 
 
 register_event_mapper(
-  DatePickerChangeEvent,
-  lambda userEvent, key: DatePickerChangeEvent(
-    date=_try_make_date(userEvent.string_value),
+  DateRangePickerChangeEvent,
+  lambda userEvent, key: DateRangePickerChangeEvent(
+    start_date=_try_make_date(userEvent.date_range_picker_event.start_date),
+    end_date=_try_make_date(userEvent.date_range_picker_event.end_date),
     key=key.key,
   ),
 )
 
 
 @register_native_component
-def date_picker(
+def date_range_picker(
   *,
   label: str = "",
-  on_change: Callable[[DatePickerChangeEvent], Any] | None = None,
+  on_change: Callable[[DateRangePickerChangeEvent], Any] | None = None,
   appearance: Literal["fill", "outline"] = "fill",
   style: Style | None = None,
   disabled: bool = False,
-  placeholder: str = "",
+  placeholder_start_date: str = "",
+  placeholder_end_date: str = "",
   required: bool = False,
-  value: date | None = None,
+  start_date: date | None = None,
+  end_date: date | None = None,
   readonly: bool = False,
   hide_required_marker: bool = False,
   color: Literal["primary", "accent", "warn"] = "primary",
@@ -57,17 +62,19 @@ def date_picker(
   hint_label: str = "",
   key: str | None = None,
 ):
-  """Creates a date picker component.
+  """Creates a date range picker component.
 
   Args:
-    label: Label for date picker input.
-    on_change: Fires when a valid date value has been specified through Calendar date selection or user input blur.
+    label: Label for date range picker input.
+    on_change: Fires when valid date values for both start/end have been specified through Calendar date selection or user input blur.
     appearance: The form field appearance style.
-    style: Style for date picker input.
+    style: Style for date range picker input.
     disabled: Whether it's disabled.
-    placeholder: Placeholder value.
+    placeholder_start_date: Start date placeholder value.
+    placeholder_end_date: End date placeholder value.
     required: Whether it's required.
-    value: Initial value.
+    start_date: Start date initial value.
+    end_date: End date initial value.
     readonly: Whether the element is readonly.
     hide_required_marker: Whether the required marker should be hidden.
     color: The color palette for the form field.
@@ -79,10 +86,12 @@ def date_picker(
 
   insert_component(
     key=key,
-    type_name="datepicker",
-    proto=datepicker_pb.DatePickerType(
-      value=_try_make_date_str(value),
-      placeholder=placeholder,
+    type_name="date_range_picker",
+    proto=date_range_picker_pb.DateRangePickerType(
+      start_date=_try_make_date_str(start_date),
+      end_date=_try_make_date_str(end_date),
+      placeholder_start_date=placeholder_start_date,
+      placeholder_end_date=placeholder_end_date,
       disabled=disabled,
       required=required,
       readonly=readonly,
@@ -94,7 +103,7 @@ def date_picker(
       hint_label=hint_label,
       label=label,
       on_change_handler_id=register_event_handler(
-        on_change, event=DatePickerChangeEvent
+        on_change, event=DateRangePickerChangeEvent
       )
       if on_change
       else "",

--- a/mesop/components/date_range_picker/date_range_picker.ts
+++ b/mesop/components/date_range_picker/date_range_picker.ts
@@ -1,0 +1,169 @@
+import {
+  MatDatepickerModule,
+  MatDatepickerInputEvent,
+  DateRange,
+} from '@angular/material/datepicker';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {Component, Input} from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import {
+  DateRangePickerEvent,
+  UserEvent,
+  Key,
+  Type,
+  Style,
+} from 'mesop/mesop/protos/ui_jspb_proto_pb/mesop/protos/ui_pb';
+import {DateRangePickerType} from 'mesop/mesop/components/date_range_picker/date_range_picker_jspb_proto_pb/mesop/components/date_range_picker/date_range_picker_pb';
+import {CommonModule} from '@angular/common';
+import {Channel} from '../../web/src/services/channel';
+import {formatStyle} from '../../web/src/utils/styles';
+import {provideNativeDateAdapter} from '@angular/material/core';
+import {debounceTime} from 'rxjs/operators';
+import {Subject} from 'rxjs';
+
+@Component({
+  selector: 'mesop-date-range-picker',
+  templateUrl: 'date_range_picker.ng.html',
+  standalone: true,
+  providers: [provideNativeDateAdapter()],
+  imports: [
+    MatDatepickerModule,
+    MatFormFieldModule,
+    MatInputModule,
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+  ],
+})
+export class DateRangePickerComponent {
+  @Input({required: true}) type!: Type;
+  @Input() key!: Key;
+  @Input() style!: Style;
+  private _config!: DateRangePickerType;
+
+  readonly dateRange = new FormGroup({
+    start: new FormControl(),
+    end: new FormControl(),
+  });
+  private initialStartDate = '';
+  private initialEndDate = '';
+  private dateRangeChangeSubject = new Subject<
+    MatDatepickerInputEvent<string | undefined, DateRange<string | undefined>>
+  >();
+
+  constructor(private readonly channel: Channel) {
+    this.dateRangeChangeSubject
+      .pipe(debounceTime(30))
+      .subscribe((event) => this.onChangeDebounced(event));
+  }
+
+  ngOnChanges() {
+    this._config = DateRangePickerType.deserializeBinary(
+      this.type.getValue() as unknown as Uint8Array,
+    );
+
+    const startDateString = this._config.getStartDate() || '';
+    const endDateString = this._config.getEndDate() || '';
+
+    let dateInputUpdated = false;
+    if (this.initialStartDate !== startDateString) {
+      this.initialStartDate = startDateString;
+      dateInputUpdated = true;
+    }
+    if (this.initialEndDate !== endDateString) {
+      this.initialEndDate = endDateString;
+      this.initialEndDate = endDateString;
+      dateInputUpdated = true;
+    }
+
+    if (dateInputUpdated) {
+      this.dateRange.setValue({
+        start: this.makeDate(startDateString),
+        end: this.makeDate(endDateString),
+      });
+    }
+  }
+
+  onChange(
+    event: MatDatepickerInputEvent<
+      string | undefined,
+      DateRange<string | undefined>
+    >,
+  ): void {
+    this.dateRangeChangeSubject.next(event);
+  }
+
+  // We debounce the date range change event to avoid an issue where two change events
+  // are fired consecutively when resetting the date range.
+  //
+  // If we send both events, this can cause issues if the value parameters are set on
+  // the component. What will happen is the end date will not get reset, which is why
+  // we only want to send the second event.
+  //
+  // The other reason we need debounce is to handle the case where the user edits the
+  // start date directly. On blur, only one event will fire. And we need to send this
+  // event if the end date is also set.
+  onChangeDebounced(
+    event: MatDatepickerInputEvent<
+      string | undefined,
+      DateRange<string | undefined>
+    >,
+  ): void {
+    if (this.dateRange.value.start && this.dateRange.value.end) {
+      const userEvent = new UserEvent();
+      userEvent.setHandlerId(this.config().getOnChangeHandlerId()!);
+      const dateRangeEvent = new DateRangePickerEvent();
+      dateRangeEvent.setStartDate(
+        this.makeDateString(this.dateRange.value.start),
+      );
+      dateRangeEvent.setEndDate(this.makeDateString(this.dateRange.value.end));
+      userEvent.setDateRangePickerEvent(dateRangeEvent);
+      userEvent.setKey(this.key);
+      this.channel.dispatch(userEvent);
+    }
+  }
+
+  private makeDate(dateInput: string): Date | null {
+    if (dateInput) {
+      const [year, month, date] = dateInput.split('-').map((e) => parseInt(e));
+      return new Date(year, month - 1, date);
+    }
+    return null;
+  }
+
+  private makeDateString(date: Date | null): string {
+    return date
+      ? `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
+      : '';
+  }
+
+  config(): DateRangePickerType {
+    return this._config;
+  }
+
+  getStyle(): string {
+    return formatStyle(this.style);
+  }
+
+  getColor(): 'primary' | 'accent' | 'warn' {
+    return this.config().getColor() as 'primary' | 'accent' | 'warn';
+  }
+
+  getFloatLabel(): 'always' | 'auto' {
+    return this.config().getFloatLabel() as 'always' | 'auto';
+  }
+
+  getAppearance(): 'fill' | 'outline' {
+    return this.config().getAppearance() as 'fill' | 'outline';
+  }
+
+  getSubscriptSizing(): 'fixed' | 'dynamic' {
+    return this.config().getSubscriptSizing() as 'fixed' | 'dynamic';
+  }
+}

--- a/mesop/components/date_range_picker/e2e/BUILD
+++ b/mesop/components/date_range_picker/e2e/BUILD
@@ -1,0 +1,13 @@
+load("//build_defs:defaults.bzl", "py_library")
+
+package(
+    default_visibility = ["//build_defs:mesop_examples"],
+)
+
+py_library(
+    name = "e2e",
+    srcs = glob(["*.py"]),
+    deps = [
+        "//mesop",
+    ],
+)

--- a/mesop/components/date_range_picker/e2e/__init__.py
+++ b/mesop/components/date_range_picker/e2e/__init__.py
@@ -1,0 +1,1 @@
+from . import date_range_picker_app as date_range_picker_app

--- a/mesop/components/date_range_picker/e2e/date_range_picker_app.py
+++ b/mesop/components/date_range_picker/e2e/date_range_picker_app.py
@@ -14,7 +14,7 @@ class State:
   )
 
 
-@me.page(path="/date_range_picker")
+@me.page(path="/components/date_range_picker/e2e/datepicker_app")
 def app():
   state = me.state(State)
   with me.box(
@@ -28,8 +28,8 @@ def app():
     me.date_range_picker(
       label="Date Range",
       disabled=False,
-      placeholder_start_date="9/1/2024",
-      placeholder_end_date="10/1/2024",
+      placeholder_start_date="9/12/2024",
+      placeholder_end_date="10/12/2024",
       required=True,
       start_date=state.picked_start_date,
       end_date=state.picked_end_date,

--- a/mesop/components/date_range_picker/e2e/date_range_picker_app.py
+++ b/mesop/components/date_range_picker/e2e/date_range_picker_app.py
@@ -14,7 +14,7 @@ class State:
   )
 
 
-@me.page(path="/components/date_range_picker/e2e/datepicker_app")
+@me.page(path="/components/date_range_picker/e2e/date_range_picker_app")
 def app():
   state = me.state(State)
   with me.box(
@@ -28,8 +28,8 @@ def app():
     me.date_range_picker(
       label="Date Range",
       disabled=False,
-      placeholder_start_date="9/12/2024",
-      placeholder_end_date="10/12/2024",
+      placeholder_start_date="9/1/2024",
+      placeholder_end_date="10/1/2024",
       required=True,
       start_date=state.picked_start_date,
       end_date=state.picked_end_date,

--- a/mesop/components/date_range_picker/e2e/date_range_picker_test.ts
+++ b/mesop/components/date_range_picker/e2e/date_range_picker_test.ts
@@ -1,8 +1,52 @@
 import {test, expect} from '@playwright/test';
 
-test('test', async ({page}) => {
+test('start date input', async ({page}) => {
   await page.goto('/components/date_range_picker/e2e/date_range_picker_app');
-  expect(await page.getByText('Hello, world!').textContent()).toContain(
-    'Hello, world!',
-  );
+
+  // Enter valid start date
+  const startDateInput = page.locator('//input[@placeholder="9/1/2024"]');
+  await startDateInput.click();
+  await startDateInput.fill('9/10/2024');
+  await page.getByText('Start date: ').click();
+  await expect(page.getByText('Start date: 2024-09-10')).toBeVisible();
+
+  // Enter invalid start date
+  await startDateInput.click();
+  await startDateInput.fill('13/10/2024');
+  await page.getByText('Start date: 2024-09-10').click();
+  await expect(page.getByText('Start date: 2024-09-10')).toBeVisible();
+});
+
+test('end date input', async ({page}) => {
+  await page.goto('/components/date_range_picker/e2e/date_range_picker_app');
+
+  // Enter valid end date
+  const endDateInput = page.locator('//input[@placeholder="10/1/2024"]');
+  await endDateInput.click();
+  await endDateInput.fill('12/10/2024');
+  await page.getByText('End date: ').click();
+  await expect(page.getByText('End date: 2024-12-10')).toBeVisible();
+
+  // Enter invalid end date
+  await endDateInput.click();
+  await endDateInput.fill('13/10/2024');
+  await page.getByText('End date: 2024-12-10').click();
+  await expect(page.getByText('End date: 2024-12-10')).toBeVisible();
+});
+
+test('date range picker', async ({page}) => {
+  await page.goto('/components/date_range_picker/e2e/date_range_picker_app');
+
+  await page.locator('//button').click();
+  await page.locator('//button/span[text()=" 15 "]').click();
+
+  // Unchanged until end date is selected.
+  await expect(page.getByText('Start date: 2024-10-01')).toBeVisible();
+  await expect(page.getByText('End date: 2024-11-01')).toBeVisible();
+
+  await page.locator('//button/span[text()=" 28 "]').click();
+
+  // Updated after end date selected.
+  await expect(page.getByText('Start date: 2024-10-15')).toBeVisible();
+  await expect(page.getByText('End date: 2024-10-28')).toBeVisible();
 });

--- a/mesop/components/date_range_picker/e2e/date_range_picker_test.ts
+++ b/mesop/components/date_range_picker/e2e/date_range_picker_test.ts
@@ -1,0 +1,8 @@
+import {test, expect} from '@playwright/test';
+
+test('test', async ({page}) => {
+  await page.goto('/components/date_range_picker/e2e/date_range_picker_app');
+  expect(await page.getByText('Hello, world!').textContent()).toContain(
+    'Hello, world!',
+  );
+});

--- a/mesop/components/date_range_picker/e2e/date_range_picker_test.ts
+++ b/mesop/components/date_range_picker/e2e/date_range_picker_test.ts
@@ -37,7 +37,7 @@ test('end date input', async ({page}) => {
 test('date range picker', async ({page}) => {
   await page.goto('/components/date_range_picker/e2e/date_range_picker_app');
 
-  await page.locator('//button').click();
+  await page.getByLabel('Open calendar').click();
   await page.locator('//button/span[text()=" 15 "]').click();
 
   // Unchanged until end date is selected.

--- a/mesop/components/datepicker/BUILD
+++ b/mesop/components/datepicker/BUILD
@@ -1,0 +1,9 @@
+load("//mesop/components:defs.bzl", "mesop_component")
+
+package(
+    default_visibility = ["//build_defs:mesop_internal"],
+)
+
+mesop_component(
+    name = "datepicker",
+)

--- a/mesop/components/datepicker/datepicker.ng.html
+++ b/mesop/components/datepicker/datepicker.ng.html
@@ -1,41 +1,3 @@
-@if(config().getIsDateRange()) {
-<mat-form-field
-  [hideRequiredMarker]="config().getHideRequiredMarker()!"
-  [color]="getColor()"
-  [floatLabel]="getFloatLabel()"
-  [appearance]="getAppearance()"
-  [subscriptSizing]="getSubscriptSizing()"
-  [style]="getStyle()"
->
-  <mat-label *ngIf="config().getLabel()">{{config().getLabel()}}</mat-label>
-  <mat-date-range-input
-    [formGroup]="dateRange"
-    [rangePicker]="picker"
-    [required]="config().getRequired()!"
-    [disabled]="config().getDisabled()!"
-  >
-    <input
-      matStartDate
-      formControlName="start"
-      [readonly]="config().getReadonly()!"
-      [placeholder]="config().getPlaceholder1()!"
-      (dateChange)="onDateRangeChange($event)"
-    />
-    <input
-      matEndDate
-      formControlName="end"
-      [readonly]="config().getReadonly()!"
-      [placeholder]="config().getPlaceholder2()!"
-      (dateChange)="onDateRangeChange($event)"
-    />
-  </mat-date-range-input>
-  <mat-hint *ngIf="config().getHintLabel()">
-    {{ config().getHintLabel() }}
-  </mat-hint>
-  <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
-  <mat-date-range-picker #picker></mat-date-range-picker>
-</mat-form-field>
-} @else {
 <mat-form-field
   [hideRequiredMarker]="config().getHideRequiredMarker()"
   [color]="getColor()"
@@ -48,11 +10,11 @@
     matInput
     [matDatepicker]="dp"
     [disabled]="config().getDisabled()!"
-    [placeholder]="config().getPlaceholder1()!"
+    [placeholder]="config().getPlaceholder()!"
     [required]="config().getRequired()!"
     [formControl]="date"
     [readonly]="config().getReadonly()!"
-    (dateChange)="onDateChange($event)"
+    (dateChange)="onChange($event)"
   />
   <mat-hint *ngIf="config().getHintLabel()">
     {{ config().getHintLabel() }}
@@ -60,4 +22,3 @@
   <mat-datepicker-toggle matIconSuffix [for]="dp"></mat-datepicker-toggle>
   <mat-datepicker #dp></mat-datepicker>
 </mat-form-field>
-}

--- a/mesop/components/datepicker/datepicker.ng.html
+++ b/mesop/components/datepicker/datepicker.ng.html
@@ -1,0 +1,63 @@
+@if(config().getIsDateRange()) {
+<mat-form-field
+  [hideRequiredMarker]="config().getHideRequiredMarker()!"
+  [color]="getColor()"
+  [floatLabel]="getFloatLabel()"
+  [appearance]="getAppearance()"
+  [subscriptSizing]="getSubscriptSizing()"
+  [style]="getStyle()"
+>
+  <mat-label *ngIf="config().getLabel()">{{config().getLabel()}}</mat-label>
+  <mat-date-range-input
+    [formGroup]="dateRange"
+    [rangePicker]="picker"
+    [required]="config().getRequired()!"
+    [disabled]="config().getDisabled()!"
+  >
+    <input
+      matStartDate
+      formControlName="start"
+      [readonly]="config().getReadonly()!"
+      [placeholder]="config().getPlaceholder1()!"
+      (dateChange)="onDateRangeChange($event)"
+    />
+    <input
+      matEndDate
+      formControlName="end"
+      [readonly]="config().getReadonly()!"
+      [placeholder]="config().getPlaceholder2()!"
+      (dateChange)="onDateRangeChange($event)"
+    />
+  </mat-date-range-input>
+  <mat-hint *ngIf="config().getHintLabel()">
+    {{ config().getHintLabel() }}
+  </mat-hint>
+  <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+  <mat-date-range-picker #picker></mat-date-range-picker>
+</mat-form-field>
+} @else {
+<mat-form-field
+  [hideRequiredMarker]="config().getHideRequiredMarker()"
+  [color]="getColor()"
+  [floatLabel]="getFloatLabel()"
+  [appearance]="getAppearance()"
+  [subscriptSizing]="getSubscriptSizing()"
+  [style]="getStyle()"
+  ><mat-label *ngIf="config().getLabel()">{{config().getLabel()}}</mat-label>
+  <input
+    matInput
+    [matDatepicker]="dp"
+    [disabled]="config().getDisabled()!"
+    [placeholder]="config().getPlaceholder1()!"
+    [required]="config().getRequired()!"
+    [formControl]="date"
+    [readonly]="config().getReadonly()!"
+    (dateChange)="onDateChange($event)"
+  />
+  <mat-hint *ngIf="config().getHintLabel()">
+    {{ config().getHintLabel() }}
+  </mat-hint>
+  <mat-datepicker-toggle matIconSuffix [for]="dp"></mat-datepicker-toggle>
+  <mat-datepicker #dp></mat-datepicker>
+</mat-form-field>
+}

--- a/mesop/components/datepicker/datepicker.proto
+++ b/mesop/components/datepicker/datepicker.proto
@@ -2,10 +2,10 @@ syntax = "proto2";
 
 package mesop.components.datepicker;
 
-// Next ID: 17
-message DatepickerType {
-  optional string value1 = 1;
-  optional string placeholder1 = 2;
+// Next ID: 14
+message DatePickerType {
+  optional string value = 1;
+  optional string placeholder = 2;
   optional bool disabled = 3;
   optional bool required = 4;
   optional bool readonly = 5;
@@ -17,9 +17,4 @@ message DatepickerType {
   optional string hint_label = 11;
   optional string label = 12;
   optional string on_change_handler_id = 13;
-  // Used for date range picker only.
-  optional string placeholder2 = 14;
-  optional string value2 = 15;
-  // Not exposed as public API.
-  optional bool is_date_range = 16;
 }

--- a/mesop/components/datepicker/datepicker.proto
+++ b/mesop/components/datepicker/datepicker.proto
@@ -1,0 +1,25 @@
+syntax = "proto2";
+
+package mesop.components.datepicker;
+
+// Next ID: 17
+message DatepickerType {
+  optional string value1 = 1;
+  optional string placeholder1 = 2;
+  optional bool disabled = 3;
+  optional bool required = 4;
+  optional bool readonly = 5;
+  optional bool hide_required_marker = 6;
+  optional string color = 7;
+  optional string float_label = 8;
+  optional string appearance = 9;
+  optional string subscript_sizing = 10;
+  optional string hint_label = 11;
+  optional string label = 12;
+  optional string on_change_handler_id = 13;
+  // Used for date range picker only.
+  optional string placeholder2 = 14;
+  optional string value2 = 15;
+  // Not exposed as public API.
+  optional bool is_date_range = 16;
+}

--- a/mesop/components/datepicker/datepicker.py
+++ b/mesop/components/datepicker/datepicker.py
@@ -1,0 +1,211 @@
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Callable, Literal
+
+import mesop.components.datepicker.datepicker_pb2 as datepicker_pb
+from mesop.component_helpers import (
+  Style,
+  insert_component,
+  register_event_handler,
+  register_event_mapper,
+  register_native_component,
+)
+from mesop.events import MesopEvent
+
+_DATE_FORMAT = "%Y-%m-%d"
+
+
+@dataclass(kw_only=True)
+class DatePickerChangeEvent(MesopEvent):
+  """Represents a date picker change event.
+
+  This event will only fire if a valid date was specified.
+
+  Attributes:
+      date: Date value
+      key (str): key of the component that emitted this event.
+  """
+
+  date: date
+
+
+register_event_mapper(
+  DatePickerChangeEvent,
+  lambda userEvent, key: DatePickerChangeEvent(
+    date=_try_make_date(userEvent.string_value),
+    key=key.key,
+  ),
+)
+
+
+@dataclass(kw_only=True)
+class DateRangePickerChangeEvent(MesopEvent):
+  """Represents a date range picker change event.
+
+  This event will only fire if start and ends dates are valid dates.
+
+  Attributes:
+      start_date: Start date
+      end_date: End date
+      key (str): key of the component that emitted this event.
+  """
+
+  start_date: date
+  end_date: date
+
+
+register_event_mapper(
+  DateRangePickerChangeEvent,
+  lambda userEvent, key: DateRangePickerChangeEvent(
+    start_date=_try_make_date(userEvent.date_range_picker_event.start_date),
+    end_date=_try_make_date(userEvent.date_range_picker_event.end_date),
+    key=key.key,
+  ),
+)
+
+
+@register_native_component
+def date_picker(
+  *,
+  label: str = "",
+  on_change: Callable[[DatePickerChangeEvent], Any] | None = None,
+  appearance: Literal["fill", "outline"] = "fill",
+  style: Style | None = None,
+  disabled: bool = False,
+  placeholder: str = "",
+  required: bool = False,
+  value: date | None = None,
+  readonly: bool = False,
+  hide_required_marker: bool = False,
+  color: Literal["primary", "accent", "warn"] = "primary",
+  float_label: Literal["always", "auto"] = "auto",
+  subscript_sizing: Literal["fixed", "dynamic"] = "fixed",
+  hint_label: str = "",
+  key: str | None = None,
+):
+  """Creates a date picker component.
+
+  Args:
+    label: Label for datepicker input.
+    on_change: Fires when a valid date value has been specified through Calendar date selection or user input blur.
+    appearance: The form field appearance style.
+    style: Style for datepicker input.
+    disabled: Whether it's disabled.
+    placeholder: Placeholder value.
+    required: Whether it's required.
+    value: Initial value.
+    readonly: Whether the element is readonly.
+    hide_required_marker: Whether the required marker should be hidden.
+    color: The color palette for the form field.
+    float_label: Whether the label should always float or float as the user types.
+    subscript_sizing: Whether the form field should reserve space for one line of hint/error text (default) or to have the spacing grow from 0px as needed based on the size of the hint/error content. Note that when using dynamic sizing, layout shifts will occur when hint/error text changes.
+    hint_label: Text for the form field hint.
+    key: The component [key](../components/index.md#component-key).
+  """
+
+  insert_component(
+    key=key,
+    type_name="datepicker",
+    proto=datepicker_pb.DatepickerType(
+      value1=_try_make_date_str(value),
+      placeholder1=placeholder,
+      disabled=disabled,
+      required=required,
+      readonly=readonly,
+      hide_required_marker=hide_required_marker,
+      color=color,
+      float_label=float_label,
+      appearance=appearance,
+      subscript_sizing=subscript_sizing,
+      hint_label=hint_label,
+      label=label,
+      on_change_handler_id=register_event_handler(
+        on_change, event=DatePickerChangeEvent
+      )
+      if on_change
+      else "",
+    ),
+    style=style,
+  )
+
+
+@register_native_component
+def date_range_picker(
+  *,
+  label: str = "",
+  on_change: Callable[[DateRangePickerChangeEvent], Any] | None = None,
+  appearance: Literal["fill", "outline"] = "fill",
+  style: Style | None = None,
+  disabled: bool = False,
+  placeholder_start_date: str = "",
+  placeholder_end_date: str = "",
+  required: bool = False,
+  value_start_date: date | None = None,
+  value_end_date: date | None = None,
+  readonly: bool = False,
+  hide_required_marker: bool = False,
+  color: Literal["primary", "accent", "warn"] = "primary",
+  float_label: Literal["always", "auto"] = "auto",
+  subscript_sizing: Literal["fixed", "dynamic"] = "fixed",
+  hint_label: str = "",
+  key: str | None = None,
+):
+  """Creates a date range picker component.
+
+  Args:
+    label: Label for datepicker input.
+    on_change: Fires when valid date values for both start/end have been specified through Calendar date selection or user input blur.
+    appearance: The form field appearance style.
+    style: Style for datepicker input.
+    disabled: Whether it's disabled.
+    placeholder_start_date: Start date placeholder value.
+    placeholder_end_date: End date placeholder value.
+    required: Whether it's required.
+    value_start_date: Start date initial value.
+    value_end_date: End date initial value.
+    readonly: Whether the element is readonly.
+    hide_required_marker: Whether the required marker should be hidden.
+    color: The color palette for the form field.
+    float_label: Whether the label should always float or float as the user types.
+    subscript_sizing: Whether the form field should reserve space for one line of hint/error text (default) or to have the spacing grow from 0px as needed based on the size of the hint/error content. Note that when using dynamic sizing, layout shifts will occur when hint/error text changes.
+    hint_label: Text for the form field hint.
+    key: The component [key](../components/index.md#component-key).
+  """
+
+  insert_component(
+    key=key,
+    type_name="datepicker",
+    proto=datepicker_pb.DatepickerType(
+      is_date_range=True,
+      value1=_try_make_date_str(value_start_date),
+      value2=_try_make_date_str(value_end_date),
+      placeholder1=placeholder_start_date,
+      placeholder2=placeholder_end_date,
+      disabled=disabled,
+      required=required,
+      readonly=readonly,
+      hide_required_marker=hide_required_marker,
+      color=color,
+      float_label=float_label,
+      appearance=appearance,
+      subscript_sizing=subscript_sizing,
+      hint_label=hint_label,
+      label=label,
+      on_change_handler_id=register_event_handler(
+        on_change, event=DateRangePickerChangeEvent
+      )
+      if on_change
+      else "",
+    ),
+    style=style,
+  )
+
+
+def _try_make_date_str(date_input: date | None) -> str:
+  if date_input:
+    return date_input.isoformat()
+  return ""
+
+
+def _try_make_date(date_string: str) -> date:
+  return datetime.strptime(date_string, _DATE_FORMAT).date()

--- a/mesop/components/datepicker/datepicker.py
+++ b/mesop/components/datepicker/datepicker.py
@@ -19,7 +19,7 @@ _DATE_FORMAT = "%Y-%m-%d"
 class DatePickerChangeEvent(MesopEvent):
   """Represents a date picker change event.
 
-  This event will only fire if a valid date was specified.
+  This event will only fire if a valid date is specified.
 
   Attributes:
       date: Date value
@@ -42,7 +42,7 @@ register_event_mapper(
 class DateRangePickerChangeEvent(MesopEvent):
   """Represents a date range picker change event.
 
-  This event will only fire if start and ends dates are valid dates.
+  This event will only fire if start and end dates are valid dates.
 
   Attributes:
       start_date: Start date
@@ -86,10 +86,10 @@ def date_picker(
   """Creates a date picker component.
 
   Args:
-    label: Label for datepicker input.
+    label: Label for date picker input.
     on_change: Fires when a valid date value has been specified through Calendar date selection or user input blur.
     appearance: The form field appearance style.
-    style: Style for datepicker input.
+    style: Style for date picker input.
     disabled: Whether it's disabled.
     placeholder: Placeholder value.
     required: Whether it's required.
@@ -153,10 +153,10 @@ def date_range_picker(
   """Creates a date range picker component.
 
   Args:
-    label: Label for datepicker input.
+    label: Label for date range picker input.
     on_change: Fires when valid date values for both start/end have been specified through Calendar date selection or user input blur.
     appearance: The form field appearance style.
-    style: Style for datepicker input.
+    style: Style for date range picker input.
     disabled: Whether it's disabled.
     placeholder_start_date: Start date placeholder value.
     placeholder_end_date: End date placeholder value.

--- a/mesop/components/datepicker/datepicker.ts
+++ b/mesop/components/datepicker/datepicker.ts
@@ -1,31 +1,22 @@
 import {
   MatDatepickerModule,
   MatDatepickerInputEvent,
-  DateRange,
 } from '@angular/material/datepicker';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {Component, Input} from '@angular/core';
+import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {
-  FormControl,
-  FormGroup,
-  FormsModule,
-  ReactiveFormsModule,
-} from '@angular/forms';
-import {
-  DateRangePickerEvent,
   UserEvent,
   Key,
   Type,
   Style,
 } from 'mesop/mesop/protos/ui_jspb_proto_pb/mesop/protos/ui_pb';
-import {DatepickerType} from 'mesop/mesop/components/datepicker/datepicker_jspb_proto_pb/mesop/components/datepicker/datepicker_pb';
+import {DatePickerType} from 'mesop/mesop/components/datepicker/datepicker_jspb_proto_pb/mesop/components/datepicker/datepicker_pb';
 import {CommonModule} from '@angular/common';
 import {Channel} from '../../web/src/services/channel';
 import {formatStyle} from '../../web/src/utils/styles';
 import {provideNativeDateAdapter} from '@angular/material/core';
-import {debounceTime} from 'rxjs/operators';
-import {Subject} from 'rxjs';
 
 @Component({
   selector: 'mesop-datepicker',
@@ -45,66 +36,26 @@ export class DatepickerComponent {
   @Input({required: true}) type!: Type;
   @Input() key!: Key;
   @Input() style!: Style;
-  private _config!: DatepickerType;
+  private _config!: DatePickerType;
 
-  // Date picker specific
   readonly date = new FormControl();
   private initialDate = '';
-  // Date Range specific
-  readonly dateRange = new FormGroup({
-    start: new FormControl(),
-    end: new FormControl(),
-  });
-  private initialStartDate = '';
-  private initialEndDate = '';
-  private dateRangeChangeSubject = new Subject<
-    MatDatepickerInputEvent<string | undefined, DateRange<string | undefined>>
-  >();
 
-  constructor(private readonly channel: Channel) {
-    this.dateRangeChangeSubject
-      .pipe(debounceTime(30))
-      .subscribe((event) => this.onDateRangeChangeDebounced(event));
-  }
+  constructor(private readonly channel: Channel) {}
 
   ngOnChanges() {
-    this._config = DatepickerType.deserializeBinary(
+    this._config = DatePickerType.deserializeBinary(
       this.type.getValue() as unknown as Uint8Array,
     );
 
-    // Override date range inputs if set.
-    if (this._config.getIsDateRange()) {
-      const startDateString = this._config.getValue1() || '';
-      const endDateString = this._config.getValue2() || '';
-
-      let dateInputUpdated = false;
-      if (this.initialStartDate !== startDateString) {
-        this.initialStartDate = startDateString;
-        dateInputUpdated = true;
-      }
-      if (this.initialEndDate !== endDateString) {
-        this.initialEndDate = endDateString;
-        this.initialEndDate = endDateString;
-        dateInputUpdated = true;
-      }
-
-      if (dateInputUpdated) {
-        this.dateRange.setValue({
-          start: this.makeDate(startDateString),
-          end: this.makeDate(endDateString),
-        });
-      }
-    } else {
-      const initialDate = this._config.getValue1() || '';
-      if (this.initialDate !== initialDate) {
-        this.initialDate = initialDate;
-        this.date.setValue(this.makeDate(initialDate));
-      }
+    const initialDate = this._config.getValue() || '';
+    if (this.initialDate !== initialDate) {
+      this.initialDate = initialDate;
+      this.date.setValue(this.makeDate(initialDate));
     }
   }
 
-  // For Date picker
-  onDateChange(event: MatDatepickerInputEvent<Date>): void {
+  onChange(event: MatDatepickerInputEvent<Date>): void {
     if (this.date.value) {
       const userEvent = new UserEvent();
       userEvent.setHandlerId(this.config().getOnChangeHandlerId()!);
@@ -114,49 +65,9 @@ export class DatepickerComponent {
     }
   }
 
-  // For Date range picker
-  onDateRangeChange(
-    event: MatDatepickerInputEvent<
-      string | undefined,
-      DateRange<string | undefined>
-    >,
-  ): void {
-    this.dateRangeChangeSubject.next(event);
-  }
-
-  // We debounce the date range change event to avoid an issue where two change events
-  // are fired consecutively when resetting the date range.
-  //
-  // If we send both events, this can cause issues if the value parameters are set on
-  // the component. What will happen is the end date will not get reset, which is why
-  // we only want to send the second event.
-  //
-  // The other reason we need debounce is to handle the case where the user edits the
-  // start date directly. On blur, only one event will fire. And we need to send this
-  // event if the end date is also set.
-  onDateRangeChangeDebounced(
-    event: MatDatepickerInputEvent<
-      string | undefined,
-      DateRange<string | undefined>
-    >,
-  ): void {
-    if (this.dateRange.value.start && this.dateRange.value.end) {
-      const userEvent = new UserEvent();
-      userEvent.setHandlerId(this.config().getOnChangeHandlerId()!);
-      const dateRangeEvent = new DateRangePickerEvent();
-      dateRangeEvent.setStartDate(
-        this.makeDateString(this.dateRange.value.start),
-      );
-      dateRangeEvent.setEndDate(this.makeDateString(this.dateRange.value.end));
-      userEvent.setDateRangePickerEvent(dateRangeEvent);
-      userEvent.setKey(this.key);
-      this.channel.dispatch(userEvent);
-    }
-  }
-
-  private makeDate(date_input: string): Date | null {
-    if (date_input) {
-      const [year, month, date] = date_input.split('-').map((e) => parseInt(e));
+  private makeDate(dateInput: string): Date | null {
+    if (dateInput) {
+      const [year, month, date] = dateInput.split('-').map((e) => parseInt(e));
       return new Date(year, month - 1, date);
     }
     return null;
@@ -168,7 +79,7 @@ export class DatepickerComponent {
       : '';
   }
 
-  config(): DatepickerType {
+  config(): DatePickerType {
     return this._config;
   }
 

--- a/mesop/components/datepicker/datepicker.ts
+++ b/mesop/components/datepicker/datepicker.ts
@@ -1,0 +1,194 @@
+import {
+  MatDatepickerModule,
+  MatDatepickerInputEvent,
+  DateRange,
+} from '@angular/material/datepicker';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {Component, Input} from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import {
+  DateRangePickerEvent,
+  UserEvent,
+  Key,
+  Type,
+  Style,
+} from 'mesop/mesop/protos/ui_jspb_proto_pb/mesop/protos/ui_pb';
+import {DatepickerType} from 'mesop/mesop/components/datepicker/datepicker_jspb_proto_pb/mesop/components/datepicker/datepicker_pb';
+import {CommonModule} from '@angular/common';
+import {Channel} from '../../web/src/services/channel';
+import {formatStyle} from '../../web/src/utils/styles';
+import {provideNativeDateAdapter} from '@angular/material/core';
+import {debounceTime} from 'rxjs/operators';
+import {Subject} from 'rxjs';
+
+@Component({
+  selector: 'mesop-datepicker',
+  templateUrl: 'datepicker.ng.html',
+  standalone: true,
+  providers: [provideNativeDateAdapter()],
+  imports: [
+    MatDatepickerModule,
+    MatFormFieldModule,
+    MatInputModule,
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+  ],
+})
+export class DatepickerComponent {
+  @Input({required: true}) type!: Type;
+  @Input() key!: Key;
+  @Input() style!: Style;
+  private _config!: DatepickerType;
+
+  // Date picker specific
+  readonly date = new FormControl();
+  private initialDate = '';
+  // Date Range specific
+  readonly dateRange = new FormGroup({
+    start: new FormControl(),
+    end: new FormControl(),
+  });
+  private initialStartDate = '';
+  private initialEndDate = '';
+  private dateRangeChangeSubject = new Subject<
+    MatDatepickerInputEvent<string | undefined, DateRange<string | undefined>>
+  >();
+
+  constructor(private readonly channel: Channel) {
+    this.dateRangeChangeSubject
+      .pipe(debounceTime(30))
+      .subscribe((event) => this.onDateRangeChangeDebounced(event));
+  }
+
+  ngOnChanges() {
+    this._config = DatepickerType.deserializeBinary(
+      this.type.getValue() as unknown as Uint8Array,
+    );
+
+    // Override date range inputs if set.
+    if (this._config.getIsDateRange()) {
+      const startDateString = this._config.getValue1() || '';
+      const endDateString = this._config.getValue2() || '';
+
+      let dateInputUpdated = false;
+      if (this.initialStartDate !== startDateString) {
+        this.initialStartDate = startDateString;
+        dateInputUpdated = true;
+      }
+      if (this.initialEndDate !== endDateString) {
+        this.initialEndDate = endDateString;
+        this.initialEndDate = endDateString;
+        dateInputUpdated = true;
+      }
+
+      if (dateInputUpdated) {
+        this.dateRange.setValue({
+          start: this.makeDate(startDateString),
+          end: this.makeDate(endDateString),
+        });
+      }
+    } else {
+      const initialDate = this._config.getValue1() || '';
+      if (this.initialDate !== initialDate) {
+        this.initialDate = initialDate;
+        this.date.setValue(this.makeDate(initialDate));
+      }
+    }
+  }
+
+  // For Date picker
+  onDateChange(event: MatDatepickerInputEvent<Date>): void {
+    if (this.date.value) {
+      const userEvent = new UserEvent();
+      userEvent.setHandlerId(this.config().getOnChangeHandlerId()!);
+      userEvent.setStringValue(this.makeDateString(this.date.value));
+      userEvent.setKey(this.key);
+      this.channel.dispatch(userEvent);
+    }
+  }
+
+  // For Date range picker
+  onDateRangeChange(
+    event: MatDatepickerInputEvent<
+      string | undefined,
+      DateRange<string | undefined>
+    >,
+  ): void {
+    this.dateRangeChangeSubject.next(event);
+  }
+
+  // We debounce the date range change event to avoid an issue where two change events
+  // are fired consecutively when resetting the date range.
+  //
+  // If we send both events, this can cause issues if the value parameters are set on
+  // the component. What will happen is the end date will not get reset, which is why
+  // we only want to send the second event.
+  //
+  // The other reason we need debounce is to handle the case where the user edits the
+  // start date directly. On blur, only one event will fire. And we need to send this
+  // event if the end date is also set.
+  onDateRangeChangeDebounced(
+    event: MatDatepickerInputEvent<
+      string | undefined,
+      DateRange<string | undefined>
+    >,
+  ): void {
+    if (this.dateRange.value.start && this.dateRange.value.end) {
+      const userEvent = new UserEvent();
+      userEvent.setHandlerId(this.config().getOnChangeHandlerId()!);
+      const dateRangeEvent = new DateRangePickerEvent();
+      dateRangeEvent.setStartDate(
+        this.makeDateString(this.dateRange.value.start),
+      );
+      dateRangeEvent.setEndDate(this.makeDateString(this.dateRange.value.end));
+      userEvent.setDateRangePickerEvent(dateRangeEvent);
+      userEvent.setKey(this.key);
+      this.channel.dispatch(userEvent);
+    }
+  }
+
+  private makeDate(date_input: string): Date | null {
+    if (date_input) {
+      const [year, month, date] = date_input.split('-').map((e) => parseInt(e));
+      return new Date(year, month - 1, date);
+    }
+    return null;
+  }
+
+  private makeDateString(date: Date | null): string {
+    return date
+      ? `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
+      : '';
+  }
+
+  config(): DatepickerType {
+    return this._config;
+  }
+
+  getStyle(): string {
+    return formatStyle(this.style);
+  }
+
+  getColor(): 'primary' | 'accent' | 'warn' {
+    return this.config().getColor() as 'primary' | 'accent' | 'warn';
+  }
+
+  getFloatLabel(): 'always' | 'auto' {
+    return this.config().getFloatLabel() as 'always' | 'auto';
+  }
+
+  getAppearance(): 'fill' | 'outline' {
+    return this.config().getAppearance() as 'fill' | 'outline';
+  }
+
+  getSubscriptSizing(): 'fixed' | 'dynamic' {
+    return this.config().getSubscriptSizing() as 'fixed' | 'dynamic';
+  }
+}

--- a/mesop/components/datepicker/e2e/BUILD
+++ b/mesop/components/datepicker/e2e/BUILD
@@ -1,0 +1,13 @@
+load("//build_defs:defaults.bzl", "py_library")
+
+package(
+    default_visibility = ["//build_defs:mesop_examples"],
+)
+
+py_library(
+    name = "e2e",
+    srcs = glob(["*.py"]),
+    deps = [
+        "//mesop",
+    ],
+)

--- a/mesop/components/datepicker/e2e/__init__.py
+++ b/mesop/components/datepicker/e2e/__init__.py
@@ -1,0 +1,1 @@
+from . import datepicker_app as datepicker_app

--- a/mesop/components/datepicker/e2e/datepicker_app.py
+++ b/mesop/components/datepicker/e2e/datepicker_app.py
@@ -7,12 +7,6 @@ import mesop as me
 @me.stateclass
 class State:
   picked_date: date | None = field(default_factory=lambda: date(2024, 10, 1))
-  picked_start_date: date | None = field(
-    default_factory=lambda: date(2024, 10, 1)
-  )
-  picked_end_date: date | None = field(
-    default_factory=lambda: date(2024, 11, 1)
-  )
 
 
 @me.page(path="/components/datepicker/e2e/datepicker_app")
@@ -42,37 +36,10 @@ def app():
 
     me.text("Selected date: " + _render_date(state.picked_date))
 
-    me.divider()
-
-    me.date_range_picker(
-      label="Date Range",
-      disabled=False,
-      placeholder_start_date="9/12/2024",
-      placeholder_end_date="10/12/2024",
-      required=True,
-      value_start_date=state.picked_start_date,
-      value_end_date=state.picked_end_date,
-      readonly=False,
-      hide_required_marker=False,
-      color="accent",
-      float_label="always",
-      appearance="outline",
-      on_change=on_date_range_change,
-    )
-
-    me.text("Start date: " + _render_date(state.picked_start_date))
-    me.text("End date: " + _render_date(state.picked_end_date))
-
 
 def on_date_change(e: me.DatePickerChangeEvent):
   state = me.state(State)
   state.picked_date = e.date
-
-
-def on_date_range_change(e: me.DateRangePickerChangeEvent):
-  state = me.state(State)
-  state.picked_start_date = e.start_date
-  state.picked_end_date = e.end_date
 
 
 def _render_date(maybe_date: date | None) -> str:

--- a/mesop/components/datepicker/e2e/datepicker_app.py
+++ b/mesop/components/datepicker/e2e/datepicker_app.py
@@ -1,0 +1,81 @@
+from dataclasses import field
+from datetime import date
+
+import mesop as me
+
+
+@me.stateclass
+class State:
+  picked_date: date | None = field(default_factory=lambda: date(2024, 10, 1))
+  picked_start_date: date | None = field(
+    default_factory=lambda: date(2024, 10, 1)
+  )
+  picked_end_date: date | None = field(
+    default_factory=lambda: date(2024, 11, 1)
+  )
+
+
+@me.page(path="/components/datepicker/e2e/datepicker_app")
+def app():
+  state = me.state(State)
+  with me.box(
+    style=me.Style(
+      display="flex",
+      flex_direction="column",
+      gap=15,
+      padding=me.Padding.all(15),
+    )
+  ):
+    me.date_picker(
+      label="Date",
+      disabled=False,
+      placeholder="9/12/2024",
+      required=True,
+      value=state.picked_date,
+      readonly=False,
+      hide_required_marker=False,
+      color="accent",
+      float_label="always",
+      appearance="outline",
+      on_change=on_date_change,
+    )
+
+    me.text("Selected date: " + _render_date(state.picked_date))
+
+    me.divider()
+
+    me.date_range_picker(
+      label="Date Range",
+      disabled=False,
+      placeholder_start_date="9/12/2024",
+      placeholder_end_date="10/12/2024",
+      required=True,
+      value_start_date=state.picked_start_date,
+      value_end_date=state.picked_end_date,
+      readonly=False,
+      hide_required_marker=False,
+      color="accent",
+      float_label="always",
+      appearance="outline",
+      on_change=on_date_range_change,
+    )
+
+    me.text("Start date: " + _render_date(state.picked_start_date))
+    me.text("End date: " + _render_date(state.picked_end_date))
+
+
+def on_date_change(e: me.DatePickerChangeEvent):
+  state = me.state(State)
+  state.picked_date = e.date
+
+
+def on_date_range_change(e: me.DateRangePickerChangeEvent):
+  state = me.state(State)
+  state.picked_start_date = e.start_date
+  state.picked_end_date = e.end_date
+
+
+def _render_date(maybe_date: date | None) -> str:
+  if maybe_date:
+    return maybe_date.strftime("%Y-%m-%d")
+  return "None"

--- a/mesop/components/datepicker/e2e/datepicker_test.ts
+++ b/mesop/components/datepicker/e2e/datepicker_test.ts
@@ -16,7 +16,7 @@ test('date picker', async ({page}) => {
   await expect(page.getByText('Selected date: 2024-09-10')).toBeVisible();
 
   // Pick date from calendar
-  await page.locator('//button').click();
+  await page.getByLabel('Open calendar').click();
   await page.locator('//button/span[text()=" 15 "]').click();
   await expect(page.getByText('Selected date: 2024-09-15')).toBeVisible();
 });

--- a/mesop/components/datepicker/e2e/datepicker_test.ts
+++ b/mesop/components/datepicker/e2e/datepicker_test.ts
@@ -2,8 +2,21 @@ import {test, expect} from '@playwright/test';
 
 test('date picker', async ({page}) => {
   await page.goto('/components/datepicker/e2e/datepicker_app');
-  await page.locator('//input').nth(0).click();
-  await page.locator('//input').nth(0).fill('9/10/2024');
-  await page.locator('//input').nth(1).click();
+
+  // Enter valid date
+  await page.locator('//input').click();
+  await page.locator('//input').fill('9/10/2024');
+  await page.getByText('Selected date: ').click();
   await expect(page.getByText('Selected date: 2024-09-10')).toBeVisible();
+
+  // Enter invalid date
+  await page.locator('//input').click();
+  await page.locator('//input').fill('13/10/2024');
+  await page.getByText('Selected date: 2024-09-10').click();
+  await expect(page.getByText('Selected date: 2024-09-10')).toBeVisible();
+
+  // Pick date from calendar
+  await page.locator('//button').click();
+  await page.locator('//button/span[text()=" 15 "]').click();
+  await expect(page.getByText('Selected date: 2024-09-15')).toBeVisible();
 });

--- a/mesop/components/datepicker/e2e/datepicker_test.ts
+++ b/mesop/components/datepicker/e2e/datepicker_test.ts
@@ -1,0 +1,9 @@
+import {test, expect} from '@playwright/test';
+
+test('date picker', async ({page}) => {
+  await page.goto('/components/datepicker/e2e/datepicker_app');
+  // await page.locator('//input').nth(0).click();
+  await page.locator('//input').nth(0).fill('9/10/2024');
+  await page.locator('//input').nth(1).click();
+  await expect(page.getByText('Selected date: 2024-09-10')).toBeVisible();
+});

--- a/mesop/components/datepicker/e2e/datepicker_test.ts
+++ b/mesop/components/datepicker/e2e/datepicker_test.ts
@@ -2,7 +2,7 @@ import {test, expect} from '@playwright/test';
 
 test('date picker', async ({page}) => {
   await page.goto('/components/datepicker/e2e/datepicker_app');
-  // await page.locator('//input').nth(0).click();
+  await page.locator('//input').nth(0).click();
   await page.locator('//input').nth(0).fill('9/10/2024');
   await page.locator('//input').nth(1).click();
   await expect(page.getByText('Selected date: 2024-09-10')).toBeVisible();

--- a/mesop/dataclass_utils/dataclass_utils.py
+++ b/mesop/dataclass_utils/dataclass_utils.py
@@ -2,7 +2,7 @@
 import base64
 import json
 from dataclasses import Field, asdict, dataclass, field, is_dataclass
-from datetime import datetime
+from datetime import date, datetime
 from io import StringIO
 from typing import Any, Type, TypeVar, cast, get_origin, get_type_hints
 
@@ -14,6 +14,7 @@ from mesop.components.uploader.uploaded_file import UploadedFile
 from mesop.exceptions import MesopDeveloperException, MesopException
 
 _PANDAS_OBJECT_KEY = "__pandas.DataFrame__"
+_DATE_OBJECT_KEY = "__datetime.date__"
 _DATETIME_OBJECT_KEY = "__datetime.datetime__"
 _BYTES_OBJECT_KEY = "__python.bytes__"
 _SET_OBJECT_KEY = "__python.set__"
@@ -190,6 +191,9 @@ class MesopJSONEncoder(json.JSONEncoder):
     if isinstance(obj, datetime):
       return {_DATETIME_OBJECT_KEY: obj.isoformat()}
 
+    if isinstance(obj, date):
+      return {_DATE_OBJECT_KEY: obj.isoformat()}
+
     if isinstance(obj, bytes):
       return {_BYTES_OBJECT_KEY: base64.b64encode(obj).decode("utf-8")}
 
@@ -223,6 +227,9 @@ def decode_mesop_json_state_hook(dct):
 
   if _DATETIME_OBJECT_KEY in dct:
     return datetime.fromisoformat(dct[_DATETIME_OBJECT_KEY])
+
+  if _DATE_OBJECT_KEY in dct:
+    return date.fromisoformat(dct[_DATE_OBJECT_KEY])
 
   if _BYTES_OBJECT_KEY in dct:
     return base64.b64decode(dct[_BYTES_OBJECT_KEY])

--- a/mesop/dataclass_utils/dataclass_utils_test.py
+++ b/mesop/dataclass_utils/dataclass_utils_test.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date, datetime
 
 import numpy as np
 import pandas as pd
@@ -29,7 +29,10 @@ class B:
 class A:
   b: B = field(default_factory=B)
   list_b: list[B] = field(default_factory=list)
-  dates: list[datetime] = field(default_factory=lambda: [datetime(1974, 1, 1)])
+  datetimes: list[datetime] = field(
+    default_factory=lambda: [datetime(1974, 1, 1)]
+  )
+  dates: list[date] = field(default_factory=lambda: [date(1974, 1, 1)])
   strs: list[str] = field(default_factory=list)
   str_dict: dict[str, str] = field(default_factory=dict)
 
@@ -54,9 +57,13 @@ JSON_STR = """{"b": {"c": {"val": "<init>"}},
   {"c": {"val": "1"}},
   {"c": {"val": "2"}}
 ],
-"dates": [
+"datetimes": [
   {"__datetime.datetime__": "1972-01-01T02:00:30"},
   {"__datetime.datetime__": "2024-06-12T05:01:30"}
+],
+"dates": [
+  {"__datetime.date__": "1972-01-01"},
+  {"__datetime.date__": "2024-06-12"}
 ],
 "strs": ["a", "b"]}"""
 
@@ -134,7 +141,7 @@ def test_serialize_dataclass():
   val = serialize_dataclass(A())
   assert (
     val
-    == """{"b": {"c": {"val": "<init>"}}, "list_b": [], "dates": [{"__datetime.datetime__": "1974-01-01T00:00:00"}], "strs": [], "str_dict": {}}"""
+    == """{"b": {"c": {"val": "<init>"}}, "list_b": [], "datetimes": [{"__datetime.datetime__": "1974-01-01T00:00:00"}], "dates": [{"__datetime.date__": "1974-01-01"}], "strs": [], "str_dict": {}}"""
   )
 
 
@@ -211,9 +218,13 @@ def test_update_dataclass_from_json_nested_dataclass():
 
   a = A()
   update_dataclass_from_json(a, JSON_STR)
-  assert a.dates == [
+  assert a.datetimes == [
     datetime(1972, 1, 1, 2, 0, 30),
     datetime(2024, 6, 12, 5, 1, 30),
+  ]
+  assert a.dates == [
+    date(1972, 1, 1),
+    date(2024, 6, 12),
   ]
   assert a.b.c.val == "<init>"
 

--- a/mesop/example_index.py
+++ b/mesop/example_index.py
@@ -32,4 +32,5 @@ import mesop.components.html.e2e as html_e2e
 import mesop.components.link.e2e as link_e2e
 import mesop.components.autocomplete.e2e as autocomplete_e2e
 import mesop.components.datepicker.e2e as datepicker_e2e
+import mesop.components.date_range_picker.e2e as date_range_picker_e2e
 # REF(//scripts/scaffold_component.py):insert_component_e2e_import_export

--- a/mesop/example_index.py
+++ b/mesop/example_index.py
@@ -31,4 +31,5 @@ import mesop.components.uploader.e2e as uploader_e2e
 import mesop.components.html.e2e as html_e2e
 import mesop.components.link.e2e as link_e2e
 import mesop.components.autocomplete.e2e as autocomplete_e2e
+import mesop.components.datepicker.e2e as datepicker_e2e
 # REF(//scripts/scaffold_component.py):insert_component_e2e_import_export

--- a/mesop/examples/BUILD
+++ b/mesop/examples/BUILD
@@ -15,6 +15,7 @@ py_library(
     deps = [
         "//demo",
         # REF(//scripts/scaffold_component.py):insert_component_e2e_import
+        "//mesop/components/date_range_picker/e2e",
         "//mesop/components/datepicker/e2e",
         "//mesop/components/autocomplete/e2e",
         "//mesop/components/link/e2e",

--- a/mesop/examples/BUILD
+++ b/mesop/examples/BUILD
@@ -15,6 +15,7 @@ py_library(
     deps = [
         "//demo",
         # REF(//scripts/scaffold_component.py):insert_component_e2e_import
+        "//mesop/components/datepicker/e2e",
         "//mesop/components/autocomplete/e2e",
         "//mesop/components/link/e2e",
         "//mesop/components/html/e2e",

--- a/mesop/protos/ui.proto
+++ b/mesop/protos/ui.proto
@@ -24,7 +24,7 @@ message QueryParam {
     repeated string values = 2;
 }
 
-// Next ID: 18
+// Next ID: 19
 message UserEvent {
     optional States states = 1;
 
@@ -48,6 +48,7 @@ message UserEvent {
         ChangePrefersColorScheme change_prefers_color_scheme = 14;
         ClickEvent click = 16;
         TextareaShortcutEvent textarea_shortcut = 17;
+        DateRangePickerEvent date_range_picker_event = 18;
     }
 
     optional string state_token = 12;
@@ -101,6 +102,10 @@ message Shortcut {
   optional bool meta = 5;
 }
 
+message DateRangePickerEvent {
+  optional string start_date = 1;
+  optional string end_date = 2;
+}
 
 // This is a user-triggered navigation (e.g. go back/forwards) or a hot reload event.
 message NavigationEvent{

--- a/mesop/web/src/component_renderer/BUILD
+++ b/mesop/web/src/component_renderer/BUILD
@@ -17,6 +17,7 @@ ng_module(
     ]) + ["component_renderer.css"],
     deps = [
         # REF(//scripts/scaffold_component.py):insert_component_import
+        "//mesop/components/datepicker:ng",
         "//mesop/components/autocomplete:ng",
         "//mesop/components/link:ng",
         "//mesop/components/html:ng",

--- a/mesop/web/src/component_renderer/BUILD
+++ b/mesop/web/src/component_renderer/BUILD
@@ -17,6 +17,7 @@ ng_module(
     ]) + ["component_renderer.css"],
     deps = [
         # REF(//scripts/scaffold_component.py):insert_component_import
+        "//mesop/components/date_range_picker:ng",
         "//mesop/components/datepicker:ng",
         "//mesop/components/autocomplete:ng",
         "//mesop/components/link:ng",

--- a/mesop/web/src/component_renderer/type_to_component.ts
+++ b/mesop/web/src/component_renderer/type_to_component.ts
@@ -1,3 +1,4 @@
+import {DateRangePickerComponent} from '../../../components/date_range_picker/date_range_picker';
 import {DatepickerComponent} from '../../../components/datepicker/datepicker';
 import {AutocompleteComponent} from '../../../components/autocomplete/autocomplete';
 import {LinkComponent} from '../../../components/link/link';
@@ -57,6 +58,7 @@ export class UserDefinedComponent implements BaseComponent {
 }
 
 export const typeToComponent = {
+  'date_range_picker': DateRangePickerComponent,
   'datepicker': DatepickerComponent,
   'autocomplete': AutocompleteComponent,
   'link': LinkComponent,

--- a/mesop/web/src/component_renderer/type_to_component.ts
+++ b/mesop/web/src/component_renderer/type_to_component.ts
@@ -1,3 +1,4 @@
+import {DatepickerComponent} from '../../../components/datepicker/datepicker';
 import {AutocompleteComponent} from '../../../components/autocomplete/autocomplete';
 import {LinkComponent} from '../../../components/link/link';
 import {HtmlComponent} from '../../../components/html/html';
@@ -56,6 +57,7 @@ export class UserDefinedComponent implements BaseComponent {
 }
 
 export const typeToComponent = {
+  'datepicker': DatepickerComponent,
   'autocomplete': AutocompleteComponent,
   'link': LinkComponent,
   'html': HtmlComponent,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,8 @@ nav:
           - Autocomplete: components/autocomplete.md
           - Button: components/button.md
           - Checkbox: components/checkbox.md
+          - Date picker: components/date_picker.md
+          - Date range picker: components/date_range_picker.md
           - Input: components/input.md
           - Textarea: components/textarea.md
           - Radio: components/radio.md

--- a/packages.bzl
+++ b/packages.bzl
@@ -22,6 +22,7 @@ _CDK_ENTRY_POINTS = [
 _MATERIAL_ENTRY_POINTS = [
     "autocomplete",
     "dialog",
+    "datepicker",
     "menu",
     "slide-toggle",
     "grid-list",

--- a/packages.bzl
+++ b/packages.bzl
@@ -21,8 +21,8 @@ _CDK_ENTRY_POINTS = [
 
 _MATERIAL_ENTRY_POINTS = [
     "autocomplete",
-    "dialog",
     "datepicker",
+    "dialog",
     "menu",
     "slide-toggle",
     "grid-list",


### PR DESCRIPTION
Note: Still need to add integration tests. But playwright is breaking for me (I think because I updated to Sequoia).

This adds basic date picker and date range picker functionality. It only implements the bare minimum of the API.

Also adds support for date object for serialization in state.

Closes https://github.com/google/mesop/issues/550