### PR TITLE
Fixes major memory leak in component renderer

### DIFF
--- a/mesop/version.py
+++ b/mesop/version.py
@@ -1,6 +1,6 @@
 """Contains the version string."""
 
-VERSION = "0.12.9"
+VERSION = "0.12.10beta5"
 
 if __name__ == "__main__":
   print(VERSION)

--- a/mesop/version.py
+++ b/mesop/version.py
@@ -1,6 +1,6 @@
 """Contains the version string."""
 
-VERSION = "0.12.10beta5"
+VERSION = "0.12.9"
 
 if __name__ == "__main__":
   print(VERSION)

--- a/mesop/web/src/component_renderer/component_renderer.ts
+++ b/mesop/web/src/component_renderer/component_renderer.ts
@@ -69,7 +69,6 @@ export class ComponentRenderer {
       );
     }
     if (this.projectedViewRef) {
-      this.applicationRef.detachView(this.projectedViewRef);
       this.projectedViewRef.destroy();
     }
   }

--- a/mesop/web/src/component_renderer/component_renderer.ts
+++ b/mesop/web/src/component_renderer/component_renderer.ts
@@ -67,9 +67,6 @@ export class ComponentRenderer {
         MESOP_EVENT_NAME,
         this.dispatchCustomUserEvent,
       );
-      if (this.customElement.parentNode) {
-        this.customElement.parentNode.removeChild(this.customElement);
-      }
     }
     if (this.projectedViewRef) {
       this.applicationRef.detachView(this.projectedViewRef);
@@ -217,10 +214,10 @@ export class ComponentRenderer {
     if (this.component.getChildrenList().length) {
       this.projectedViewRef = this.childrenTemplate.createEmbeddedView(this);
       // Need to attach view or it doesn't render.
-      // View automatically detaches when it is destroyed.
-      // Template will destroy each ViewRef when it is destroyed.
-      const index = this.component.getType()?.getTypeIndex() ?? 0;
+      // ApplicationRef will automatically detach the view
+      // when the view ref is destroyed.
       this.applicationRef.attachView(this.projectedViewRef);
+      const index = this.component.getType()?.getTypeIndex() ?? 0;
       const projectableNodes = [];
       projectableNodes[index] = this.projectedViewRef.rootNodes;
       options = {


### PR DESCRIPTION
If you navigate to the same pages over and over again, you can measure an significant increase in JS memory (heap snapshots). The main contributor was that we weren't cleaning up the embedded view refs.