### PR TITLE
Use bracket notation for window property access

### DIFF
--- a/mesop/web/src/services/BUILD
+++ b/mesop/web/src/services/BUILD
@@ -1,4 +1,4 @@
-load("//build_defs:defaults.bzl", "ANGULAR_CORE_DEPS", "ANGULAR_MATERIAL_TS_DEPS", "ng_module")
+load("//build_defs:defaults.bzl", "ANGULAR_CORE_DEPS", "ANGULAR_MATERIAL_TS_DEPS", "ng_module", "ng_test_library", "ng_web_test_suite")
 
 package(
     default_visibility = ["//build_defs:mesop_internal"],
@@ -6,11 +6,27 @@ package(
 
 ng_module(
     name = "services",
-    srcs = glob([
-        "*.ts",
-    ]),
+    srcs = glob(
+        ["*.ts"],
+        exclude = ["*_spec.ts"],
+    ),
     deps = [
         "//mesop/protos:ui_jspb_proto",
         "//mesop/web/src/utils",
     ] + ANGULAR_CORE_DEPS + ANGULAR_MATERIAL_TS_DEPS,
+)
+
+ng_test_library(
+    name = "services_test_lib",
+    srcs = glob(["*_spec.ts"]),
+    deps = [
+        ":services",
+    ] + ANGULAR_CORE_DEPS,
+)
+
+ng_web_test_suite(
+    name = "unit_tests",
+    deps = [
+        ":services_test_lib",
+    ],
 )

--- a/mesop/web/src/services/channel.ts
+++ b/mesop/web/src/services/channel.ts
@@ -569,7 +569,7 @@ function createDeferred<T = void>(): {
 
 function generatePayloadString(request: UiRequest): string {
   let path = window.location.pathname;
-  const base = (window as any).__MESOP_BASE_URL_PATH__ as string | undefined;
+  const base = (window as any)['__MESOP_BASE_URL_PATH__'] as string | undefined;
   if (base && path.startsWith(base)) {
     path = path.slice(base.length) || '/';
   }

--- a/mesop/web/src/services/experiment_service.ts
+++ b/mesop/web/src/services/experiment_service.ts
@@ -12,7 +12,7 @@ export class ExperimentService {
   private readonly settings: ExperimentSettings;
 
   constructor() {
-    const windowSettings = (window as any).__MESOP_EXPERIMENTS__;
+    const windowSettings = (window as any)['__MESOP_EXPERIMENTS__'];
     this.settings = windowSettings ?? {
       websocketsEnabled: false,
     };

--- a/mesop/web/src/services/experiment_service_spec.ts
+++ b/mesop/web/src/services/experiment_service_spec.ts
@@ -2,7 +2,7 @@ import {ExperimentService} from 'mesop/mesop/web/src/services/experiment_service
 
 describe('ExperimentService', () => {
   afterEach(() => {
-    delete (window as any).__MESOP_EXPERIMENTS__;
+    (window as any).__MESOP_EXPERIMENTS__ = undefined;
   });
 
   it('uses default settings when __MESOP_EXPERIMENTS__ is not set', () => {

--- a/mesop/web/src/services/experiment_service_spec.ts
+++ b/mesop/web/src/services/experiment_service_spec.ts
@@ -2,7 +2,7 @@ import {ExperimentService} from 'mesop/mesop/web/src/services/experiment_service
 
 describe('ExperimentService', () => {
   afterEach(() => {
-    delete (window as any)['__MESOP_EXPERIMENTS__'];
+    delete (window as any).__MESOP_EXPERIMENTS__;
   });
 
   it('uses default settings when __MESOP_EXPERIMENTS__ is not set', () => {
@@ -11,7 +11,7 @@ describe('ExperimentService', () => {
   });
 
   it('reads websocketsEnabled=true from window settings', () => {
-    (window as any)['__MESOP_EXPERIMENTS__'] = {
+    (window as any).__MESOP_EXPERIMENTS__ = {
       websocketsEnabled: true,
       webComponentsCacheKey: null,
     };
@@ -20,7 +20,7 @@ describe('ExperimentService', () => {
   });
 
   it('reads webComponentsCacheKey from window settings', () => {
-    (window as any)['__MESOP_EXPERIMENTS__'] = {
+    (window as any).__MESOP_EXPERIMENTS__ = {
       websocketsEnabled: false,
       webComponentsCacheKey: 'abc123',
     };
@@ -29,7 +29,7 @@ describe('ExperimentService', () => {
   });
 
   it('returns null webComponentsCacheKey when explicitly set to null', () => {
-    (window as any)['__MESOP_EXPERIMENTS__'] = {
+    (window as any).__MESOP_EXPERIMENTS__ = {
       websocketsEnabled: false,
       webComponentsCacheKey: null,
     };

--- a/mesop/web/src/services/experiment_service_spec.ts
+++ b/mesop/web/src/services/experiment_service_spec.ts
@@ -1,0 +1,39 @@
+import {ExperimentService} from 'mesop/mesop/web/src/services/experiment_service';
+
+describe('ExperimentService', () => {
+  afterEach(() => {
+    delete (window as any)['__MESOP_EXPERIMENTS__'];
+  });
+
+  it('uses default settings when __MESOP_EXPERIMENTS__ is not set', () => {
+    const service = new ExperimentService();
+    expect(service.websocketsEnabled).toBe(false);
+  });
+
+  it('reads websocketsEnabled=true from window settings', () => {
+    (window as any)['__MESOP_EXPERIMENTS__'] = {
+      websocketsEnabled: true,
+      webComponentsCacheKey: null,
+    };
+    const service = new ExperimentService();
+    expect(service.websocketsEnabled).toBe(true);
+  });
+
+  it('reads webComponentsCacheKey from window settings', () => {
+    (window as any)['__MESOP_EXPERIMENTS__'] = {
+      websocketsEnabled: false,
+      webComponentsCacheKey: 'abc123',
+    };
+    const service = new ExperimentService();
+    expect(service.webComponentsCacheKey).toBe('abc123');
+  });
+
+  it('returns null webComponentsCacheKey when explicitly set to null', () => {
+    (window as any)['__MESOP_EXPERIMENTS__'] = {
+      websocketsEnabled: false,
+      webComponentsCacheKey: null,
+    };
+    const service = new ExperimentService();
+    expect(service.webComponentsCacheKey).toBeNull();
+  });
+});

--- a/mesop/web/src/utils/base_path.ts
+++ b/mesop/web/src/utils/base_path.ts
@@ -1,5 +1,5 @@
 export function prefixBasePath(path: string): string {
-  const base = (window as any).__MESOP_BASE_URL_PATH__ as string | undefined;
+  const base = (window as any)['__MESOP_BASE_URL_PATH__'] as string | undefined;
   if (!base) {
     return path;
   }


### PR DESCRIPTION
## Summary
Updated window property access patterns to use bracket notation instead of dot notation for accessing dynamically-named properties.

## Key Changes
- Changed `window.__MESOP_EXPERIMENTS__` to `window['__MESOP_EXPERIMENTS__']` in ExperimentService
- Changed `window.__MESOP_BASE_URL_PATH__` to `window['__MESOP_BASE_URL_PATH__']` in base_path utility

## Implementation Details
This change improves compatibility and follows TypeScript best practices for accessing properties with special characters or dynamic names on the window object. Bracket notation is more reliable for properties that may not be recognized by type checkers and avoids potential issues with minification or property name conflicts.

https://claude.ai/code/session_01JHTYDRqtzkgz1neR6SCRZf