### PR TITLE
Only add click listener when necessary on ComponentRenderer

### DIFF
--- a/mesop/components/box/e2e/box_app.py
+++ b/mesop/components/box/e2e/box_app.py
@@ -1,9 +1,22 @@
 import mesop as me
 
 
+@me.stateclass
+class State:
+  inner_counter: int = 0
+  outer_counter: int = 0
+
+
 @me.page(path="/components/box/e2e/box_app")
 def app():
-  with me.box(style=me.Style(background="red", padding=me.Padding.all(16))):
+  state = me.state(State)
+  me.text(f"Outer counter: {state.outer_counter}")
+  me.text(f"Inner counter: {state.inner_counter}")
+  with me.box(
+    style=me.Style(background="red", padding=me.Padding.all(16)),
+    on_click=on_outer_click,
+  ):
+    me.text(text="outer-box")
     with me.box(
       style=me.Style(
         background="green",
@@ -13,7 +26,17 @@ def app():
           horizontal=me.BorderSide(width=2, color="pink", style="solid"),
           vertical=me.BorderSide(width=2, color="orange", style="solid"),
         ),
-      )
+      ),
+      on_click=on_inner_click,
     ):
-      me.text(text="hi1")
-      me.text(text="hi2")
+      me.text(text="inner-box")
+
+
+def on_outer_click(e: me.ClickEvent):
+  state = me.state(State)
+  state.outer_counter += 1
+
+
+def on_inner_click(e: me.ClickEvent):
+  state = me.state(State)
+  state.inner_counter += 1

--- a/mesop/components/box/e2e/box_test.ts
+++ b/mesop/components/box/e2e/box_test.ts
@@ -1,7 +1,10 @@
 import {test, expect} from '@playwright/test';
 
-test('test', async ({page}) => {
+test('test box', async ({page}) => {
   await page.goto('/components/box/e2e/box_app');
-  expect(await page.getByText('hi1').textContent()).toContain('hi1');
-  expect(await page.getByText('hi2').textContent()).toContain('hi2');
+  await page.getByText('outer-box').click();
+  await expect(page.getByText('Outer counter: 1')).toBeVisible();
+  await page.getByText('inner-box').click();
+  await expect(page.getByText('Outer counter: 2')).toBeVisible();
+  await expect(page.getByText('Inner counter: 1')).toBeVisible();
 });

--- a/mesop/web/src/component_renderer/component_renderer.ts
+++ b/mesop/web/src/component_renderer/component_renderer.ts
@@ -72,6 +72,7 @@ export class ComponentRenderer {
     if (this.projectedViewRef) {
       this.projectedViewRef.destroy();
     }
+    this.clickListenerRemover?.();
   }
 
   getKey() {

--- a/mesop/web/src/component_renderer/component_renderer.ts
+++ b/mesop/web/src/component_renderer/component_renderer.ts
@@ -4,8 +4,8 @@ import {
   ComponentRef,
   ElementRef,
   EmbeddedViewRef,
-  HostListener,
   Input,
+  Renderer2,
   TemplateRef,
   ViewChild,
   ViewContainerRef,
@@ -52,9 +52,11 @@ export class ComponentRenderer {
   private _componentRef!: ComponentRef<BaseComponent>;
   customElement: HTMLElement | undefined;
   projectedViewRef: EmbeddedViewRef<ComponentRenderer> | undefined;
+  clickListenerRemover: (() => void) | undefined;
 
   constructor(
     private channel: Channel,
+    private renderer: Renderer2,
     private applicationRef: ApplicationRef,
     private elementRef: ElementRef,
     private errorDialogService: ErrorDialogService,
@@ -119,12 +121,26 @@ export class ComponentRenderer {
       this.updateComponentRef();
       return;
     }
+    let hasClickHandler = false;
     if (this.isBoxType()) {
       this._boxType = BoxType.deserializeBinary(
         this.component.getType()!.getValue() as unknown as Uint8Array,
       );
       // Used for determinine which component-renderer elements are not boxes.
       this.elementRef.nativeElement.setAttribute('mesop-box', 'true');
+      hasClickHandler = Boolean(this._boxType.getOnClickHandlerId());
+    }
+
+    if (hasClickHandler) {
+      if (!this.clickListenerRemover) {
+        this.clickListenerRemover = this.renderer.listen(
+          this.elementRef.nativeElement,
+          'click',
+          this.onClick.bind(this),
+        );
+      }
+    } else {
+      this.clickListenerRemover?.();
     }
 
     this.computeStyles();
@@ -308,7 +324,6 @@ Make sure the web component name is spelled the same between Python and JavaScri
     return '';
   }
 
-  @HostListener('click', ['$event'])
   onClick(event: Event) {
     if (!this._boxType) {
       return;


### PR DESCRIPTION
This keeps the current functionality `Box#on_click` but improves the performance on ComponentRenderer

I was noticing 30-45 ms spent on the click handler on my mesop app. It's particularly noticeable when there's a deep component hierarchy I think. 

This trims down the click handler to something much shorter ~10ms.