### PR TITLE
Update README.md - restore security link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Learn more in [Getting Started](https://google.github.io/mesop/getting-started/i
 
 ## Reporting a security issue
 
-If you identify a security vulnerability with Mesop, please file a [GitHub security issue](https://github.com/google/mesop/security/policy) and we will promptly respond to it.
+If you identify a security vulnerability with Mesop, please file a [GitHub security issue](https://github.com/google/mesop/security/advisories/new) and we will promptly respond to it.
 
 ## Disclaimer
 


### PR DESCRIPTION
We need to link people to directly file a security advisory on GitHub because Mesop is not an official project and the Google security team will _not_ triage security issues for this project