### PR TITLE
Fix typo for MESOP_WEBSOCKETS_ENABLED docs

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -244,7 +244,7 @@ Allows concurrent updates to state in the same session. If this is not updated, 
 
 By default, this is not enabled. You can enable this by setting it to `true`.
 
-### MESOP_WEB_SOCKETS_ENABLED
+### MESOP_WEBSOCKETS_ENABLED
 
 !!! warning "Experimental feature"
 


### PR DESCRIPTION
Accidentally spelled it incorrectly in the docs (I forgot whether websockets is one or two words :()