### PR TITLE
Make sure .env is loaded before env var are set

### DIFF
--- a/mesop/env/env.py
+++ b/mesop/env/env.py
@@ -1,6 +1,17 @@
 import os
 
+from dotenv import find_dotenv, load_dotenv
+
 from mesop.exceptions import MesopDeveloperException
+
+if os.environ.get("BUILD_WORKSPACE_DIRECTORY"):
+  # If running with Bazel, we look for `mesop/.env` from the root workspace.
+  load_dotenv()
+else:
+  # Try to load .env file for PyPi Mesop build which should be in the user's current
+  # working directory.
+  load_dotenv(find_dotenv(usecwd=True))
+
 
 AI_SERVICE_BASE_URL = os.environ.get(
   "MESOP_AI_SERVICE_BASE_URL", "http://localhost:43234"

--- a/mesop/server/config.py
+++ b/mesop/server/config.py
@@ -2,16 +2,10 @@ import os
 from pathlib import Path
 from typing import Literal
 
-from dotenv import find_dotenv, load_dotenv
 from pydantic import BaseModel
 
-if os.environ.get("BUILD_WORKSPACE_DIRECTORY"):
-  # If running with Bazel, we look for `mesop/.env` from the root workspace.
-  load_dotenv()
-else:
-  # Try to load .env file for PyPi Mesop build which should be in the user's current
-  # working directory.
-  load_dotenv(find_dotenv(usecwd=True))
+# Needed to ensure dotenv is loaded
+import mesop.env.env  # noqa: F401
 
 
 class Config(BaseModel):


### PR DESCRIPTION
Looks like the issue is that env.py gets loaded before config.py since the latter contains the code to load the .env. We may want to combine env.py and config.py. But for now, just fixing the bug.

So basically the .env file was being loaded correctly. It just wasn't handling the env vars in env.py correctly which was why I could never enable web sockets. 

Closes #1180