### PR TITLE
Add option expose static folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,14 @@ jobs:
           name: playwright-report-with-memory-state-session
           path: playwright-report-with-memory-state-session/
           retention-days: 30
+      - name: Run playwright test with static folder
+        run: MESOP_STATIC_FOLDER=mesop/static PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-with-static-folder yarn playwright test mesop/tests/e2e/static_folder_test.ts
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        if: always()
+        with:
+          name: playwright-report-with-static-folder
+          path: playwright-report-with-static-folder/
+          retention-days: 30
   # Deploy docs
   deploy-docs:
     # Only deploy docs if we're pushing to main (see on.push.branches)

--- a/demo/main.py
+++ b/demo/main.py
@@ -63,6 +63,7 @@ import slide_toggle as slide_toggle
 import slider as slider
 import snackbar as snackbar
 import table as table
+import tailwind as tailwind
 import text as text
 import text_to_image as text_to_image
 import text_to_text as text_to_text
@@ -131,6 +132,7 @@ FIRST_SECTIONS = [
     name="Integrations",
     examples=[
       Example(name="bootstrap"),
+      Example(name="tailwind"),
     ],
   ),
 ]

--- a/demo/static/tailwind.css
+++ b/demo/static/tailwind.css
@@ -1,0 +1,732 @@
+*,
+::before,
+::after {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+::backdrop {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+/*
+! tailwindcss v3.4.14 | MIT License | https://tailwindcss.com
+*/
+
+/*
+1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
+2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
+*/
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+  /* 1 */
+  border-width: 0;
+  /* 2 */
+  border-style: solid;
+  /* 2 */
+  border-color: #e5e7eb;
+  /* 2 */
+}
+
+::before,
+::after {
+  --tw-content: '';
+}
+
+/*
+1. Use a consistent sensible line-height in all browsers.
+2. Prevent adjustments of font size after orientation changes in iOS.
+3. Use a more readable tab size.
+4. Use the user's configured `sans` font-family by default.
+5. Use the user's configured `sans` font-feature-settings by default.
+6. Use the user's configured `sans` font-variation-settings by default.
+7. Disable tap highlights on iOS
+*/
+
+html,
+:host {
+  line-height: 1.5;
+  /* 1 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
+  -moz-tab-size: 4;
+  /* 3 */
+  -o-tab-size: 4;
+  tab-size: 4;
+  /* 3 */
+  font-family: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  /* 4 */
+  font-feature-settings: normal;
+  /* 5 */
+  font-variation-settings: normal;
+  /* 6 */
+  -webkit-tap-highlight-color: transparent;
+  /* 7 */
+}
+
+/*
+1. Remove the margin in all browsers.
+2. Inherit line-height from `html` so users can set them as a class directly on the `html` element.
+*/
+
+body {
+  margin: 0;
+  /* 1 */
+  line-height: inherit;
+  /* 2 */
+}
+
+/*
+1. Add the correct height in Firefox.
+2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+3. Ensure horizontal rules are visible by default.
+*/
+
+hr {
+  height: 0;
+  /* 1 */
+  color: inherit;
+  /* 2 */
+  border-top-width: 1px;
+  /* 3 */
+}
+
+/*
+Add the correct text decoration in Chrome, Edge, and Safari.
+*/
+
+abbr:where([title]) {
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+}
+
+/*
+Remove the default font size and weight for headings.
+*/
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+/*
+Reset links to optimize for opt-in styling instead of opt-out.
+*/
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/*
+Add the correct font weight in Edge and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/*
+1. Use the user's configured `mono` font-family by default.
+2. Use the user's configured `mono` font-feature-settings by default.
+3. Use the user's configured `mono` font-variation-settings by default.
+4. Correct the odd `em` font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  /* 1 */
+  font-feature-settings: normal;
+  /* 2 */
+  font-variation-settings: normal;
+  /* 3 */
+  font-size: 1em;
+  /* 4 */
+}
+
+/*
+Add the correct font size in all browsers.
+*/
+
+small {
+  font-size: 80%;
+}
+
+/*
+Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+3. Remove gaps between table borders by default.
+*/
+
+table {
+  text-indent: 0;
+  /* 1 */
+  border-color: inherit;
+  /* 2 */
+  border-collapse: collapse;
+  /* 3 */
+}
+
+/*
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+3. Remove default padding in all browsers.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  /* 1 */
+  font-feature-settings: inherit;
+  /* 1 */
+  font-variation-settings: inherit;
+  /* 1 */
+  font-size: 100%;
+  /* 1 */
+  font-weight: inherit;
+  /* 1 */
+  line-height: inherit;
+  /* 1 */
+  letter-spacing: inherit;
+  /* 1 */
+  color: inherit;
+  /* 1 */
+  margin: 0;
+  /* 2 */
+  padding: 0;
+  /* 3 */
+}
+
+/*
+Remove the inheritance of text transform in Edge and Firefox.
+*/
+
+button,
+select {
+  text-transform: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Remove default button styles.
+*/
+
+button,
+input:where([type='button']),
+input:where([type='reset']),
+input:where([type='submit']) {
+  -webkit-appearance: button;
+  /* 1 */
+  background-color: transparent;
+  /* 2 */
+  background-image: none;
+  /* 2 */
+}
+
+/*
+Use the modern Firefox focus style for all focusable elements.
+*/
+
+:-moz-focusring {
+  outline: auto;
+}
+
+/*
+Remove the additional `:invalid` styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737)
+*/
+
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+
+/*
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/*
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/*
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  outline-offset: -2px;
+  /* 2 */
+}
+
+/*
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to `inherit` in Safari.
+*/
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  /* 1 */
+  font: inherit;
+  /* 2 */
+}
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
+}
+
+/*
+Removes the default spacing and border for appropriate elements.
+*/
+
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+
+fieldset {
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  padding: 0;
+}
+
+ol,
+ul,
+menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/*
+Reset default styling for dialogs.
+*/
+
+dialog {
+  padding: 0;
+}
+
+/*
+Prevent resizing textareas horizontally by default.
+*/
+
+textarea {
+  resize: vertical;
+}
+
+/*
+1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
+2. Set the default placeholder color to the user's configured gray 400 color.
+*/
+
+input::-moz-placeholder,
+textarea::-moz-placeholder {
+  opacity: 1;
+  /* 1 */
+  color: #9ca3af;
+  /* 2 */
+}
+
+input::placeholder,
+textarea::placeholder {
+  opacity: 1;
+  /* 1 */
+  color: #9ca3af;
+  /* 2 */
+}
+
+/*
+Set the default cursor for buttons.
+*/
+
+button,
+[role='button'] {
+  cursor: pointer;
+}
+
+/*
+Make sure disabled buttons don't get the pointer cursor.
+*/
+
+:disabled {
+  cursor: default;
+}
+
+/*
+1. Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
+2. Add `vertical-align: middle` to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
+   This can trigger a poorly considered lint error in some tools but is included by design.
+*/
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: block;
+  /* 1 */
+  vertical-align: middle;
+  /* 2 */
+}
+
+/*
+Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
+*/
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Make elements with the HTML hidden attribute stay hidden by default */
+
+[hidden]:where(:not([hidden='until-found'])) {
+  display: none;
+}
+
+.container {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.block {
+  display: block;
+}
+
+.flex {
+  display: flex;
+}
+
+.grid {
+  display: grid;
+}
+
+.min-h-screen {
+  min-height: 100vh;
+}
+
+.w-64 {
+  width: 16rem;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
+}
+
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.rounded {
+  border-radius: 0.25rem;
+}
+
+.bg-gray-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 244 246 / var(--tw-bg-opacity));
+}
+
+.bg-gray-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
+}
+
+.bg-gray-800 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(31 41 55 / var(--tw-bg-opacity));
+}
+
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.p-6 {
+  padding: 1.5rem;
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.font-semibold {
+  font-weight: 600;
+}
+
+.text-gray-700 {
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity));
+}
+
+.text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.shadow {
+  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color),
+    0 1px 2px -1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+@media (min-width: 768px) {
+  .md\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/demo/static/tailwind.css
+++ b/demo/static/tailwind.css
@@ -1,3 +1,27 @@
+/*
+MIT License
+
+Copyright (c) Tailwind Labs, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 *,
 ::before,
 ::after {

--- a/demo/tailwind.py
+++ b/demo/tailwind.py
@@ -5,6 +5,14 @@ Example Tailwind command:
 npx tailwindcss -i ./tailwind_input.css -o ./tailwind.css
 ```
 
+Example tailwind_input.css
+
+```
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
 Example Tailwind config:
 
 ```
@@ -82,13 +90,7 @@ import mesop as me
   security_policy=me.SecurityPolicy(
     allowed_iframe_parents=["https://google.github.io"]
   ),
-  stylesheets=[
-    # Specify your Tailwind CSS URL here.
-    #
-    # For local testing, you can just launch a basic Python HTTP server:
-    #   python -m http.server 8000
-    "http://localhost:8000/assets/tailwind.css",
-  ],
+  stylesheets=["/static/tailwind.css"],
   path="/tailwind",
 )
 def app():

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -8,13 +8,36 @@ Mesop is configured at the application level using environment variables.
 
 ### MESOP_STATIC_FOLDER
 
+> **NOTE:** By default, this feature is not enabled, but in an upcoming release, the
+default will be `static`.
+
 Allows access to static files from the Mesop server.
 
-The specified folder path must be relative to the Mesop app root directory.
+It is important to know that the specified folder path is relative to the current
+working directory where the Mesop command is run. Absolute paths are not allowed.
 
-By default, this feature is not enabled.
+Example:
 
-**Default:** `''`
+In this case, the current working directory is `/srv`, which means Mesop will make
+`/srv/static` the static folder.
+
+```bash
+cd /srv
+MESOP_STATIC_FOLDER=static mesop app/main.py
+```
+
+Here are some examples of valid paths. Let's assume a current working directory `/srv/`
+
+- `static` becomes `/srv/static`
+- `static/` becomes `/srv/static`
+- `static/assets` becomes `/srv/static/assets`
+- `./static` becomes `/srv/static`
+- `./static/` becomes `/srv/static`
+- `./static/assets` becomes `/srv/static/assets`
+- `.` becomes `/srv/static/.`
+    - *Period is the name of the folder*
+- `./` becomes `/srv/static/.`
+    - *Period is the name of the folder*
 
 ### MESOP_STATIC_URL_PATH
 

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -6,6 +6,28 @@ Mesop is configured at the application level using environment variables.
 
 ## Configuration values
 
+### MESOP_STATIC_FOLDER
+
+Allows access to static files from the Mesop server.
+
+The specified folder path must be relative to the Mesop app root directory.
+
+By default, this feature is not enabled.
+
+**Default:** `''`
+
+### MESOP_STATIC_URL_PATH
+
+This is the base URL path from which files for your specified static folder will be
+made viewable.
+
+The static URL path is only recognized if `MESOP_STATIC_FOLDER` is set.
+
+For example, given `MESOP_STATIC_FOLDER=static` and `MESOP_STATIC_URL_PATH=/assets`, the
+file `static/js/script.js` can be viewable from the URL path `/assets/js/script.js`.
+
+**Default:** `/static`
+
 ### MESOP_CONCURRENT_UPDATES_ENABLED
 
 Allows concurrent updates to state in the same session. If this is not updated, then updates are queued and processed sequentially.

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -35,10 +35,14 @@ Here are some examples of valid paths. Let's assume the current working director
 - `./static` becomes `/srv/static`
 - `./static/` becomes `/srv/static`
 - `./static/assets` becomes `/srv/static/assets`
-- `.` becomes `/srv/static/.`
-    - *Period is the name of the folder*
-- `./` becomes `/srv/static/.`
-    - *Period is the name of the folder*
+
+Invalid paths will raise `MesopDeveloperException`. Here are some examples:
+
+- Absolute paths (e.g. `/absolute/path`)
+- `.`
+- `./`
+- `..`
+- `../`
 
 ### MESOP_STATIC_URL_PATH
 

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -26,7 +26,8 @@ cd /srv
 MESOP_STATIC_FOLDER=static mesop app/main.py
 ```
 
-Here are some examples of valid paths. Let's assume a current working directory `/srv/`
+Here are some examples of valid paths. Let's assume the current working directory is
+`/srv/`
 
 - `static` becomes `/srv/static`
 - `static/` becomes `/srv/static`

--- a/docs/guides/static-assets.md
+++ b/docs/guides/static-assets.md
@@ -3,26 +3,40 @@
 Mesop allows you to specify a folder for storing static assets that will be served by
 the Mesop server.
 
+This feature provides a simple way to serving images, CSS stylesheets, and other files
+without having to rely on CDNs, external servers, or mounting Mesop onto FastAPI/Flask.
+
 ## Enable a static folder
 
 This feature can be enabled using environment variables.
 
 - [MESOP_STATIC_FOLDER](../api/config.md#mesop_static_folder)
-- [MESOP_STATIC_URL_PATH](../api/config.md#mesop_static_folder)
+- [MESOP_STATIC_URL_PATH](../api/config.md#mesop_static_url_path)
 
-Full description of these two settings can be found on the [config page](../api/config.md).
+Full descriptions of these two settings can be found on the [config page](../api/config.md).
 
 ### Enabling a static folder named "assets"
 
 This will make the files in the `assets` directory accessible from the Mesop server
 at `/static`.
 
-Mesop will look for the `assets` directory relative to your application directory.
+Mesop will look for the `assets` directory relative to your current working directory.
+In this case, `/some/path/mesop-app/assets`.
 
 ```bash
+cd /some/path/mesop-app
 MESOP_STATIC_FOLDER=assets mesop main.py
 ```
 
+Here is another example:
+
+Mesop will look for the `assets` directory relative to your current working directory.
+In this case, `/some/path/assets`.
+
+```bash
+cd /some/path
+MESOP_STATIC_FOLDER=assets mesop mesop-app/main.py
+```
 ### Enabling a static folder named "assets" and URL path of /assets
 
 This will make the files in the `assets` directory accessible from the Mesop server
@@ -34,8 +48,8 @@ MESOP_STATIC_FOLDER=assets MESOP_STATIC_URL_PATH=/assets mesop main.py
 
 ### Using a .env file
 
-You can also specify the environment variables in a `.env` file at the root of your
-application directory.
+You can also specify the environment variables in a `.env` file. This file should be
+placed in the same directory as the `main.py` file.
 
 ``` title=".env"
 MESOP_STATIC_FOLDER=assets
@@ -48,11 +62,11 @@ Then you can run the Mesop command like this:
 mesop main.py
 ```
 
-### Example use cases
+## Example use cases
 
 Here are a couple examples that use the static assets feature.
 
-## Add a logo
+### Add a logo
 
 This example shows you how to load an image to use as a logo for your app.
 
@@ -72,7 +86,7 @@ def foo():
   me.image(src="/static/logo.png")
 ```
 
-## Load a Tailwind stylesheet
+### Load a Tailwind stylesheet
 
 This example shows you how to use [Tailwind CSS](https://tailwindcss.com/) with Mesop.
 
@@ -97,8 +111,8 @@ def foo():
 ```
 
 Tailwind is able to extract the CSS properties from your Mesop main.py file. This does
-not work for all cases. If you have dynamic properties, then you may need to maintain
-a safelist as well.
+not work for all cases. If you are dynamically generating CSS properties using string concatenation/formatting, then Tailwind may not be able to determine which properties
+to include. In that case, you may need to manually add these classes to the safelist.
 
 ```js title="tailwind.config.js"
 /** @type {import('tailwindcss').Config} */

--- a/docs/guides/static-assets.md
+++ b/docs/guides/static-assets.md
@@ -40,7 +40,7 @@ MESOP_STATIC_FOLDER=assets mesop mesop-app/main.py
 ### Enabling a static folder named "assets" and URL path of /assets
 
 This will make the files in the `assets` directory accessible from the Mesop server
-at `/assets`.
+at `/assets`. For example: `https://example.com/assets`.
 
 ```bash
 MESOP_STATIC_FOLDER=assets MESOP_STATIC_URL_PATH=/assets mesop main.py

--- a/docs/guides/static-assets.md
+++ b/docs/guides/static-assets.md
@@ -1,0 +1,129 @@
+# Static Assets
+
+Mesop allows you to specify a folder for storing static assets that will be served by
+the Mesop server.
+
+## Enable a static folder
+
+This feature can be enabled using environment variables.
+
+- [MESOP_STATIC_FOLDER](../api/config.md#mesop_static_folder)
+- [MESOP_STATIC_URL_PATH](../api/config.md#mesop_static_folder)
+
+Full description of these two settings can be found on the [config page](../api/config.md).
+
+### Enabling a static folder named "assets"
+
+This will make the files in the `assets` directory accessible from the Mesop server
+at `/static`.
+
+Mesop will look for the `assets` directory relative to your application directory.
+
+```bash
+MESOP_STATIC_FOLDER=assets mesop main.py
+```
+
+### Enabling a static folder named "assets" and URL path of /assets
+
+This will make the files in the `assets` directory accessible from the Mesop server
+at `/assets`.
+
+```bash
+MESOP_STATIC_FOLDER=assets MESOP_STATIC_URL_PATH=/assets mesop main.py
+```
+
+### Using a .env file
+
+You can also specify the environment variables in a `.env` file at the root of your
+application directory.
+
+``` title=".env"
+MESOP_STATIC_FOLDER=assets
+MESOP_STATIC_URL_PATH=/assets
+```
+
+Then you can run the Mesop command like this:
+
+```bash
+mesop main.py
+```
+
+### Example use cases
+
+Here are a couple examples that use the static assets feature.
+
+## Add a logo
+
+This example shows you how to load an image to use as a logo for your app.
+
+Let's assume you have a directory like this:
+
+- static/logo.png
+- main.py
+- requirements.txt
+
+Then you can reference your logo in your Mesop app like this:
+
+```python title="main.py"
+import mesop as me
+
+@me.page()
+def foo():
+  me.image(src="/static/logo.png")
+```
+
+## Load a Tailwind stylesheet
+
+This example shows you how to use [Tailwind CSS](https://tailwindcss.com/) with Mesop.
+
+Let's assume you have a directory like this:
+
+- static/tailwind.css
+- tailwind_input.css
+- tailwind.config.js
+- main.py
+- requirements.txt
+
+
+You can import the CSS into your page using the `stylesheets` parameter on `@me.page`.
+
+```python title="main.py"
+import mesop as me
+
+@me.page(stylesheets=["/static/tailwind.css"])
+def foo():
+  with me.box(classes="bg-gray-800"):
+    me.text("Mesop with Tailwind CSS.")
+```
+
+Tailwind is able to extract the CSS properties from your Mesop main.py file. This does
+not work for all cases. If you have dynamic properties, then you may need to maintain
+a safelist as well.
+
+```js title="tailwind.config.js"
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["main.py"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+  safelist: [],
+};
+```
+
+This is just the base Tailwind input file.
+
+```css title="tailwind_input.css"
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+The command to generate the output Tailwind CSS is:
+
+```bash
+# This assumes you have the tailwindcss CLI installed. If not, see
+# https://tailwindcss.com/docs/installation
+npx tailwindcss -i ./tailwind_input.css -o ./static/tailwind.css
+```

--- a/mesop/BUILD
+++ b/mesop/BUILD
@@ -15,7 +15,10 @@ py_library(
     srcs = [
         "__init__.py",
     ],
-    data = glob([".env"]),
+    data = glob([
+        ".env",
+        "static/**/*",
+    ]),
     visibility = ["//build_defs:mesop_users"],
     deps = [
         ":version",

--- a/mesop/examples/__init__.py
+++ b/mesop/examples/__init__.py
@@ -49,7 +49,6 @@ from mesop.examples import (
 )
 from mesop.examples import starter_kit as starter_kit
 from mesop.examples import sxs as sxs
-from mesop.examples import tailwind as tailwind
 from mesop.examples import testing as testing
 from mesop.examples import viewport_size as viewport_size
 from mesop.examples import web_component as web_component

--- a/mesop/server/config.py
+++ b/mesop/server/config.py
@@ -24,6 +24,8 @@ class Config(BaseModel):
   state_session_backend_firestore_collection: str = "mesop_state_sessions"
   state_session_backend_sql_connection_uri: str = ""
   state_session_backend_sql_table: str = "mesop_state_sessions"
+  static_folder: str = ""
+  static_url_path: str = "/static"
 
   @property
   def state_session_enabled(self):
@@ -47,6 +49,8 @@ def CreateConfigFromEnv() -> Config:
     state_session_backend_sql_table=os.getenv(
       "MESOP_STATE_SESSION_BACKEND_SQL_TABLE",
     ),
+    static_folder=os.getenv("MESOP_STATIC_FOLDER"),
+    static_url_path=os.getenv("MESOP_STATIC_URL_PATH"),
   )
 
   return Config(

--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -34,9 +34,7 @@ def configure_flask_app(
   *, prod_mode: bool = True, exceptions_to_propagate: Sequence[type] = ()
 ) -> Flask:
   static_assets_folder = get_static_folder()
-  print(static_assets_folder)
   if static_assets_folder:
-    print(static_assets_folder, app_config.static_url_path)
     flask_app = Flask(
       __name__,
       static_folder=static_assets_folder,

--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -12,6 +12,7 @@ from flask import (
   request,
   stream_with_context,
 )
+from werkzeug.security import safe_join
 
 import mesop.protos.ui_pb2 as pb
 from mesop.component_helpers import diff_component

--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -284,7 +284,7 @@ def get_static_folder() -> str | None:
     print("Static folder disabled.")
     return None
 
-  if app_config.static_folder.startswith("/"):
+  if os.path.isabs(app_config.static_folder):
     print(
       "Static folder disabled. Static folder cannot be an absolute path: {app_config.static_folder}"
     )

--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -33,15 +33,11 @@ UI_PATH = "/__ui__"
 def configure_flask_app(
   *, prod_mode: bool = True, exceptions_to_propagate: Sequence[type] = ()
 ) -> Flask:
-  static_assets_folder = get_static_folder()
-  if static_assets_folder:
-    flask_app = Flask(
-      __name__,
-      static_folder=static_assets_folder,
-      static_url_path=app_config.static_url_path,
-    )
-  else:
-    flask_app = Flask(__name__)
+  flask_app = Flask(
+    __name__,
+    static_folder=get_static_folder(),
+    static_url_path=get_static_url_path(),
+  )
 
   def render_loop(
     path: str,
@@ -287,3 +283,9 @@ def get_static_folder() -> str | None:
   if not app_config.static_folder:
     return None
   return safe_join(os.getcwd(), app_config.static_folder)
+
+
+def get_static_url_path() -> str | None:
+  if not app_config.static_folder:
+    return None
+  return app_config.static_url_path

--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -281,8 +281,25 @@ def configure_flask_app(
 
 def get_static_folder() -> str | None:
   if not app_config.static_folder:
+    print("Static folder disabled.")
     return None
-  return safe_join(os.getcwd(), app_config.static_folder)
+
+  if app_config.static_folder.startswith("/"):
+    print(
+      "Static folder disabled. Static folder cannot be an absolute path: {app_config.static_folder}"
+    )
+    return None
+
+  static_folder_path = safe_join(os.getcwd(), app_config.static_folder)
+
+  if static_folder_path:
+    print(f"Static folder enabled: {static_folder_path}")
+  else:
+    print(
+      f"Static folder disabled. Invalid static folder specified: {app_config.static_folder}"
+    )
+
+  return static_folder_path
 
 
 def get_static_url_path() -> str | None:

--- a/mesop/static/tailwind.css
+++ b/mesop/static/tailwind.css
@@ -1,0 +1,732 @@
+*,
+::before,
+::after {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+::backdrop {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x:  ;
+  --tw-pan-y:  ;
+  --tw-pinch-zoom:  ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position:  ;
+  --tw-gradient-via-position:  ;
+  --tw-gradient-to-position:  ;
+  --tw-ordinal:  ;
+  --tw-slashed-zero:  ;
+  --tw-numeric-figure:  ;
+  --tw-numeric-spacing:  ;
+  --tw-numeric-fraction:  ;
+  --tw-ring-inset:  ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgb(59 130 246 / 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur:  ;
+  --tw-brightness:  ;
+  --tw-contrast:  ;
+  --tw-grayscale:  ;
+  --tw-hue-rotate:  ;
+  --tw-invert:  ;
+  --tw-saturate:  ;
+  --tw-sepia:  ;
+  --tw-drop-shadow:  ;
+  --tw-backdrop-blur:  ;
+  --tw-backdrop-brightness:  ;
+  --tw-backdrop-contrast:  ;
+  --tw-backdrop-grayscale:  ;
+  --tw-backdrop-hue-rotate:  ;
+  --tw-backdrop-invert:  ;
+  --tw-backdrop-opacity:  ;
+  --tw-backdrop-saturate:  ;
+  --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
+}
+
+/*
+! tailwindcss v3.4.14 | MIT License | https://tailwindcss.com
+*/
+
+/*
+1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
+2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
+*/
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+  /* 1 */
+  border-width: 0;
+  /* 2 */
+  border-style: solid;
+  /* 2 */
+  border-color: #e5e7eb;
+  /* 2 */
+}
+
+::before,
+::after {
+  --tw-content: '';
+}
+
+/*
+1. Use a consistent sensible line-height in all browsers.
+2. Prevent adjustments of font size after orientation changes in iOS.
+3. Use a more readable tab size.
+4. Use the user's configured `sans` font-family by default.
+5. Use the user's configured `sans` font-feature-settings by default.
+6. Use the user's configured `sans` font-variation-settings by default.
+7. Disable tap highlights on iOS
+*/
+
+html,
+:host {
+  line-height: 1.5;
+  /* 1 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
+  -moz-tab-size: 4;
+  /* 3 */
+  -o-tab-size: 4;
+  tab-size: 4;
+  /* 3 */
+  font-family: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  /* 4 */
+  font-feature-settings: normal;
+  /* 5 */
+  font-variation-settings: normal;
+  /* 6 */
+  -webkit-tap-highlight-color: transparent;
+  /* 7 */
+}
+
+/*
+1. Remove the margin in all browsers.
+2. Inherit line-height from `html` so users can set them as a class directly on the `html` element.
+*/
+
+body {
+  margin: 0;
+  /* 1 */
+  line-height: inherit;
+  /* 2 */
+}
+
+/*
+1. Add the correct height in Firefox.
+2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
+3. Ensure horizontal rules are visible by default.
+*/
+
+hr {
+  height: 0;
+  /* 1 */
+  color: inherit;
+  /* 2 */
+  border-top-width: 1px;
+  /* 3 */
+}
+
+/*
+Add the correct text decoration in Chrome, Edge, and Safari.
+*/
+
+abbr:where([title]) {
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+}
+
+/*
+Remove the default font size and weight for headings.
+*/
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+/*
+Reset links to optimize for opt-in styling instead of opt-out.
+*/
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/*
+Add the correct font weight in Edge and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/*
+1. Use the user's configured `mono` font-family by default.
+2. Use the user's configured `mono` font-feature-settings by default.
+3. Use the user's configured `mono` font-variation-settings by default.
+4. Correct the odd `em` font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  /* 1 */
+  font-feature-settings: normal;
+  /* 2 */
+  font-variation-settings: normal;
+  /* 3 */
+  font-size: 1em;
+  /* 4 */
+}
+
+/*
+Add the correct font size in all browsers.
+*/
+
+small {
+  font-size: 80%;
+}
+
+/*
+Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
+2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
+3. Remove gaps between table borders by default.
+*/
+
+table {
+  text-indent: 0;
+  /* 1 */
+  border-color: inherit;
+  /* 2 */
+  border-collapse: collapse;
+  /* 3 */
+}
+
+/*
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+3. Remove default padding in all browsers.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  /* 1 */
+  font-feature-settings: inherit;
+  /* 1 */
+  font-variation-settings: inherit;
+  /* 1 */
+  font-size: 100%;
+  /* 1 */
+  font-weight: inherit;
+  /* 1 */
+  line-height: inherit;
+  /* 1 */
+  letter-spacing: inherit;
+  /* 1 */
+  color: inherit;
+  /* 1 */
+  margin: 0;
+  /* 2 */
+  padding: 0;
+  /* 3 */
+}
+
+/*
+Remove the inheritance of text transform in Edge and Firefox.
+*/
+
+button,
+select {
+  text-transform: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Remove default button styles.
+*/
+
+button,
+input:where([type='button']),
+input:where([type='reset']),
+input:where([type='submit']) {
+  -webkit-appearance: button;
+  /* 1 */
+  background-color: transparent;
+  /* 2 */
+  background-image: none;
+  /* 2 */
+}
+
+/*
+Use the modern Firefox focus style for all focusable elements.
+*/
+
+:-moz-focusring {
+  outline: auto;
+}
+
+/*
+Remove the additional `:invalid` styles in Firefox. (https://github.com/mozilla/gecko-dev/blob/2f9eacd9d3d995c937b4251a5557d95d494c9be1/layout/style/res/forms.css#L728-L737)
+*/
+
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+
+/*
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/*
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/*
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  outline-offset: -2px;
+  /* 2 */
+}
+
+/*
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to `inherit` in Safari.
+*/
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  /* 1 */
+  font: inherit;
+  /* 2 */
+}
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
+}
+
+/*
+Removes the default spacing and border for appropriate elements.
+*/
+
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+
+fieldset {
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  padding: 0;
+}
+
+ol,
+ul,
+menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/*
+Reset default styling for dialogs.
+*/
+
+dialog {
+  padding: 0;
+}
+
+/*
+Prevent resizing textareas horizontally by default.
+*/
+
+textarea {
+  resize: vertical;
+}
+
+/*
+1. Reset the default placeholder opacity in Firefox. (https://github.com/tailwindlabs/tailwindcss/issues/3300)
+2. Set the default placeholder color to the user's configured gray 400 color.
+*/
+
+input::-moz-placeholder,
+textarea::-moz-placeholder {
+  opacity: 1;
+  /* 1 */
+  color: #9ca3af;
+  /* 2 */
+}
+
+input::placeholder,
+textarea::placeholder {
+  opacity: 1;
+  /* 1 */
+  color: #9ca3af;
+  /* 2 */
+}
+
+/*
+Set the default cursor for buttons.
+*/
+
+button,
+[role='button'] {
+  cursor: pointer;
+}
+
+/*
+Make sure disabled buttons don't get the pointer cursor.
+*/
+
+:disabled {
+  cursor: default;
+}
+
+/*
+1. Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
+2. Add `vertical-align: middle` to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
+   This can trigger a poorly considered lint error in some tools but is included by design.
+*/
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: block;
+  /* 1 */
+  vertical-align: middle;
+  /* 2 */
+}
+
+/*
+Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
+*/
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Make elements with the HTML hidden attribute stay hidden by default */
+
+[hidden]:where(:not([hidden='until-found'])) {
+  display: none;
+}
+
+.container {
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.block {
+  display: block;
+}
+
+.flex {
+  display: flex;
+}
+
+.grid {
+  display: grid;
+}
+
+.min-h-screen {
+  min-height: 100vh;
+}
+
+.w-64 {
+  width: 16rem;
+}
+
+.flex-1 {
+  flex: 1 1 0%;
+}
+
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+.flex-col {
+  flex-direction: column;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.rounded {
+  border-radius: 0.25rem;
+}
+
+.bg-gray-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 244 246 / var(--tw-bg-opacity));
+}
+
+.bg-gray-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
+}
+
+.bg-gray-800 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(31 41 55 / var(--tw-bg-opacity));
+}
+
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.p-6 {
+  padding: 1.5rem;
+}
+
+.py-2 {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.py-4 {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}
+
+.font-bold {
+  font-weight: 700;
+}
+
+.font-semibold {
+  font-weight: 600;
+}
+
+.text-gray-700 {
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity));
+}
+
+.text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.shadow {
+  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color),
+    0 1px 2px -1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+@media (min-width: 768px) {
+  .md\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/mesop/static/tailwind.css
+++ b/mesop/static/tailwind.css
@@ -1,3 +1,26 @@
+/*
+MIT License
+
+Copyright (c) Tailwind Labs, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 *,
 ::before,
 ::after {

--- a/mesop/tests/e2e/static_folder_test.ts
+++ b/mesop/tests/e2e/static_folder_test.ts
@@ -1,0 +1,34 @@
+import {test, expect} from '@playwright/test';
+
+test.describe('Static Folders', () => {
+  test.describe('MESOP_STATIC_FOLDER disabled', () => {
+    test('static folder not viewable if MESOP_STATIC_FOLDER not enabled', async ({
+      page,
+    }) => {
+      if (process.env['MESOP_STATIC_FOLDER'] !== undefined) {
+        test.skip('Test skipped because MESOP_STATIC_FOLDER is set.');
+      }
+      const response = await page.goto('/static/tailwind.css');
+      expect(response!.status()).toBe(500);
+    });
+  });
+
+  test.describe('MESOP_STATIC_FOLDER enabled', () => {
+    if (process.env['MESOP_STATIC_FOLDER'] === undefined) {
+      test.skip('Test skipped because MESOP_STATIC_FOLDER is not set.');
+    }
+
+    test('static file viewable if exists', async ({page}) => {
+      const response = await page.goto('/static/tailwind.css');
+      expect(response!.status()).toBe(200);
+    });
+    test('static file not viewable if not exists', async ({page}) => {
+      const response = await page.goto('/static/non-existent.css');
+      expect(response!.status()).toBe(404);
+    });
+    test('moving down from the root path is not allowed', async ({page}) => {
+      const response = await page.goto('/static/../config.py');
+      expect(response!.status()).toBe(500);
+    });
+  });
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
           - Multi-Pages: guides/multi-pages.md
           - Auth: guides/auth.md
           - Theming: guides/theming.md
+          - Static assets: guides/static-assets.md
           - Server integration: guides/server-integration.md
       - Development:
           - Debugging: guides/debugging.md

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -55,6 +55,8 @@ export default defineConfig({
       process.env.MESOP_CONCURRENT_UPDATES_ENABLED || 'false'
     } MESOP_STATE_SESSION_BACKEND=${
       process.env.MESOP_STATE_SESSION_BACKEND || 'none'
+    } MESOP_STATIC_FOLDER=${
+      process.env.MESOP_STATIC_FOLDER || ''
     } bazel run //mesop/cli -- --path=mesop/mesop/example_index.py --prod=${
       process.env.MESOP_DEBUG_MODE === 'true' ? 'false' : 'true'
     }`,


### PR DESCRIPTION
Flask allows a static assets directory be specified. It turns out this can be an absolute path or a relative path.

I'm not sure if I'm doing the relatively path part correctly for bazel or the pip version.

This is not completed yet. Still need to add docs, tests. But mainly just wanted to see if this is reasonable.

One issue is that specifying the stylesheet from the page object in terms of CSP:

```
The source list for the Content Security Policy directive 'style-src' contains an invalid source: '/assets/tailwind.css'. It will be ignored.
```
Interestingly the CSS seems to be still read correctly.

Ref: https://github.com/google/mesop/issues/960