### PR TITLE
Use OS specific path separator

### DIFF
--- a/mesop/labs/web_component.py
+++ b/mesop/labs/web_component.py
@@ -31,8 +31,8 @@ def web_component(*, path: str, skip_validation: bool = False):
     os.path.dirname(os.path.abspath(caller_module_file))
   )
   full_path = os.path.normpath(os.path.join(caller_module_dir, path))
-  if not full_path.startswith("/"):
-    full_path = "/" + full_path
+  if not full_path.startswith(os.sep):
+    full_path = os.sep + full_path
   js_module_path = full_path
 
   def component_wrapper(fn: C) -> C:


### PR DESCRIPTION
In the [web_component.py](https://github.com/google/mesop/blob/main/mesop/labs/web_component.py#L34-L35) file, an os specific path is constructed at [line 33](https://github.com/google/mesop/blob/main/mesop/labs/web_component.py#L33) using `os.path.join`. 

But immediately the path is checked whether it starts with "/" or not. "/" is a linux specific path separator and ideally the code should use os specific path separator. 

This PR fixes that issue.

Because of this issue, in windows, full_path `\some\dir\file.js` becomes `/\some\dir\file.js` and later when converted to a URL it becomes `http://host:port//some/dir/file.js` which is not really a valid URL. 