### PR TITLE
Turn (server) error box into a more standard dialog UI

### DIFF
--- a/mesop/tests/e2e/event_handler_error_test.ts
+++ b/mesop/tests/e2e/event_handler_error_test.ts
@@ -8,7 +8,7 @@ test('event handler error message is shown', async ({page}) => {
   await expect(
     page.getByText('Error in on_click.', {exact: true}),
   ).toBeVisible();
-  await page.locator('button').filter({hasText: 'close'}).click();
+  await page.locator('button').filter({hasText: 'OK'}).click();
 
   // Generator event handler
   await page
@@ -17,14 +17,14 @@ test('event handler error message is shown', async ({page}) => {
   await expect(
     page.getByText('Error in on_click_generator.', {exact: true}),
   ).toBeVisible();
-  await page.locator('button').filter({hasText: 'close'}).click();
+  await page.locator('button').filter({hasText: 'OK'}).click();
 
   // Yield from event handler
   await page.getByRole('button', {name: 'Yield from event handler'}).click();
   await expect(
     page.getByText('Error in a_generator.', {exact: true}),
   ).toBeVisible();
-  await page.locator('button').filter({hasText: 'close'}).click();
+  await page.locator('button').filter({hasText: 'OK'}).click();
 
   // Async generator event handler
   await page
@@ -33,5 +33,5 @@ test('event handler error message is shown', async ({page}) => {
   await expect(
     page.getByText('Error in on_click_async_generator.', {exact: true}),
   ).toBeVisible();
-  await page.locator('button').filter({hasText: 'close'}).click();
+  await page.locator('button').filter({hasText: 'OK'}).click();
 });

--- a/mesop/web/src/error/error_box.ng.html
+++ b/mesop/web/src/error/error_box.ng.html
@@ -1,8 +1,5 @@
-<div *ngIf="error && !isHidden(error)" class="error">
+<div class="error">
   <div class="exception">
-    <button mat-icon-button class="close-button" (click)="hideError(error)">
-      <mat-icon>close</mat-icon>
-    </button>
     <div class="error-box-markdown" [innerHTML]="markdownHTML"></div>
   </div>
   <div *ngIf="error.hasTraceback()">
@@ -37,3 +34,14 @@
     >
   </div>
 </div>
+<mat-dialog-actions align="end">
+  <button
+    mat-button
+    class="ok-button"
+    color="warn"
+    [mat-dialog-close]="true"
+    cdkFocusInitial
+  >
+    OK
+  </button>
+</mat-dialog-actions>

--- a/mesop/web/src/error/error_box.scss
+++ b/mesop/web/src/error/error_box.scss
@@ -1,25 +1,11 @@
 .error {
-  background-color: #ffe8ef;
   padding: 28px;
   color: #9e4242;
-  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
-  position: absolute;
-  z-index: 9999;
-  width: 100%;
-  height: 100%;
   overflow: auto;
 }
 
-.close-button {
-  background: none;
-  border: none;
-  color: #872c0a;
-  font-weight: 500;
-  font-size: 23px;
-  cursor: pointer;
-  top: 6px;
-  position: absolute;
-  left: 0px;
+.ok-button {
+  color: #9e4242;
 }
 
 .exception {

--- a/mesop/web/src/error/error_box.ts
+++ b/mesop/web/src/error/error_box.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component, Inject, Input} from '@angular/core';
 import {MatProgressBarModule} from '@angular/material/progress-bar';
 import {
   ServerError,
@@ -10,6 +10,8 @@ import {ComponentRenderer} from '../component_renderer/component_renderer';
 import {Channel} from '../services/channel';
 import {marked} from '../../external/marked';
 import {MatIconModule} from '@angular/material/icon';
+import {MAT_DIALOG_DATA, MatDialogModule} from '@angular/material/dialog';
+import {MatButtonModule} from '@angular/material/button';
 
 @Component({
   selector: 'mesop-error-box',
@@ -21,23 +23,16 @@ import {MatIconModule} from '@angular/material/icon';
     ComponentRenderer,
     MatProgressBarModule,
     MatIconModule,
+    MatDialogModule,
+    MatButtonModule,
   ],
   providers: [Channel],
 })
 export class ErrorBox {
   _showFullTraceback = false;
   _lastAppFrame: StackFrame | undefined;
-  _hiddenErrors: Set<ServerError> = new Set();
   @Input({required: true}) error!: ServerError;
   markdownHTML = '';
-
-  isHidden(error: ServerError): boolean {
-    return this._hiddenErrors.has(error);
-  }
-
-  hideError(error: ServerError): void {
-    this._hiddenErrors.add(error);
-  }
 
   async ngOnChanges() {
     this.markdownHTML = (
@@ -77,4 +72,21 @@ export class ErrorBox {
   isLastAppCode(frame: StackFrame): boolean {
     return frame === this._lastAppFrame;
   }
+}
+
+@Component({
+  selector: 'mesop-server-error-dialog',
+  template: ` <mesop-error-box [error]="data.error"></mesop-error-box> `,
+  styles: `
+    :host {
+      display: block;
+      max-height: 80vh;
+      background-color: #ffe5e5;
+    }
+  `,
+  standalone: true,
+  imports: [MatDialogModule, MatButtonModule, ErrorBox],
+})
+export class ServerErrorBoxDialogComponent {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: {error: ServerError}) {}
 }

--- a/mesop/web/src/shell/shell.ng.html
+++ b/mesop/web/src/shell/shell.ng.html
@@ -1,5 +1,3 @@
-<mesop-error-box *ngIf="error != null" [error]="error" />
-
 <div class="status">
   <mat-progress-bar
     data-testid="connection-progress-bar"


### PR DESCRIPTION
- Dialog provides a more standard UI compared to the somewhat strange fullscreen error box (it's easier to dismiss it and it's clearer from the overlay that there's, potentially, still UI that you can interact with).
- Stop automatically hiding the error UI if there's no more errors in the next render; instead we will close the previous error dialog if there's a new error. 
  - The problem with the previous approach of automatically hiding is that if you're streaming a response, the first chunk could through an error, but the second chunk might not, which results in a flash of the error UI even though the error is still in the code.