### PR TITLE
Support multi-file demos in demo viewer

### DIFF
--- a/demo/BUILD
+++ b/demo/BUILD
@@ -6,7 +6,10 @@ package(
 
 py_library(
     name = "demo",
-    srcs = glob(["*.py", "*/*.py"]),
+    srcs = glob([
+        "*.py",
+        "*/*.py",
+    ]),
     data = [
         ":screenshots",
         ":web_component_files",
@@ -20,7 +23,10 @@ py_library(
 # JS/CSS files for subdirectory web component demos
 filegroup(
     name = "web_component_files",
-    srcs = glob(["*/*.js", "*/*.css"]),
+    srcs = glob([
+        "*/*.js",
+        "*/*.css",
+    ]),
 )
 
 # Make source files available for distribution via pkg_npm

--- a/demo/BUILD
+++ b/demo/BUILD
@@ -6,12 +6,21 @@ package(
 
 py_library(
     name = "demo",
-    srcs = glob(["*.py"]),
-    data = [":screenshots"],
+    srcs = glob(["*.py", "*/*.py"]),
+    data = [
+        ":screenshots",
+        ":web_component_files",
+    ],
     deps = [
         "//mesop",
         "//mesop/labs",
     ],
+)
+
+# JS/CSS files for subdirectory web component demos
+filegroup(
+    name = "web_component_files",
+    srcs = glob(["*/*.js", "*/*.css"]),
 )
 
 # Make source files available for distribution via pkg_npm

--- a/demo/copy_to_clipboard/app.py
+++ b/demo/copy_to_clipboard/app.py
@@ -1,0 +1,43 @@
+import mesop as me
+from .copy_to_clipboard_component import copy_to_clipboard_component
+
+TEXT = """
+Lorem ipsum odor amet, consectetuer adipiscing elit. Libero maecenas curae
+porttitor laoreet quam proin phasellus. Efficitur hendrerit magnis volutpat sed
+nascetur; turpis vitae dis. Phasellus suspendisse eleifend mus arcu scelerisque
+quis. Eget venenatis diam dui mattis eleifend porttitor risus. Mollis eros
+fermentum lectus magnis enim dapibus magna elit. Sapien gravida arcu fusce;
+lacinia magnis donec. Nostra vulputate litora luctus id ut.
+""".strip()
+
+
+def on_load(e: me.LoadEvent):
+  me.set_theme_mode("system")
+
+
+@me.page(
+  on_load=on_load,
+  path="/copy_to_clipboard",
+  security_policy=me.SecurityPolicy(
+    allowed_iframe_parents=["https://mesop-dev.github.io"],
+    allowed_script_srcs=["https://cdn.jsdelivr.net"],
+  ),
+)
+def page():
+  with me.box(
+    style=me.Style(
+      width=300,
+      margin=me.Margin.all(15),
+      padding=me.Padding.all(10),
+      border=me.Border.all(
+        me.BorderSide(
+          width=1, color=me.theme_var("outline-variant"), style="solid"
+        )
+      ),
+    )
+  ):
+    with me.box(style=me.Style(display="flex", justify_content="end")):
+      with copy_to_clipboard_component(text=TEXT):
+        with me.content_button():
+          me.icon("content_copy")
+    me.text(TEXT)

--- a/demo/copy_to_clipboard/app.py
+++ b/demo/copy_to_clipboard/app.py
@@ -1,5 +1,5 @@
 import mesop as me
-from .copy_to_clipboard_component import copy_to_clipboard_component
+from copy_to_clipboard_component import copy_to_clipboard_component
 
 TEXT = """
 Lorem ipsum odor amet, consectetuer adipiscing elit. Libero maecenas curae

--- a/demo/copy_to_clipboard/app.py
+++ b/demo/copy_to_clipboard/app.py
@@ -1,5 +1,6 @@
-import mesop as me
 from copy_to_clipboard_component import copy_to_clipboard_component
+
+import mesop as me
 
 TEXT = """
 Lorem ipsum odor amet, consectetuer adipiscing elit. Libero maecenas curae

--- a/demo/copy_to_clipboard/copy_to_clipboard_component.js
+++ b/demo/copy_to_clipboard/copy_to_clipboard_component.js
@@ -1,0 +1,31 @@
+import {
+  LitElement,
+  html,
+} from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
+
+class CopyToClipboard extends LitElement {
+  static properties = {
+    text: {type: String},
+  };
+
+  constructor() {
+    super();
+    this.text = '';
+  }
+
+  render() {
+    return html`
+      <div @click="${this._onClick}">
+        <slot></slot>
+      </div>
+    `;
+  }
+
+  _onClick() {
+    navigator.clipboard
+      .writeText(this.text)
+      .catch((err) => console.error('Failed to copy text: ', err));
+  }
+}
+
+customElements.define('copy-to-clipboard-component', CopyToClipboard);

--- a/demo/copy_to_clipboard/copy_to_clipboard_component.py
+++ b/demo/copy_to_clipboard/copy_to_clipboard_component.py
@@ -1,0 +1,16 @@
+import mesop as me
+
+
+@me.web_component(path="./copy_to_clipboard_component.js")
+def copy_to_clipboard_component(
+  *,
+  text: str = "",
+  key: str | None = None,
+):
+  return me.insert_web_component(
+    name="copy-to-clipboard-component",
+    key=key,
+    properties={
+      "text": text,
+    },
+  )

--- a/demo/main.py
+++ b/demo/main.py
@@ -409,6 +409,7 @@ def on_load_embed(e: me.LoadEvent):
     me.set_theme_mode("dark")
   else:
     me.set_theme_mode("system")
+  me.set_theme_density(-2)
   if not is_desktop():
     state.panel_fullscreen = "preview"
   state.selected_file = ""
@@ -609,10 +610,11 @@ def demo_code(example: Example):
             ],
           ],
           value=effective_value,
+          appearance="outline",
           on_selection_change=on_file_select,
           style=me.Style(
-            margin=me.Margin(top=4, bottom=4, left=8),
-            width=300,
+            margin=me.Margin(top=4, bottom=4, left=8, right=8),
+            flex_grow=1,
           ),
         )
       else:

--- a/demo/main.py
+++ b/demo/main.py
@@ -274,7 +274,9 @@ BORDER_SIDE = me.BorderSide(
 class State:
   current_demo: str
   panel_fullscreen: Literal["preview", "editor", None] = None
-  selected_file: str = ""  # "" = main Python file; otherwise a value from extra_files
+  selected_file: str = (
+    ""  # "" = main Python file; otherwise a value from extra_files
+  )
 
 
 screenshots: dict[str, str] = {}
@@ -563,7 +565,9 @@ def _get_code_for_example(example: Example) -> tuple[str, str]:
   path = os.path.join(module_dir, state.selected_file)
   with open(path) as f:
     code = f.read()
-  ext = state.selected_file.rsplit(".", 1)[-1] if "." in state.selected_file else ""
+  ext = (
+    state.selected_file.rsplit(".", 1)[-1] if "." in state.selected_file else ""
+  )
   return code, _LANG_MAP.get(ext, "")
 
 
@@ -601,7 +605,11 @@ def demo_code(example: Example):
           if state.selected_file in example.extra_files
           else main_filename
         )
-        with me.box(style=me.Style(flex_grow=1, overflow_x="hidden")):
+        with me.box(
+          style=me.Style(
+            flex_grow=1, overflow_x="hidden", margin=me.Margin(bottom=-21)
+          )
+        ):
           me.select(
             options=[
               me.SelectOption(label=main_filename, value=main_filename),
@@ -611,10 +619,8 @@ def demo_code(example: Example):
               ],
             ],
             value=effective_value,
-            appearance="outline",
             on_selection_change=on_file_select,
             style=me.Style(
-              margin=me.Margin(top=4, bottom=4, left=8, right=8),
               width="100%",
             ),
           )

--- a/demo/main.py
+++ b/demo/main.py
@@ -601,22 +601,23 @@ def demo_code(example: Example):
           if state.selected_file in example.extra_files
           else main_filename
         )
