### PR TITLE
Fix loading bar not resetting on network errors

### DIFF
--- a/mesop/web/src/services/channel.ts
+++ b/mesop/web/src/services/channel.ts
@@ -165,20 +165,26 @@ export class Channel {
     });
 
     this.eventSource.addEventListener('error', (e) => {
-      zone.run(() => {
+      zone.run(async () => {
         console.error('SSE error:', e);
+        this.status = ChannelStatus.CLOSED;
         clearTimeout(this.isWaitingTimeout);
         this.isWaiting = false;
         this._isHotReloading = false;
+        await this.processMessageQueue();
+        this.dequeueEvent();
       });
     });
 
     this.eventSource.addEventListener('abort', (e) => {
-      zone.run(() => {
+      zone.run(async () => {
         console.error('SSE aborted:', e);
+        this.status = ChannelStatus.CLOSED;
         clearTimeout(this.isWaitingTimeout);
         this.isWaiting = false;
         this._isHotReloading = false;
+        await this.processMessageQueue();
+        this.dequeueEvent();
       });
     });
   }
@@ -235,22 +241,26 @@ export class Channel {
     };
 
     this.webSocket.onerror = (error) => {
-      zone.run(() => {
+      zone.run(async () => {
         console.error('WebSocket error:', error);
         this.status = ChannelStatus.CLOSED;
         clearTimeout(this.isWaitingTimeout);
         this.isWaiting = false;
         this._isHotReloading = false;
+        await this.processMessageQueue();
+        this.dequeueEvent();
       });
     };
 
     this.webSocket.onclose = (event) => {
-      zone.run(() => {
+      zone.run(async () => {
         console.error('WebSocket closed:', event.reason);
         this.status = ChannelStatus.CLOSED;
         clearTimeout(this.isWaitingTimeout);
         this.isWaiting = false;
         this._isHotReloading = false;
+        await this.processMessageQueue();
+        this.dequeueEvent();
 
         // Attempt to reconnect if we haven't exceeded max attempts
         if (this.wsReconnectAttempts < this.wsMaxReconnectAttempts) {


### PR DESCRIPTION
When Chrome encounters ERR_NETWORK_CHANGED or other network errors,
the SSE/WebSocket connection is terminated abnormally without sending
a STREAM_END signal. This caused the loading bar to remain visible
indefinitely because the isWaiting flag and timeout were never cleared.

This fix adds proper error handling:
- For SSE: Added 'error' and 'abort' event listeners
- For WebSocket: Updated 'onerror' and 'onclose' handlers
Both now properly clear the isWaitingTimeout and reset the isWaiting
and _isHotReloading flags to ensure the loading bar hides correctly.

Fixes #1312