### PR TITLE
Fix missing type hints for @content_component

### DIFF
--- a/mesop/component_helpers/helper.py
+++ b/mesop/component_helpers/helper.py
@@ -93,7 +93,7 @@ class _UserCompositeComponent:
     runtime().context().set_current_node(self.prev_current_node)
 
 
-def content_component(fn: Callable[..., Any]):
+def content_component(fn):
   @wraps(fn)
   def wrapper(*args: Any, **kwargs: Any):
     return _UserCompositeComponent(lambda: fn(*args, **kwargs))


### PR DESCRIPTION
I checked @component again and that seems to work. It was only @content_component which was not showing the type hints.

Not sure why removing the annotation made it so thecustom component's annotations showed up.

# Before

<img width="348" alt="Screenshot 2024-12-11 at 6 04 35 PM" src="https://github.com/user-attachments/assets/cf143b8b-ab14-43e1-894a-dbcbde438a12" />

# After

<img width="307" alt="Screenshot 2024-12-11 at 6 04 55 PM" src="https://github.com/user-attachments/assets/56842b23-351f-4d16-a56f-5f5f7be8661b" />


Closes #912