-        me.select(
-          options=[
-            me.SelectOption(label=main_filename, value=main_filename),
-            *[
-              me.SelectOption(label=os.path.basename(f), value=f)
-              for f in example.extra_files
+        with me.box(style=me.Style(flex_grow=1, overflow_x="hidden")):
+          me.select(
+            options=[
+              me.SelectOption(label=main_filename, value=main_filename),
+              *[
+                me.SelectOption(label=os.path.basename(f), value=f)
+                for f in example.extra_files
+              ],
             ],
-          ],
-          value=effective_value,
-          appearance="outline",
-          on_selection_change=on_file_select,
-          style=me.Style(
-            margin=me.Margin(top=4, bottom=4, left=8, right=8),
-            flex_grow=1,
-          ),
-        )
+            value=effective_value,
+            appearance="outline",
+            on_selection_change=on_file_select,
+            style=me.Style(
+              margin=me.Margin(top=4, bottom=4, left=8, right=8),
+              width="100%",
+            ),
+          )
       else:
         me.text(
           "Code",

--- a/demo/main.py
+++ b/demo/main.py
@@ -31,11 +31,15 @@ def _import_demo_subdir(demo_name: str) -> types.ModuleType:
   subdir = os.path.join(current_dir, demo_name)
   if subdir not in sys.path:
     sys.path.append(subdir)
+  app_path = os.path.join(subdir, "app.py")
   spec = importlib.util.spec_from_file_location(
     demo_name,
-    os.path.join(subdir, "app.py"),
+    app_path,
   )
-  assert spec is not None and spec.loader is not None
+  if spec is None or spec.loader is None:
+    raise ImportError(
+      f"Could not load demo module '{demo_name}' from {app_path}"
+    )
   module = importlib.util.module_from_spec(spec)
   sys.modules[demo_name] = module
   spec.loader.exec_module(module)  # type: ignore[union-attr]
@@ -274,9 +278,10 @@ BORDER_SIDE = me.BorderSide(
 class State:
   current_demo: str
   panel_fullscreen: Literal["preview", "editor", None] = None
-  selected_file: str = (
-    ""  # "" = main Python file; otherwise a value from extra_files
-  )
+  # "" on initial load/reset; the main filename (e.g. "app.py") when the user
+  # explicitly selects it; or one of the extra_files values otherwise.
+  # _get_code_for_example treats any value not in extra_files as the main file.
+  selected_file: str = ""
 
 
 screenshots: dict[str, str] = {}
@@ -562,8 +567,12 @@ def _get_code_for_example(example: Example) -> tuple[str, str]:
   if state.selected_file not in example.extra_files:
     return inspect.getsource(module), "python"
   module_dir = os.path.dirname(os.path.abspath(module.__file__))
-  path = os.path.join(module_dir, state.selected_file)
-  with open(path) as f:
+  path = os.path.abspath(os.path.join(module_dir, state.selected_file))
+  # Defense in depth: reject any path that escapes the demo's own directory,
+  # even though selected_file is already validated against the extra_files allowlist.
+  if not path.startswith(module_dir + os.sep):
+    return inspect.getsource(module), "python"
+  with open(path, encoding="utf-8") as f:
     code = f.read()
   ext = (
     state.selected_file.rsplit(".", 1)[-1] if "." in state.selected_file else ""

--- a/demo/main.py
+++ b/demo/main.py
@@ -3,9 +3,11 @@
 # ruff: noqa: E402
 
 import base64
+import importlib.util
 import inspect
 import os
 import sys
+import types
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -17,6 +19,28 @@ import mesop as me
 current_dir = os.path.dirname(os.path.abspath(__file__))
 if current_dir not in sys.path:
   sys.path.append(current_dir)
+
+
+def _import_demo_subdir(demo_name: str) -> types.ModuleType:
+  """Load app.py from a demo subdirectory.
+
+  Adds the subdirectory to sys.path so that app.py can import its sibling
+  files (e.g. component .py/.js) without needing relative or package-qualified
+  imports.
+  """
+  subdir = os.path.join(current_dir, demo_name)
+  if subdir not in sys.path:
+    sys.path.append(subdir)
+  spec = importlib.util.spec_from_file_location(
+    demo_name,
+    os.path.join(subdir, "app.py"),
+  )
+  assert spec is not None and spec.loader is not None
+  module = importlib.util.module_from_spec(spec)
+  sys.modules[demo_name] = module
+  spec.loader.exec_module(module)  # type: ignore[union-attr]
+  return module
+
 
 import glob
 
@@ -75,7 +99,8 @@ import textarea as textarea
 import tooltip as tooltip
 import uploader as uploader
 import video as video
-from copy_to_clipboard import app as copy_to_clipboard
+
+copy_to_clipboard = _import_demo_subdir("copy_to_clipboard")
 
 
 @dataclass

--- a/demo/main.py
+++ b/demo/main.py
@@ -75,6 +75,7 @@ import textarea as textarea
 import tooltip as tooltip
 import uploader as uploader
 import video as video
+from copy_to_clipboard import app as copy_to_clipboard
 
 
 @dataclass
@@ -207,6 +208,13 @@ COMPONENTS_SECTIONS = [
       Example(name="embed"),
       Example(name="html_demo"),
       Example(name="link"),
+      Example(
+        name="copy_to_clipboard",
+        extra_files=[
+          "copy_to_clipboard_component.py",
+          "copy_to_clipboard_component.js",
+        ],
+      ),
     ],
   ),
   Section(

--- a/demo/main.py
+++ b/demo/main.py
@@ -233,6 +233,11 @@ COMPONENTS_SECTIONS = [
       Example(name="embed"),
       Example(name="html_demo"),
       Example(name="link"),
+    ],
+  ),
+  Section(
+    name="Web Components",
+    examples=[
       Example(
         name="copy_to_clipboard",
         extra_files=[
@@ -551,7 +556,7 @@ def _get_code_for_example(example: Example) -> tuple[str, str]:
   """Returns (source_code, language) for the currently selected file."""
   state = me.state(State)
   module = get_module(example.name)
-  if not state.selected_file:
+  if state.selected_file not in example.extra_files:
     return inspect.getsource(module), "python"
   module_dir = os.path.dirname(os.path.abspath(module.__file__))
   path = os.path.join(module_dir, state.selected_file)
@@ -590,21 +595,24 @@ def demo_code(example: Example):
       )
     ):
       if example.extra_files:
+        effective_value = (
+          state.selected_file
+          if state.selected_file in example.extra_files
+          else main_filename
+        )
         me.select(
           options=[
-            me.SelectOption(label=main_filename, value=""),
+            me.SelectOption(label=main_filename, value=main_filename),
             *[
-              me.SelectOption(
-                label=os.path.basename(f), value=f
-              )
+              me.SelectOption(label=os.path.basename(f), value=f)
               for f in example.extra_files
             ],
           ],
-          value=state.selected_file,
+          value=effective_value,
           on_selection_change=on_file_select,
           style=me.Style(
             margin=me.Margin(top=4, bottom=4, left=8),
-            width=220,
+            width=300,
           ),
         )
       else:

--- a/demo/main.py
+++ b/demo/main.py
@@ -6,7 +6,7 @@ import base64
 import inspect
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 import mesop as me
@@ -81,6 +81,8 @@ import video as video
 class Example:
   # module_name (should also be the path name)
   name: str
+  # Additional files to show in the code viewer (relative to the demo's directory)
+  extra_files: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -217,6 +219,12 @@ COMPONENTS_SECTIONS = [
 
 ALL_SECTIONS = FIRST_SECTIONS + COMPONENTS_SECTIONS
 
+ALL_EXAMPLES: dict[str, Example] = {
+  example.name: example
+  for section in ALL_SECTIONS
+  for example in section.examples
+}
+
 BORDER_SIDE = me.BorderSide(
   style="solid",
   width=1,
@@ -228,6 +236,7 @@ BORDER_SIDE = me.BorderSide(
 class State:
   current_demo: str
   panel_fullscreen: Literal["preview", "editor", None] = None
+  selected_file: str = ""  # "" = main Python file; otherwise a value from extra_files
 
 
 screenshots: dict[str, str] = {}
@@ -357,12 +366,14 @@ def example_card(name: str):
 
 
 def on_load_embed(e: me.LoadEvent):
+  state = me.state(State)
   if me.state(ThemeState).dark_mode:
     me.set_theme_mode("dark")
   else:
     me.set_theme_mode("system")
   if not is_desktop():
-    me.state(State).panel_fullscreen = "preview"
+    state.panel_fullscreen = "preview"
+  state.selected_file = ""
 
 
 def create_main_fn(example: Example):
@@ -417,7 +428,7 @@ def body(current_demo: str):
       if state.panel_fullscreen != "editor":
         demo_ui(src)
       if state.panel_fullscreen != "preview":
-        demo_code(inspect.getsource(get_module(current_demo)))
+        demo_code(ALL_EXAMPLES[current_demo])
 
 
 def demo_ui(src: str):
@@ -494,7 +505,37 @@ def toggle_fullscreen(e: me.ClickEvent):
     state.panel_fullscreen = "preview"
 
 
-def demo_code(code_arg: str):
+_LANG_MAP: dict[str, str] = {
+  "py": "python",
+  "js": "javascript",
+  "ts": "typescript",
+  "css": "css",
+  "html": "html",
+}
+
+
+def _get_code_for_example(example: Example) -> tuple[str, str]:
+  """Returns (source_code, language) for the currently selected file."""
+  state = me.state(State)
+  module = get_module(example.name)
+  if not state.selected_file:
+    return inspect.getsource(module), "python"
+  module_dir = os.path.dirname(os.path.abspath(module.__file__))
+  path = os.path.join(module_dir, state.selected_file)
+  with open(path) as f:
+    code = f.read()
+  ext = state.selected_file.rsplit(".", 1)[-1] if "." in state.selected_file else ""
+  return code, _LANG_MAP.get(ext, "")
+
+
+def on_file_select(e: me.SelectSelectionChangeEvent):
+  me.state(State).selected_file = e.value
+
+
+def demo_code(example: Example):
+  state = me.state(State)
+  module = get_module(example.name)
+  main_filename = os.path.basename(module.__file__)
   with me.box(
     style=me.Style(
       flex_grow=1,
@@ -515,22 +556,39 @@ def demo_code(code_arg: str):
         background=me.theme_var("background"),
       )
     ):
-      me.text(
-        "Code",
-        style=me.Style(
-          font_weight=500,
-          padding=me.Padding.all(14),
-        ),
-      )
+      if example.extra_files:
+        me.select(
+          options=[
+            me.SelectOption(label=main_filename, value=""),
+            *[
+              me.SelectOption(
+                label=os.path.basename(f), value=f
+              )
+              for f in example.extra_files
+            ],
+          ],
+          value=state.selected_file,
+          on_selection_change=on_file_select,
+          style=me.Style(
+            margin=me.Margin(top=4, bottom=4, left=8),
+            width=220,
+          ),
+        )
+      else:
+        me.text(
+          "Code",
+          style=me.Style(
+            font_weight=500,
+            padding=me.Padding.all(14),
+          ),
+        )
       if not is_desktop():
         swap_button()
+    code, lang = _get_code_for_example(example)
     # Use four backticks for code fence to avoid conflicts with backticks being used
     # within the displayed code.
     me.markdown(
-      f"""````python
-{code_arg}
-````
-              """,
+      f"````{lang}\n{code}\n````",
       style=me.Style(
         border=me.Border(
           right=BORDER_SIDE,


### PR DESCRIPTION
- Add `extra_files: list[str]` to `Example` dataclass for listing
  additional files (relative to the demo's own directory) to show
  in the code panel
- Add `selected_file` to `State`; reset it on page load so navigating
  between demos always starts on the main Python file
- Build `ALL_EXAMPLES` lookup dict for O(1) name→Example access
- Rewrite `demo_code()` to show a file-select dropdown when a demo
  has extra files; derive file paths via `module.__file__` so both
  flat and subdirectory demos work without special-casing
- Auto-detect language for the code fence (py/js/ts/css/html)

https://claude.ai/code/session_01Noq84VqXg7nnYcDJAnrWPu