### PR TITLE
Fix clearing query params when navigating

### DIFF
--- a/mesop/commands/navigate.py
+++ b/mesop/commands/navigate.py
@@ -3,9 +3,6 @@ from typing import Sequence
 from mesop.features.query_params import (
   QueryParams,
 )
-from mesop.features.query_params import (
-  query_params as me_query_params,
-)
 from mesop.runtime import runtime
 from mesop.utils.url_utils import remove_url_query_param
 from mesop.warn import warn
@@ -35,5 +32,5 @@ def navigate(
 
   # Clear the query params because the query params will
   # either be replaced with the new query_params or emptied (in server.py).
-  me_query_params.clear()
+  runtime().context().query_params().clear()
   runtime().context().navigate(cleaned_url, query_params)

--- a/mesop/tests/e2e/query_params_test.ts
+++ b/mesop/tests/e2e/query_params_test.ts
@@ -153,6 +153,24 @@ test('query_param: navigate to another page with query params', async ({
   expect(new URL(page.url()).search).toEqual('?on_load=loaded');
 });
 
+test('query_param: back nav preserves query params', async ({page}) => {
+  await page.goto('/examples/query_params');
+  await page
+    .getByRole('button', {name: 'navigate to page 2 without query params'})
+    .click();
+
+  // Make sure navigation to page 2 has completed
+  await expect(page.getByText('query_params(page_2)={}')).toBeVisible();
+  // Navigate back to page 1
+  await page.goBack();
+
+  // Assert the query params are preserved.
+  await expect(
+    page.getByText(`query_params={'on_load': ['loaded']}`),
+  ).toBeVisible();
+  expect(new URL(page.url()).search).toEqual('?on_load=loaded');
+});
+
 test('query_param: navigate to another page with dict', async ({page}) => {
   await page.goto('/examples/query_params');
   await page


### PR DESCRIPTION
The previous implementation had a flaw where it issued a command to clear the query params which resulted in replacing the browser history entry, which means that back navigations would not restore the original query params. (The e2e test case demonstrates this issue).