### PR TITLE
Add support for multi-file demo screenshots

### DIFF
--- a/demo/screenshot.ts
+++ b/demo/screenshot.ts
@@ -3,12 +3,23 @@ import {test, expect} from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 
-// Filter for Python files (.py extension)
+// Single-file demos: root-level .py files
 const pythonDemoFiles = fs
   .readdirSync(__dirname)
   .filter((file) => path.extname(file) === '.py');
 
-console.log(pythonDemoFiles);
+// Multi-file demos: subdirectories that contain an app.py entry point
+const multiFileDemoDirs = fs
+  .readdirSync(__dirname, {withFileTypes: true})
+  .filter(
+    (entry) =>
+      entry.isDirectory() &&
+      fs.existsSync(path.join(__dirname, entry.name, 'app.py')),
+  )
+  .map((entry) => entry.name);
+
+console.log('Single-file demos:', pythonDemoFiles);
+console.log('Multi-file demos:', multiFileDemoDirs);
 
 // Remove the skip if you want to re-generate the screenshots.
 test.skip('screenshot each demo', async ({page}) => {
@@ -17,13 +28,23 @@ test.skip('screenshot each demo', async ({page}) => {
 
   await page.setViewportSize({width: 400, height: 300});
 
+  // Screenshot single-file demos
   for (const demoFile of pythonDemoFiles) {
     const demo = demoFile.slice(0, -3);
     await page.goto('/' + demo);
     await new Promise((resolve) => setTimeout(resolve, 3000));
-    // Take a full-page screenshot
     await page.screenshot({
       path: `demo/screenshots/${demo}.png`,
+      fullPage: true,
+    });
+  }
+
+  // Screenshot multi-file demos (entry point is app.py, URL is /dirname)
+  for (const demoDir of multiFileDemoDirs) {
+    await page.goto('/' + demoDir);
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    await page.screenshot({
+      path: `demo/screenshots/${demoDir}.png`,
       fullPage: true,
     });
   }


### PR DESCRIPTION
## Summary
Extended the screenshot generation script to support both single-file and multi-file demo structures. Previously, only root-level Python files were screenshotted. Now the script also discovers and screenshots multi-file demos organized in subdirectories with an `app.py` entry point.

## Key Changes
- Added detection logic for multi-file demos: subdirectories containing an `app.py` file
- Separated demo discovery into two categories with clearer variable names (`pythonDemoFiles` and `multiFileDemoDirs`)
- Updated console logging to distinguish between single-file and multi-file demos
- Extended the screenshot test to iterate over both demo types
- Added comments clarifying the purpose of each screenshot loop

## Implementation Details
- Multi-file demos are identified by checking for the presence of `app.py` within subdirectories using `fs.existsSync()`
- Both demo types follow the same screenshot pattern: navigate to the URL, wait 3 seconds, then capture a full-page screenshot
- The URL structure remains consistent: single-file demos use `/filename` and multi-file demos use `/dirname`

https://claude.ai/code/session_01PK891QAtNQJjscAUmvUD5a