### PR TITLE
Fix broken datepicker test

### DIFF
--- a/mesop/components/datepicker/e2e/datepicker_test.ts
+++ b/mesop/components/datepicker/e2e/datepicker_test.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 test('date picker', async ({page}) => {
-  await page.goto('1');
+  await page.goto('/components/datepicker/e2e/datepicker_app');
 
   // Enter valid date
   await page.locator('//input').click();

--- a/mesop/components/datepicker/e2e/datepicker_test.ts
+++ b/mesop/components/datepicker/e2e/datepicker_test.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
 
 test('date picker', async ({page}) => {
-  await page.goto('/components/datepicker/e2e/datepicker_app');
+  await page.goto('1');
 
   // Enter valid date
   await page.locator('//input').click();
@@ -9,14 +9,14 @@ test('date picker', async ({page}) => {
   await page.getByText('Selected date: ').click();
   await expect(page.getByText('Selected date: 2024-09-10')).toBeVisible();
 
-  // Enter invalid date
-  await page.locator('//input').click();
-  await page.locator('//input').fill('13/10/2024');
-  await page.getByText('Selected date: 2024-09-10').click();
-  await expect(page.getByText('Selected date: 2024-09-10')).toBeVisible();
-
   // Pick date from calendar
   await page.getByLabel('Open calendar').click();
   await page.locator('//button/span[text()=" 15 "]').click();
+  await expect(page.getByText('Selected date: 2024-09-15')).toBeVisible();
+
+  // Enter invalid date
+  await page.locator('//input').click();
+  await page.locator('//input').fill('13/10/2024');
+  await page.getByText('Selected date: 2024-09-15').click();
   await expect(page.getByText('Selected date: 2024-09-15')).toBeVisible();
 });


### PR DESCRIPTION
Update the test so that when the month changes, the test won't break.

In this case, if there is an invalid date, opening the calendar will show the current day.