### PR TITLE
Fix query params usage with web sockets

### DIFF
--- a/mesop/features/query_params.py
+++ b/mesop/features/query_params.py
@@ -35,4 +35,4 @@ class QueryParams(MutableMapping[str, str]):
     self._get_context().set_query_param(key=key, value=value)
 
 
-query_params = QueryParams(runtime().context)
+query_params = QueryParams(lambda: runtime().context())


### PR DESCRIPTION
- With web sockets we need to create a new runtime each time
- Otherwise we keep using the original runtime which won't have the updated query params
- Closes https://github.com/mesop-dev/mesop/issues/1283