### PR TITLE
Add support for font-src

### DIFF
--- a/mesop/examples/testing/__init__.py
+++ b/mesop/examples/testing/__init__.py
@@ -14,6 +14,9 @@ from mesop.examples.testing import (
   csp_escaping as csp_escaping,
 )
 from mesop.examples.testing import (
+  csp_font_srcs as csp_font_srcs,
+)
+from mesop.examples.testing import (
   csp_trusted_types as csp_trusted_types,
 )
 from mesop.examples.testing import (

--- a/mesop/examples/testing/csp_font_srcs.py
+++ b/mesop/examples/testing/csp_font_srcs.py
@@ -1,0 +1,12 @@
+import mesop as me
+
+
+@me.page(
+  path="/testing/csp_font_srcs",
+  title="CSP font_srcs",
+  security_policy=me.SecurityPolicy(
+    allowed_font_srcs=["fontsrc1", "fontsrc2"],
+  ),
+)
+def page():
+  me.text("CSP font srcs")

--- a/mesop/security/security_policy.py
+++ b/mesop/security/security_policy.py
@@ -14,6 +14,7 @@ class SecurityPolicy:
     allowed_script_srcs: A list of sites you can load scripts from, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src).
     allowed_worker_srcs. A list of sites you can load workers from, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src).
     allowed_trusted_types: A list of trusted type policy names, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types).
+    allowed_font_srcs: A list of sites you can load fonts from, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src).
     dangerously_disable_trusted_types: A flag to disable trusted types.
       Highly recommended to not disable trusted types because
       it's an important web security feature!
@@ -24,6 +25,7 @@ class SecurityPolicy:
   allowed_script_srcs: list[str] = field(default_factory=list)
   allowed_worker_srcs: list[str] = field(default_factory=list)
   allowed_trusted_types: list[str] = field(default_factory=list)
+  allowed_font_srcs: list[str] = field(default_factory=list)
   dangerously_disable_trusted_types: bool = False
 
   def __post_init__(self):

--- a/mesop/server/static_file_serving.py
+++ b/mesop/server/static_file_serving.py
@@ -276,7 +276,6 @@ def configure_static_file_serving(
         ]
       )
     if security_policy and security_policy.allowed_font_srcs:
-      print(security_policy.allowed_font_srcs)
       csp["font-src"] += " " + " ".join(
         [sanitize_url_for_csp(url) for url in security_policy.allowed_font_srcs]
       )

--- a/mesop/server/static_file_serving.py
+++ b/mesop/server/static_file_serving.py
@@ -275,6 +275,11 @@ def configure_static_file_serving(
           for url in security_policy.allowed_worker_srcs
         ]
       )
+    if security_policy and security_policy.allowed_font_srcs:
+      print(security_policy.allowed_font_srcs)
+      csp["font-src"] += " " + " ".join(
+        [sanitize_url_for_csp(url) for url in security_policy.allowed_font_srcs]
+      )
     if security_policy and security_policy.allowed_trusted_types:
       csp["trusted-types"] += " " + " ".join(
         security_policy.allowed_trusted_types

--- a/mesop/tests/e2e/snapshots/web_security_test.ts_csp-allowed-font-srcs.txt
+++ b/mesop/tests/e2e/snapshots/web_security_test.ts_csp-allowed-font-srcs.txt
@@ -1,0 +1,11 @@
+default-src 'self'
+font-src 'self' fonts.gstatic.com data: fontsrc1 fontsrc2
+frame-src *
+img-src 'self' data: https: http: blob:
+media-src 'self' data: https: blob:
+style-src 'self' 'unsafe-inline' fonts.googleapis.com
+script-src 'self' 'nonce-{{NONCE}}'
+trusted-types angular angular#unsafe-bypass lit-html highlight.js
+require-trusted-types-for 'script'
+report-uri /__csp__
+frame-ancestors 'self'

--- a/mesop/tests/e2e/web_security_test.ts
+++ b/mesop/tests/e2e/web_security_test.ts
@@ -20,6 +20,12 @@ testInProdOnly('csp escaping', async ({page}) => {
   expect(cleanCsp(csp)).toMatchSnapshot('csp_escaping.txt');
 });
 
+testInProdOnly('csp font srcs', async ({page}) => {
+  const response = await page.goto('/testing/csp_font_srcs');
+  const csp = response?.headers()['content-security-policy']!;
+  expect(cleanCsp(csp)).toMatchSnapshot('csp_allowed_font_srcs.txt');
+});
+
 testInProdOnly('csp trusted types', async ({page}) => {
   const response = await page.goto('/testing/csp_trusted_types');
   const csp = response?.headers()['content-security-policy']!;


### PR DESCRIPTION
One example use case is when a stylesheet contains references to remote font files. These files will get blocked by CSP unless added to font-src