### PR TITLE
Fix sidenav "escape" key bug

### DIFF
--- a/demo/sidenav.py
+++ b/demo/sidenav.py
@@ -33,6 +33,7 @@ def app():
   state = me.state(State)
   with me.sidenav(
     opened=state.sidenav_open,
+    disable_close=False,
     on_opened_changed=opened_changed,
     style=me.Style(
       border_radius=0,

--- a/demo/sidenav.py
+++ b/demo/sidenav.py
@@ -1,5 +1,7 @@
 import mesop as me
 
+SIDENAV_WIDTH = 200
+
 
 @me.stateclass
 class State:
@@ -11,7 +13,9 @@ def on_click(e: me.ClickEvent):
   s.sidenav_open = not s.sidenav_open
 
 
-SIDENAV_WIDTH = 200
+def opened_changed(e: me.SidenavOpenedChangedEvent):
+  s = me.state(State)
+  s.sidenav_open = e.opened
 
 
 def load(e: me.LoadEvent):
@@ -28,13 +32,21 @@ def load(e: me.LoadEvent):
 def app():
   state = me.state(State)
   with me.sidenav(
-    opened=state.sidenav_open, style=me.Style(width=SIDENAV_WIDTH)
+    opened=state.sidenav_open,
+    on_opened_changed=opened_changed,
+    style=me.Style(
+      border_radius=0,
+      width=SIDENAV_WIDTH,
+      background=me.theme_var("surface-container-low"),
+      padding=me.Padding.all(15),
+    ),
   ):
     me.text("Inside sidenav")
 
   with me.box(
     style=me.Style(
       margin=me.Margin(left=SIDENAV_WIDTH if state.sidenav_open else 0),
+      padding=me.Padding.all(15),
     ),
   ):
     with me.content_button(on_click=on_click):

--- a/mesop/__init__.py
+++ b/mesop/__init__.py
@@ -142,6 +142,9 @@ from mesop.components.select.select import (
 from mesop.components.select.select import (
   select as select,
 )
+from mesop.components.sidenav.sidenav import (
+  SidenavOpenedChangedEvent as SidenavOpenedChangedEvent,
+)
 from mesop.components.sidenav.sidenav import sidenav as sidenav
 from mesop.components.slide_toggle.slide_toggle import (
   SlideToggleChangeEvent as SlideToggleChangeEvent,

--- a/mesop/components/sidenav/e2e/__init__.py
+++ b/mesop/components/sidenav/e2e/__init__.py
@@ -1,1 +1,3 @@
 from . import sidenav_app as sidenav_app
+from . import sidenav_app_no_esc as sidenav_app_no_esc
+from . import sidenav_app_position as sidenav_app_position

--- a/mesop/components/sidenav/e2e/sidenav_app.py
+++ b/mesop/components/sidenav/e2e/sidenav_app.py
@@ -23,6 +23,7 @@ def app():
   state = me.state(State)
   with me.sidenav(
     opened=state.sidenav_open,
+    disable_close=False,
     on_opened_changed=opened_changed,
     style=me.Style(
       border_radius=0,

--- a/mesop/components/sidenav/e2e/sidenav_app_no_esc.py
+++ b/mesop/components/sidenav/e2e/sidenav_app_no_esc.py
@@ -18,11 +18,12 @@ def opened_changed(e: me.SidenavOpenedChangedEvent):
   s.sidenav_open = e.opened
 
 
-@me.page(path="/components/sidenav/e2e/sidenav_app")
+@me.page(path="/components/sidenav/e2e/sidenav_app_no_esc")
 def app():
   state = me.state(State)
   with me.sidenav(
     opened=state.sidenav_open,
+    disable_close=True,
     on_opened_changed=opened_changed,
     style=me.Style(
       border_radius=0,

--- a/mesop/components/sidenav/e2e/sidenav_app_position.py
+++ b/mesop/components/sidenav/e2e/sidenav_app_position.py
@@ -24,6 +24,7 @@ def app():
   with me.sidenav(
     opened=state.sidenav_open,
     position="end",
+    disable_close=False,
     on_opened_changed=opened_changed,
     style=me.Style(
       border_radius=0,

--- a/mesop/components/sidenav/e2e/sidenav_app_position.py
+++ b/mesop/components/sidenav/e2e/sidenav_app_position.py
@@ -18,11 +18,12 @@ def opened_changed(e: me.SidenavOpenedChangedEvent):
   s.sidenav_open = e.opened
 
 
-@me.page(path="/components/sidenav/e2e/sidenav_app")
+@me.page(path="/components/sidenav/e2e/sidenav_app_position")
 def app():
   state = me.state(State)
   with me.sidenav(
     opened=state.sidenav_open,
+    position="end",
     on_opened_changed=opened_changed,
     style=me.Style(
       border_radius=0,

--- a/mesop/components/sidenav/e2e/sidenav_test.ts
+++ b/mesop/components/sidenav/e2e/sidenav_test.ts
@@ -3,9 +3,9 @@ import {test, expect} from '@playwright/test';
 test.describe('Sidenav component', () => {
   test('open/close sidenav', async ({page}) => {
     await page.goto('/components/sidenav/e2e/sidenav_app');
-    await (await page.getByRole('button')).click();
+    await (await page.locator('button').filter({hasText: 'menu'})).click();
     await expect(await page.getByText('Inside sidenav')).toBeVisible();
-    await (await page.getByRole('button')).click();
+    await (await page.locator('button').filter({hasText: 'menu'})).click();
     await expect(await page.getByText('Inside sidenav')).toBeHidden();
   });
 
@@ -13,7 +13,7 @@ test.describe('Sidenav component', () => {
     await page.goto('/components/sidenav/e2e/sidenav_app');
     const mainContent = await page.getByText('Main content');
     const startLocation = await mainContent.boundingBox();
-    await (await page.getByRole('button')).click();
+    await (await page.locator('button').filter({hasText: 'menu'})).click();
     await expect(await page.getByText('Inside sidenav')).toBeVisible();
     const midLocation = await mainContent.boundingBox();
     // Main content should be pushed over to the left when sidenav is opened.
@@ -31,7 +31,7 @@ test.describe('Sidenav component', () => {
     page,
   }) => {
     await page.goto('/components/sidenav/e2e/sidenav_app_no_esc');
-    await (await page.getByRole('button')).click();
+    await (await page.locator('button').filter({hasText: 'menu'})).click();
     await expect(await page.getByText('Inside sidenav')).toBeVisible();
     await page.getByText('Inside sidenav').click();
     await page.keyboard.press('Escape');
@@ -40,7 +40,7 @@ test.describe('Sidenav component', () => {
 
   test('show sidenav on the right side', async ({page}) => {
     await page.goto('/components/sidenav/e2e/sidenav_app_position');
-    await (await page.getByRole('button')).click();
+    await (await page.locator('button').filter({hasText: 'menu'})).click();
     const sidenav = await page.getByText('Inside sidenav');
     await expect(sidenav).toBeVisible();
     const sidenavLocation = await sidenav.boundingBox();

--- a/mesop/components/sidenav/e2e/sidenav_test.ts
+++ b/mesop/components/sidenav/e2e/sidenav_test.ts
@@ -1,8 +1,53 @@
 import {test, expect} from '@playwright/test';
 
-test('test', async ({page}) => {
-  await page.goto('/components/sidenav/e2e/sidenav_app');
-  expect(await page.getByText('Inside sidenav').textContent()).toContain(
-    'Inside sidenav',
-  );
+test.describe('Sidenav component', () => {
+  test('open/close sidenav', async ({page}) => {
+    await page.goto('/components/sidenav/e2e/sidenav_app');
+    await (await page.getByRole('button')).click();
+    await expect(await page.getByText('Inside sidenav')).toBeVisible();
+    await (await page.getByRole('button')).click();
+    await expect(await page.getByText('Inside sidenav')).toBeHidden();
+  });
+
+  test('escape closes sidenav', async ({page}) => {
+    await page.goto('/components/sidenav/e2e/sidenav_app');
+    const mainContent = await page.getByText('Main content');
+    const startLocation = await mainContent.boundingBox();
+    await (await page.getByRole('button')).click();
+    await expect(await page.getByText('Inside sidenav')).toBeVisible();
+    const midLocation = await mainContent.boundingBox();
+    // Main content should be pushed over to the left when sidenav is opened.
+    expect(startLocation!.x).toBeLessThan(midLocation!.x);
+    await page.getByText('Inside sidenav').click();
+    await page.keyboard.press('Escape');
+    await expect(await page.getByText('Inside sidenav')).toBeHidden();
+    // Make sure the main content has moved back to original position after sidenav
+    // has closed. Fix for GH-1019.
+    const endLocation = await mainContent.boundingBox();
+    expect(startLocation!.x).toEqual(endLocation!.x);
+  });
+
+  test('escape does not close sidenav if disable_close=True', async ({
+    page,
+  }) => {
+    await page.goto('/components/sidenav/e2e/sidenav_app_no_esc');
+    await (await page.getByRole('button')).click();
+    await expect(await page.getByText('Inside sidenav')).toBeVisible();
+    await page.getByText('Inside sidenav').click();
+    await page.keyboard.press('Escape');
+    await expect(await page.getByText('Inside sidenav')).toBeVisible();
+  });
+
+  test('show sidenav on the right side', async ({page}) => {
+    await page.goto('/components/sidenav/e2e/sidenav_app_position');
+    await (await page.getByRole('button')).click();
+    const sidenav = await page.getByText('Inside sidenav');
+    await expect(sidenav).toBeVisible();
+    const sidenavLocation = await sidenav.boundingBox();
+    // During manually testing the x position of the sidenav with position start was
+    // approx -130. With position end, the position was approx 1,200. So we'll just
+    // check the x position is greater than 0 since browser window width may change
+    // depending on the machine.
+    expect(sidenavLocation!.x).toBeGreaterThan(0);
+  });
 });

--- a/mesop/components/sidenav/sidenav.ng.html
+++ b/mesop/components/sidenav/sidenav.ng.html
@@ -1,7 +1,10 @@
 <mat-sidenav
   [style]="getStyle()"
   [opened]="config().getOpened()"
+  [disableClose]="config().getDisableClose()"
   [fixedInViewport]="true"
+  [position]="getPosition()"
+  (openedChange)="onOpenedChange($event)"
 >
   <ng-content></ng-content>
 </mat-sidenav>

--- a/mesop/components/sidenav/sidenav.proto
+++ b/mesop/components/sidenav/sidenav.proto
@@ -4,4 +4,7 @@ package mesop.components.sidenav;
 
 message SidenavType {
     optional bool opened = 1;
+    optional bool disable_close = 2;
+    optional string position = 3;
+    optional string on_opened_changed_event_handler_id = 4;
 }

--- a/mesop/components/sidenav/sidenav.py
+++ b/mesop/components/sidenav/sidenav.py
@@ -1,8 +1,35 @@
+from dataclasses import dataclass
+from typing import Any, Callable, Literal
+
 import mesop.components.sidenav.sidenav_pb2 as sidenav_pb
 from mesop.component_helpers import (
   Style,
   insert_composite_component,
+  register_event_handler,
+  register_event_mapper,
   register_native_component,
+)
+from mesop.events import MesopEvent
+
+
+@dataclass(kw_only=True)
+class SidenavOpenedChangedEvent(MesopEvent):
+  """Event representing the opened state change of the select component.
+
+  Attributes:
+      opened: A boolean indicating whether the select component is opened (True) or closed (False).
+      key (str): key of the component that emitted this event.
+  """
+
+  opened: bool
+
+
+register_event_mapper(
+  SidenavOpenedChangedEvent,
+  lambda event, key: SidenavOpenedChangedEvent(
+    key=key.key,
+    opened=event.bool_value,
+  ),
 )
 
 
@@ -10,6 +37,9 @@ from mesop.component_helpers import (
 def sidenav(
   *,
   opened: bool = True,
+  disable_close: bool = False,
+  position: Literal["start", "end"] = "start",
+  on_opened_changed: Callable[[SidenavOpenedChangedEvent], Any] | None = None,
   style: Style | None = None,
   key: str | None = None,
 ):
@@ -18,6 +48,9 @@ def sidenav(
 
   Args:
       opened: A flag to determine if the sidenav is open or closed. Defaults to True.
+      disable_close: Whether the drawer can be closed with the escape key.
+      position: The side that the drawer is attached to.
+      on_opened_changed: Handles event emitted when the drawer open state is changed.
       style: An optional Style object to apply custom styles. Defaults to None.
       key: The component [key](../components/index.md#component-key).
   """
@@ -27,5 +60,12 @@ def sidenav(
     style=style,
     proto=sidenav_pb.SidenavType(
       opened=opened,
+      disable_close=disable_close,
+      position=position,
+      on_opened_changed_event_handler_id=register_event_handler(
+        on_opened_changed, event=SidenavOpenedChangedEvent
+      )
+      if on_opened_changed
+      else "",
     ),
   )

--- a/mesop/components/sidenav/sidenav.py
+++ b/mesop/components/sidenav/sidenav.py
@@ -14,10 +14,10 @@ from mesop.events import MesopEvent
 
 @dataclass(kw_only=True)
 class SidenavOpenedChangedEvent(MesopEvent):
-  """Event representing the opened state change of the select component.
+  """Event representing the opened state change of the sidenav component.
 
   Attributes:
-      opened: A boolean indicating whether the select component is opened (True) or closed (False).
+      opened: A boolean indicating whether the sidenav component is opened (True) or closed (False).
       key (str): key of the component that emitted this event.
   """
 

--- a/mesop/components/sidenav/sidenav.py
+++ b/mesop/components/sidenav/sidenav.py
@@ -37,7 +37,7 @@ register_event_mapper(
 def sidenav(
   *,
   opened: bool = True,
-  disable_close: bool = False,
+  disable_close: bool = True,
   position: Literal["start", "end"] = "start",
   on_opened_changed: Callable[[SidenavOpenedChangedEvent], Any] | None = None,
   style: Style | None = None,

--- a/mesop/components/sidenav/sidenav.ts
+++ b/mesop/components/sidenav/sidenav.ts
@@ -1,5 +1,6 @@
 import {Component, Input} from '@angular/core';
 import {
+  UserEvent,
   Key,
   Style,
   Type,
@@ -7,6 +8,7 @@ import {
 import {SidenavType} from 'mesop/mesop/components/sidenav/sidenav_jspb_proto_pb/mesop/components/sidenav/sidenav_pb';
 import {MatSidenavModule} from '@angular/material/sidenav';
 import {formatStyle} from '../../web/src/utils/styles';
+import {Channel} from '../../web/src/services/channel';
 
 @Component({
   selector: 'mesop-sidenav',
@@ -20,6 +22,8 @@ export class SidenavComponent {
   @Input() style!: Style;
   private _config!: SidenavType;
 
+  constructor(private readonly channel: Channel) {}
+
   ngOnChanges() {
     this._config = SidenavType.deserializeBinary(
       this.type.getValue() as unknown as Uint8Array,
@@ -32,5 +36,17 @@ export class SidenavComponent {
 
   getStyle(): string {
     return formatStyle(this.style);
+  }
+
+  getPosition(): 'start' | 'end' {
+    return this.config().getPosition() as 'start' | 'end';
+  }
+
+  onOpenedChange(isOpened: boolean): void {
+    const userEvent = new UserEvent();
+    userEvent.setHandlerId(this.config().getOnOpenedChangedEventHandlerId()!);
+    userEvent.setBoolValue(isOpened);
+    userEvent.setKey(this.key);
+    this.channel.dispatch(userEvent);
   }
 }


### PR DESCRIPTION
Changes:

- Add on opened change event handler (so user can update state) when escape pressed
- Add disable_close property to prevent escape from being used
- Drive bys:
  - Add position property so sidenav can be rendered on the right side
  - Minor style adjustments to sidenav demo

Closes #1019