### PR TITLE
Allow blob as a valid origin for img/media

### DIFF
--- a/mesop/server/static_file_serving.py
+++ b/mesop/server/static_file_serving.py
@@ -233,8 +233,8 @@ def configure_static_file_serving(
         # Mesop app developers should be able to iframe other sites.
         "frame-src": "*",
         # Mesop app developers should be able to load images and media from various origins.
-        "img-src": "'self' data: https: http:",
-        "media-src": "'self' data: https:",
+        "img-src": "'self' data: https: http: blob:",
+        "media-src": "'self' data: https: blob:",
         # Need 'unsafe-inline' because we apply inline styles for our components.
         # This is also used by Angular for animations:
         # https://github.com/angular/angular/pull/55260

--- a/mesop/tests/e2e/snapshots/web_security_test.ts_csp-allowed-iframe-parents.txt
+++ b/mesop/tests/e2e/snapshots/web_security_test.ts_csp-allowed-iframe-parents.txt
@@ -1,8 +1,8 @@
 default-src 'self'
 font-src fonts.gstatic.com data:
 frame-src *
-img-src 'self' data: https: http:
-media-src 'self' data: https:
+img-src 'self' data: https: http: blob:
+media-src 'self' data: https: blob:
 style-src 'self' 'unsafe-inline' fonts.googleapis.com
 script-src 'self' 'nonce-{{NONCE}}'
 trusted-types angular angular#unsafe-bypass lit-html highlight.js

--- a/mesop/tests/e2e/snapshots/web_security_test.ts_csp-escaping.txt
+++ b/mesop/tests/e2e/snapshots/web_security_test.ts_csp-escaping.txt
@@ -1,8 +1,8 @@
 default-src 'self'
 font-src fonts.gstatic.com data:
 frame-src *
-img-src 'self' data: https: http:
-media-src 'self' data: https:
+img-src 'self' data: https: http: blob:
+media-src 'self' data: https: blob:
 style-src 'self' 'unsafe-inline' fonts.googleapis.com http://google.com/stylesheets%2C1%3B2
 script-src 'self' 'nonce-{{NONCE}}' http://google.com/allowed_script_srcs/1%2C1%3B2 http://google.com/allowed_script_srcs/2%2C1%3B2
 trusted-types angular angular#unsafe-bypass lit-html highlight.js

--- a/mesop/tests/e2e/snapshots/web_security_test.ts_csp-trusted-types.txt
+++ b/mesop/tests/e2e/snapshots/web_security_test.ts_csp-trusted-types.txt
@@ -1,8 +1,8 @@
 default-src 'self'
 font-src fonts.gstatic.com data:
 frame-src *
-img-src 'self' data: https: http:
-media-src 'self' data: https:
+img-src 'self' data: https: http: blob:
+media-src 'self' data: https: blob:
 style-src 'self' 'unsafe-inline' fonts.googleapis.com
 script-src 'self' 'nonce-{{NONCE}}'
 trusted-types angular angular#unsafe-bypass lit-html highlight.js ttpolicy1 ttpolicy2

--- a/mesop/tests/e2e/snapshots/web_security_test.ts_csp.txt
+++ b/mesop/tests/e2e/snapshots/web_security_test.ts_csp.txt
@@ -1,8 +1,8 @@
 default-src 'self'
 font-src fonts.gstatic.com data:
 frame-src *
-img-src 'self' data: https: http:
-media-src 'self' data: https:
+img-src 'self' data: https: http: blob:
+media-src 'self' data: https: blob:
 style-src 'self' 'unsafe-inline' fonts.googleapis.com
 script-src 'self' 'nonce-{{NONCE}}'
 trusted-types angular angular#unsafe-bypass lit-html highlight.js


### PR DESCRIPTION
For example, if you use mux.com, their mux player will try to load the video from the blob origin.