### PR TITLE
Skip unnecessary trace render loop in WebSockets mode

### DIFF
--- a/mesop/runtime/context.py
+++ b/mesop/runtime/context.py
@@ -35,7 +35,6 @@ class Context:
     self._states: dict[type[Any], object] = states
     # Previous states is used for performing state diffs.
     self._previous_states: dict[type[Any], object] = copy.deepcopy(states)
-    self._trace_mode = False
     self._handlers: dict[str, Handler] = {}
     self._commands: list[pb.Command] = []
     self._node_slot: pb.Component | None = None
@@ -191,11 +190,7 @@ class Context:
     return self._viewport_size
 
   def register_event_handler(self, fn_id: str, handler: Handler) -> None:
-    if self._trace_mode:
-      self._handlers[fn_id] = handler
-
-  def set_trace_mode(self, trace_mode: bool) -> None:
-    self._trace_mode = trace_mode
+    self._handlers[fn_id] = handler
 
   def current_node(self) -> pb.Component:
     return self._current_node

--- a/mesop/runtime/runtime.py
+++ b/mesop/runtime/runtime.py
@@ -108,9 +108,7 @@ class Runtime:
         lambda: not self.is_hot_reload_in_progress, initial_delay=0.100
       )
 
-  def run_path(self, path: str, trace_mode: bool = False) -> None:
-    self.context().set_trace_mode(trace_mode)
-
+  def run_path(self, path: str) -> None:
     if path not in self._path_to_page_config:
       paths = list(self._path_to_page_config.keys())
       if not paths:


### PR DESCRIPTION
This skips the trace mode render loop in WebSockets mode which is a significant perf improvement, since we can use the last render loop because the Context is long-lived across multiple UI requests (for the same session).

This always registers the event handler regardless of whether we're in trace mode. For non-WebSockets mode, there's no practical difference.