### PR TITLE
Send experiment settings on initial page load

### DIFF
--- a/mesop/protos/ui.proto
+++ b/mesop/protos/ui.proto
@@ -172,15 +172,8 @@ message RenderEvent {
 
     // Only sent in editor mode:
     repeated ComponentConfig component_configs = 5;
-    // Only sent in initial render:
-    optional ExperimentSettings experiment_settings = 7;
 }
 
-message ExperimentSettings {
-    optional bool experimental_editor_toolbar_enabled = 1;
-    optional bool concurrent_updates_enabled = 2;
-    optional bool websockets_enabled = 3;
-}
 
 // UI response event for updating state.
 message UpdateStateEvent {

--- a/mesop/server/server.py
+++ b/mesop/server/server.py
@@ -16,8 +16,6 @@ import mesop.protos.ui_pb2 as pb
 from mesop.component_helpers import diff_component
 from mesop.editor.component_configs import get_component_configs
 from mesop.env.env import (
-  EXPERIMENTAL_EDITOR_TOOLBAR_ENABLED,
-  MESOP_CONCURRENT_UPDATES_ENABLED,
   MESOP_WEBSOCKETS_ENABLED,
 )
 from mesop.events import LoadEvent
@@ -101,13 +99,6 @@ def configure_flask_app(
             f"/{WEB_COMPONENTS_PATH_SEGMENT}{js_module}"
             for js_module in js_modules
           ],
-          experiment_settings=pb.ExperimentSettings(
-            websockets_enabled=MESOP_WEBSOCKETS_ENABLED,
-            concurrent_updates_enabled=MESOP_CONCURRENT_UPDATES_ENABLED,
-            experimental_editor_toolbar_enabled=EXPERIMENTAL_EDITOR_TOOLBAR_ENABLED,
-          )
-          if init_request
-          else None,
         )
       )
       yield serialize(data)

--- a/mesop/server/static_file_serving.py
+++ b/mesop/server/static_file_serving.py
@@ -81,7 +81,6 @@ def configure_static_file_serving(
             for stylesheet in page_config.stylesheets
           ]
         )
-      # Insert experiment settings before the closing </head> tag
       if (
         line.strip() == "<!-- Inject experiment settings script (if needed) -->"
       ):

--- a/mesop/version.py
+++ b/mesop/version.py
@@ -1,6 +1,6 @@
 """Contains the version string."""
 
-VERSION = "0.12.9beta1"
+VERSION = "0.12.8"
 
 if __name__ == "__main__":
   print(VERSION)

--- a/mesop/version.py
+++ b/mesop/version.py
@@ -1,6 +1,6 @@
 """Contains the version string."""
 
-VERSION = "0.12.8"
+VERSION = "0.12.9beta1"
 
 if __name__ == "__main__":
   print(VERSION)

--- a/mesop/web/src/app/editor/index.html
+++ b/mesop/web/src/app/editor/index.html
@@ -18,6 +18,7 @@
   <body>
     <mesop-editor-app ngCspNonce="$$INSERT_CSP_NONCE$$"></mesop-editor-app>
     <!-- Inject livereload script (if needed) -->
+    <!-- Inject experiment settings script (if needed) -->
     <script src="zone.js/bundles/zone.umd.js"></script>
     <script src="editor_bundle/bundle.js" type="module"></script>
   </body>

--- a/mesop/web/src/app/prod/index.html
+++ b/mesop/web/src/app/prod/index.html
@@ -18,6 +18,7 @@
   <body>
     <mesop-app ngCspNonce="$$INSERT_CSP_NONCE$$"></mesop-app>
     <!-- Inject livereload script (if needed) -->
+    <!-- Inject experiment settings script (if needed) -->
     <script src="zone.js/bundles/zone.umd.js"></script>
     <script src="prod_bundle.js" type="module"></script>
   </body>

--- a/mesop/web/src/services/channel.ts
+++ b/mesop/web/src/services/channel.ts
@@ -305,17 +305,6 @@ export class Channel {
         } else {
           this.rootComponent = rootComponent;
         }
-        const experimentSettings = uiResponse
-          .getRender()!
-          .getExperimentSettings();
-        if (experimentSettings) {
-          this.experimentService.websocketsEnabled =
-            experimentSettings.getWebsocketsEnabled() ?? false;
-          this.experimentService.concurrentUpdatesEnabled =
-            experimentSettings.getConcurrentUpdatesEnabled() ?? false;
-          this.experimentService.experimentalEditorToolbarEnabled =
-            experimentSettings.getExperimentalEditorToolbarEnabled() ?? false;
-        }
 
         this.componentConfigs = uiResponse
           .getRender()!

--- a/mesop/web/src/services/experiment_service.ts
+++ b/mesop/web/src/services/experiment_service.ts
@@ -1,9 +1,9 @@
 import {Injectable} from '@angular/core';
 
 interface ExperimentSettings {
-  websocketsEnabled: boolean;
-  concurrentUpdatesEnabled: boolean;
-  experimentalEditorToolbarEnabled: boolean;
+  readonly websocketsEnabled: boolean;
+  readonly concurrentUpdatesEnabled: boolean;
+  readonly experimentalEditorToolbarEnabled: boolean;
 }
 
 @Injectable({
@@ -13,7 +13,6 @@ export class ExperimentService {
   private readonly settings: ExperimentSettings;
 
   constructor() {
-    // Get experiment settings from window object
     const windowSettings = (window as any).__MESOP_EXPERIMENTS__;
     this.settings = windowSettings ?? {
       websocketsEnabled: false,

--- a/mesop/web/src/services/experiment_service.ts
+++ b/mesop/web/src/services/experiment_service.ts
@@ -1,10 +1,36 @@
 import {Injectable} from '@angular/core';
 
+interface ExperimentSettings {
+  websocketsEnabled: boolean;
+  concurrentUpdatesEnabled: boolean;
+  experimentalEditorToolbarEnabled: boolean;
+}
+
 @Injectable({
   providedIn: 'root',
 })
 export class ExperimentService {
-  concurrentUpdatesEnabled = false;
-  experimentalEditorToolbarEnabled = false;
-  websocketsEnabled = false;
+  private readonly settings: ExperimentSettings;
+
+  constructor() {
+    // Get experiment settings from window object
+    const windowSettings = (window as any).__MESOP_EXPERIMENTS__;
+    this.settings = windowSettings ?? {
+      websocketsEnabled: false,
+      concurrentUpdatesEnabled: false,
+      experimentalEditorToolbarEnabled: false,
+    };
+  }
+
+  get websocketsEnabled(): boolean {
+    return this.settings.websocketsEnabled;
+  }
+
+  get concurrentUpdatesEnabled(): boolean {
+    return this.settings.concurrentUpdatesEnabled;
+  }
+
+  get experimentalEditorToolbarEnabled(): boolean {
+    return this.settings.experimentalEditorToolbarEnabled;
+  }
 }


### PR DESCRIPTION
It's better to send the experiment settings on initial page load rather than getting them from the first render, particularly for the websockets configuration because it can result in a weird edge case where the first UI request is over SSE (HTTP) and all the subsequent requests is over WebSockets. Because Mesop has very different behavior under WebSockets (e.g. state is kept in-memory and never sent over the network) compared to SSE, mixing SSE and WebSockets over a single browser session can result in weird edge cases. 