### PR TITLE
Upgrade text_io warning to error (prep for v1)

### DIFF
--- a/docs/components/text-to-text.md
+++ b/docs/components/text-to-text.md
@@ -13,5 +13,3 @@ Text to text component allows you to take in user inputted text and return a tra
 ## API
 
 ::: mesop.labs.text_to_text.text_to_text
-
-::: mesop.labs.text_to_text.text_io

--- a/mesop/labs/text_to_text.py
+++ b/mesop/labs/text_to_text.py
@@ -2,7 +2,7 @@ import types
 from typing import Callable, Generator, Literal, cast
 
 import mesop as me
-from mesop.warn import warn
+from mesop.exceptions import MesopDeveloperException
 
 
 @me.stateclass
@@ -31,8 +31,9 @@ def text_io(
                   - "append": Concatenates each new piece of text to the existing output.
                   - "replace": Replaces the existing output with each new piece of text.
   """
-  warn("text_io is deprecated, use text_to_text instead")
-  text_to_text(transform=transform, title=title, transform_mode=transform_mode)
+  raise MesopDeveloperException(
+    "text_io has been removed. Use text_to_text instead. See: https://google.github.io/mesop/components/text-to-text/"
+  )
 
 
 def text_to_text(


### PR DESCRIPTION
I can't find any usage of text_io on GitHub - see https://sourcegraph.com/search?q=context:global++mel.text_io%28&patternType=keyword&sm=0

I think it's safe to remove this as we throw an error and it's pretty easy to migrate to text_to_text (one-line change)