### PR TITLE
Bump GitHub actions workflow hash because it's outdated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@af6d1c371f387efd5703a24739412ea862c3218e
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@d16848fd2ed19fce59488b540fa26a3353c72ad4
         with:
           cache-node-modules: true
       - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@af6d1c371f387efd5703a24739412ea862c3218e
+        uses: angular/dev-infra/github-actions/bazel/setup@d16848fd2ed19fce59488b540fa26a3353c72ad4
       - name: Install node modules
         run: yarn install --frozen-lockfile
       - name: Pre-commit hook (requires yarn install)


### PR DESCRIPTION
Example of [failed run](https://github.com/google/mesop/actions/runs/13642334515/job/38134708555?pr=1215):

```
Download action repository 'angular/dev-infra@af6d1c371f387efd5703a24739412ea862c3218e' (SHA:af6d1c371f387efd5703a24739412ea862c3218e)
Download action repository 'pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507' (SHA:646c83fcd040023954eafda54b4db0192ce70507)
Download action repository 'actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08' (SHA:65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08)
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: 704facf57e6136b1bc63b828d79edcd491f0ee84`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/[20](https://github.com/google/mesop/actions/runs/13642334515/job/38134708555?pr=1215#step:1:24)24-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```