### PR TITLE
Fix query params not being read/updated correctly in WebSocket mode (#1283)

### DIFF
--- a/mesop/runtime/context.py
+++ b/mesop/runtime/context.py
@@ -150,6 +150,9 @@ class Context:
     return self._query_params
 
   def initialize_query_params(self, query_params: Sequence[pb.QueryParam]):
+    # Clear existing query params first to avoid stale params in WebSocket mode
+    # where the context is persistent across requests
+    self._query_params = {}
     for query_param in query_params:
       self._query_params[query_param.key] = list(query_param.values)
 
@@ -160,12 +163,13 @@ class Context:
       self._query_params[key] = (
         [value] if isinstance(value, str) else list(value)
       )
+    # Create UpdateQueryParam command with proper values
+    # For deletion (value=None), use empty list [] instead of None
+    values = [] if value is None else ([value] if isinstance(value, str) else value)
     self._commands.append(
       pb.Command(
         update_query_param=pb.UpdateQueryParam(
-          query_param=pb.QueryParam(
-            key=key, values=[value] if isinstance(value, str) else value
-          )
+          query_param=pb.QueryParam(key=key, values=values)
         )
       )
     )


### PR DESCRIPTION
This fixes two bugs in query parameter handling:

1. **initialize_query_params** wasn't clearing existing params before
   initializing new ones. In WebSocket mode, the Context is persistent
   across requests (stored in self._contexts), so old query params would
   stick around when they should be cleared. This caused query params
   from the URL to not be read correctly on subsequent navigations.

2. **set_query_param** was passing `values=None` to the protobuf when
   deleting a query param (value=None case), instead of `values=[]`.
   This caused the URL to not be updated correctly when query params
   were deleted.

These bugs only manifested in WebSocket mode because in regular SSE mode,
a new Context is created for each request (stored in Flask's g object).

Fixes #1283