### PR TITLE
Restore hot reload functionality

### DIFF
--- a/mesop/web/src/app/editor/BUILD
+++ b/mesop/web/src/app/editor/BUILD
@@ -17,7 +17,7 @@ ng_module(
         "*.ts",
     ]),
     deps = [
-        "//mesop/web/src/shell",
+        "//mesop/web/src/editor",
     ] + ANGULAR_CORE_DEPS,
 )
 

--- a/mesop/web/src/app/editor/bundle.ts
+++ b/mesop/web/src/app/editor/bundle.ts
@@ -1,3 +1,3 @@
-import {bootstrapApp} from '../../shell/shell';
+import {bootstrapApp} from '../../editor/editor';
 
 bootstrapApp();

--- a/mesop/web/src/app/editor/index.html
+++ b/mesop/web/src/app/editor/index.html
@@ -16,7 +16,7 @@
     <!-- Inject favicon -->
   </head>
   <body>
-    <mesop-app ngCspNonce="$$INSERT_CSP_NONCE$$"></mesop-app>
+    <mesop-editor-app ngCspNonce="$$INSERT_CSP_NONCE$$"></mesop-editor-app>
     <!-- Inject livereload script (if needed) -->
     <!-- Inject experiment settings script (if needed) -->
     <script src="zone.js/bundles/zone.umd.js"></script>

--- a/mesop/web/src/editor/BUILD
+++ b/mesop/web/src/editor/BUILD
@@ -1,0 +1,20 @@
+load("//build_defs:defaults.bzl", "ANGULAR_CDK_TS_DEPS", "ANGULAR_CORE_DEPS", "ANGULAR_MATERIAL_TS_DEPS", "ng_module")
+
+package(
+    default_visibility = ["//build_defs:mesop_internal"],
+)
+
+ng_module(
+    name = "editor",
+    srcs = glob([
+        "*.ts",
+    ]),
+    deps = [
+        "//mesop/protos:ui_jspb_proto",
+        "//mesop/web/src/component_renderer",
+        "//mesop/web/src/error",
+        "//mesop/web/src/services",
+        "//mesop/web/src/shell",
+        "//mesop/web/src/utils",
+    ] + ANGULAR_CORE_DEPS + ANGULAR_CDK_TS_DEPS + ANGULAR_MATERIAL_TS_DEPS,
+)

--- a/mesop/web/src/editor/editor.ts
+++ b/mesop/web/src/editor/editor.ts
@@ -1,6 +1,3 @@
-// Keep the following comment to ensure there's a hook for adding TS imports in the downstream sync.
-// ADD_TS_IMPORT_HERE
-
 import {Component} from '@angular/core';
 import {
   DefaultHotReloadWatcher,
@@ -14,6 +11,8 @@ import {
   ErrorDialogService,
 } from '../services/error_dialog_service';
 import {Shell, registerComponentRendererElement} from '../shell/shell';
+// Keep the following comment to ensure there's a hook for adding TS imports in the downstream sync.
+// ADD_TS_IMPORT_HERE
 
 @Component({
   selector: 'mesop-editor',

--- a/mesop/web/src/editor/editor.ts
+++ b/mesop/web/src/editor/editor.ts
@@ -1,0 +1,51 @@
+// Keep the following comment to ensure there's a hook for adding TS imports in the downstream sync.
+// ADD_TS_IMPORT_HERE
+
+import {Component} from '@angular/core';
+import {
+  DefaultHotReloadWatcher,
+  HotReloadWatcher,
+} from '../services/hot_reload_watcher';
+import {bootstrapApplication} from '@angular/platform-browser';
+import {provideAnimations} from '@angular/platform-browser/animations';
+import {RouterOutlet, Routes, provideRouter} from '@angular/router';
+import {
+  DebugErrorDialogService,
+  ErrorDialogService,
+} from '../services/error_dialog_service';
+import {Shell, registerComponentRendererElement} from '../shell/shell';
+
+@Component({
+  selector: 'mesop-editor',
+  template: '<mesop-shell></mesop-shell>',
+  standalone: true,
+  imports: [Shell],
+  providers: [{provide: HotReloadWatcher, useClass: DefaultHotReloadWatcher}],
+})
+class Editor {
+  constructor(
+    private readonly hotReloadWatcher: HotReloadWatcher /* Inject hotReloadWatcher to ensure it's instantiated. */,
+  ) {}
+}
+
+const routes: Routes = [{path: '**', component: Editor}];
+
+@Component({
+  selector: 'mesop-editor-app',
+  template: '<router-outlet></router-outlet>',
+  imports: [Editor, RouterOutlet],
+  standalone: true,
+})
+class MesopEditorApp {}
+
+export async function bootstrapApp() {
+  const app = await bootstrapApplication(MesopEditorApp, {
+    providers: [
+      provideAnimations(),
+      provideRouter(routes),
+      {provide: HotReloadWatcher, useClass: DefaultHotReloadWatcher},
+      {provide: ErrorDialogService, useClass: DebugErrorDialogService},
+    ],
+  });
+  registerComponentRendererElement(app);
+}

--- a/mesop/web/src/editor/editor.ts
+++ b/mesop/web/src/editor/editor.ts
@@ -42,7 +42,6 @@ export async function bootstrapApp() {
     providers: [
       provideAnimations(),
       provideRouter(routes),
-      {provide: HotReloadWatcher, useClass: DefaultHotReloadWatcher},
       {provide: ErrorDialogService, useClass: DebugErrorDialogService},
     ],
   });


### PR DESCRIPTION
I was over-zealous in #1135 which ended up breaking hot reload. I've restored the editor module to restore hot reload and also not break the downstream sync which has specific hooks on editor.