### PR TITLE
Update browser for karma targets

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -258,7 +258,7 @@ def karma_web_test_suite(name, **kwargs):
 
     kwargs["tags"] = ["native"] + kwargs.get("tags", [])
     kwargs["browsers"] = [
-        "@npm//@angular/build-tooling/bazel/browsers/chromium:chromium",
+        "@io_bazel_rules_webtesting//browsers:chromium-local",
     ]
 
     # Filter out options which are specific to "karma_web_test" targets. We cannot


### PR DESCRIPTION
Our karma web test targets started breaking recently on GitHub Actions because, for some reason, we can longer launch Chrome browser in a sandbox (my guess is GitHub Actions VM have changed somehow).

This uses the standard Bazel Chromium browser target rather than Angular's specific one because the the new one includes "--no-sandbox".