### PR TITLE
fix: use bracket notation to read sub-properties of __MESOP_EXPERIMENTS__

### DIFF
--- a/mesop/web/src/services/experiment_service.ts
+++ b/mesop/web/src/services/experiment_service.ts
@@ -13,8 +13,9 @@ export class ExperimentService {
 
   constructor() {
     const windowSettings = (window as any)['__MESOP_EXPERIMENTS__'];
-    this.settings = windowSettings ?? {
-      websocketsEnabled: false,
+    this.settings = {
+      websocketsEnabled: windowSettings?.['websocketsEnabled'] ?? false,
+      webComponentsCacheKey: windowSettings?.['webComponentsCacheKey'] ?? null,
     };
   }
 


### PR DESCRIPTION
## Summary

- Read `websocketsEnabled` and `webComponentsCacheKey` from the server-provided `windowSettings` object using bracket notation (`windowSettings?.['websocketsEnabled']`) to prevent Closure Compiler from mangling these property names at compile time
- Also fixes a latent bug where the fallback object was missing `webComponentsCacheKey`, causing the getter to return `undefined` instead of `null`

https://claude.ai/code/session_01JHTYDRqtzkgz1neR6SCRZf