### PR TITLE
Upgrade upload-artifact action because v3 is deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: always()
         with:
-          name: playwright-report-with-static-folder
+          name: playwright-report-with-app-base
           path: playwright-report-with-app-base/
           retention-days: 30
   # Deploy docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: bazel test //mesop/...
       - name: Run playwright test (prod mode)
         run: PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-prod-mode yarn playwright test
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: always()
         with:
           name: playwright-report-prod-mode
@@ -50,7 +50,7 @@ jobs:
           retention-days: 30
       - name: Run playwright test (debug/editor mode)
         run: MESOP_DEBUG_MODE=true PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-debug-mode yarn playwright test
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: always()
         with:
           name: playwright-report-debug-mode
@@ -58,7 +58,7 @@ jobs:
           retention-days: 30
       - name: Run playwright test (concurrency)
         run: PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-concurrency yarn playwright test mesop/tests/e2e/concurrency/state_test.ts --repeat-each=48 --workers=16
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: always()
         with:
           name: playwright-report-concurrency
@@ -66,7 +66,7 @@ jobs:
           retention-days: 30
       - name: Run playwright test with concurrent updates enabled
         run: MESOP_CONCURRENT_UPDATES_ENABLED=true PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-with-concurrent-updates-enabled yarn playwright test
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: always()
         with:
           name: playwright-report-with-concurrent-updates-enabled
@@ -74,7 +74,7 @@ jobs:
           retention-days: 30
       - name: Run playwright test with websockets enabled
         run: MESOP_WEBSOCKETS_ENABLED=true PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-with-websockets-enabled yarn playwright test
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: always()
         with:
           name: playwright-report-with-websockets-enabled
@@ -82,7 +82,7 @@ jobs:
           retention-days: 30
       - name: Run playwright test with memory state session
         run: MESOP_STATE_SESSION_BACKEND=memory PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-with-memory-state-session yarn playwright test
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: always()
         with:
           name: playwright-report-with-memory-state-session
@@ -90,7 +90,7 @@ jobs:
           retention-days: 30
       - name: Run playwright test with static folder
         run: MESOP_STATIC_FOLDER=mesop/static PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-with-static-folder yarn playwright test mesop/tests/e2e/static_folder_test.ts
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: always()
         with:
           name: playwright-report-with-static-folder
@@ -98,7 +98,7 @@ jobs:
           retention-days: 30
       - name: Run playwright test with app base
         run: MESOP_APP_BASE_PATH=$PWD/mesop/examples/app_base MESOP_STATIC_FOLDER=static PLAYWRIGHT_HTML_OUTPUT_DIR=playwright-report-with-static-folder yarn playwright test mesop/tests/e2e/app_base_test.ts
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: always()
         with:
           name: playwright-report-with-static-folder

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         if: always()
         with:
           name: playwright-report-with-static-folder
-          path: playwright-report-with-static-folder/
+          path: playwright-report-with-app-base/
           retention-days: 30
   # Deploy docs
   deploy-docs:


### PR DESCRIPTION
Notes: https://github.com/actions/upload-artifact

This fixes a non-unique artifact path which is enforced by upload-artifact@v4 (and is a good practice).

This pins it to a specific hash (which is best practice for security/reproducibility)