### PR TITLE
add event-driven auth recovery for WebSockets behind proxies

### DIFF
--- a/mesop/env/env.py
+++ b/mesop/env/env.py
@@ -48,6 +48,11 @@ MESOP_WEBSOCKETS_ENABLED = (
   os.environ.get("MESOP_WEBSOCKETS_ENABLED", "false").lower() == "true"
 )
 
+MESOP_WEBSOCKETS_PROBE_ON_DISCONNECT = (
+  os.environ.get("MESOP_WEBSOCKETS_PROBE_ON_DISCONNECT", "false").lower()
+  == "true"
+)
+
 MESOP_HTTP_CACHE_JS_BUNDLE = (
   os.environ.get("MESOP_HTTP_CACHE_JS_BUNDLE", "false").lower() == "true"
 )

--- a/mesop/server/static_file_serving.py
+++ b/mesop/server/static_file_serving.py
@@ -19,6 +19,7 @@ from mesop.env.env import (
   MESOP_HTTP_CACHE_JS_BUNDLE,
   MESOP_WEB_COMPONENTS_HTTP_CACHE_KEY,
   MESOP_WEBSOCKETS_ENABLED,
+  MESOP_WEBSOCKETS_PROBE_ON_DISCONNECT,
   get_app_base_path,
 )
 from mesop.exceptions import MesopException
@@ -103,6 +104,7 @@ def configure_static_file_serving(
         experiment_settings = {
           "websocketsEnabled": MESOP_WEBSOCKETS_ENABLED,
           "webComponentsCacheKey": MESOP_WEB_COMPONENTS_HTTP_CACHE_KEY,
+          "websocketsProbeOnDisconnect": MESOP_WEBSOCKETS_PROBE_ON_DISCONNECT,
         }
         lines[i] = f"""
           <script nonce="{g.csp_nonce}">
@@ -133,6 +135,12 @@ def configure_static_file_serving(
     return send_file(
       get_path("sandbox_iframe.html"), download_name="sandbox_iframe.html"
     )
+
+  @app.route(prefix_base_url("/__health__"), methods=["GET", "HEAD"])
+  def serve_health():
+    response = make_response("OK")
+    response.headers["Cache-Control"] = "no-store"
+    return response
 
   @app.route(prefix_base_url(f"/{WEB_COMPONENTS_PATH_SEGMENT}/<path:path>"))
   def serve_web_components(path: str):

--- a/mesop/web/src/services/channel.ts
+++ b/mesop/web/src/services/channel.ts
@@ -59,6 +59,7 @@ export class Channel {
   private webSocket: WebSocket | undefined;
   private wsReconnectAttempts = 0;
   private wsMaxReconnectAttempts = 3;
+  private isProbing = false;
   private initParams!: InitParams;
   private states: States = new States();
   private stateToken = '';
@@ -91,10 +92,40 @@ export class Channel {
       userEvent.setChangePrefersColorScheme(new ChangePrefersColorScheme());
       this.dispatch(userEvent);
     });
+
+    window.addEventListener('focus', async () => {
+      if (
+        this.isWebSocketDead &&
+        this.experimentService.websocketsProbeOnDisconnect &&
+        !this.isProbing
+      ) {
+        this.isProbing = true;
+        try {
+          console.debug('Window focused, probing connection...');
+          const isRedirected = await this.probeConnection();
+          if (!isRedirected) {
+            console.debug('Auth restored, retrying connection...');
+            const refreshRequest = this.createInitRequest();
+            this.init(this.initParams, refreshRequest);
+          }
+        } finally {
+          this.isProbing = false;
+        }
+      }
+    });
   }
 
   getStatus(): ChannelStatus {
     return this.status;
+  }
+
+  private get isWebSocketDead(): boolean {
+    return (
+      this.experimentService.websocketsEnabled &&
+      !!this.webSocket &&
+      (this.webSocket.readyState === WebSocket.CLOSED ||
+        this.webSocket.readyState === WebSocket.CLOSING)
+    );
   }
 
   isHotReloading(): boolean {
@@ -445,18 +476,26 @@ export class Channel {
     };
 
     if (this.status === ChannelStatus.CLOSED) {
-      const isWebSocketDead =
-        this.experimentService.websocketsEnabled &&
-        this.webSocket &&
-        (this.webSocket.readyState === WebSocket.CLOSED ||
-          this.webSocket.readyState === WebSocket.CLOSING);
-
-      if (isWebSocketDead) {
+      if (this.isWebSocketDead) {
         this.queuedEvents.push(initUserEvent);
 
         const refreshRequest = this.createInitRequest();
 
-        this.init(this.initParams, refreshRequest);
+        if (this.experimentService.websocketsProbeOnDisconnect) {
+          this.probeConnection().then((isRedirected) => {
+            if (isRedirected) {
+              window.dispatchEvent(
+                new CustomEvent('mesop:auth-required', {
+                  detail: {url: window.location.href},
+                }),
+              );
+            } else {
+              this.init(this.initParams, refreshRequest);
+            }
+          });
+        } else {
+          this.init(this.initParams, refreshRequest);
+        }
       } else {
         initUserEvent();
       }
@@ -490,6 +529,28 @@ export class Channel {
     if (this.queuedEvents.length) {
       const queuedEvent = this.queuedEvents.shift()!;
       queuedEvent();
+    }
+  }
+
+  /**
+   * Probes the connection to check if the session is still valid or if it has
+   * been redirected by a proxy (e.g., to an SSO login page).
+   *
+   * We use `redirect: 'manual'` to detect redirects without following them,
+   * which avoids CORS issues if the redirect points to a different domain.
+   *
+   * @returns true if a redirect was detected (meaning session expired), false otherwise.
+   */
+  private async probeConnection(): Promise<boolean> {
+    try {
+      const response = await fetch(prefixBasePath('/__health__'), {
+        method: 'HEAD',
+        redirect: 'manual',
+      });
+      return response.type === 'opaqueredirect';
+    } catch (error) {
+      console.error('Probe connection error:', error);
+      return false;
     }
   }
 

--- a/mesop/web/src/services/experiment_service.ts
+++ b/mesop/web/src/services/experiment_service.ts
@@ -3,6 +3,7 @@ import {Injectable} from '@angular/core';
 interface ExperimentSettings {
   readonly websocketsEnabled: boolean;
   readonly webComponentsCacheKey: string | null;
+  readonly websocketsProbeOnDisconnect: boolean;
 }
 
 @Injectable({
@@ -16,11 +17,16 @@ export class ExperimentService {
     this.settings = {
       websocketsEnabled: windowSettings?.['websocketsEnabled'] ?? false,
       webComponentsCacheKey: windowSettings?.['webComponentsCacheKey'] ?? null,
+      websocketsProbeOnDisconnect:
+        windowSettings?.['websocketsProbeOnDisconnect'] ?? false,
     };
   }
 
   get websocketsEnabled(): boolean {
     return this.settings.websocketsEnabled;
+  }
+  get websocketsProbeOnDisconnect(): boolean {
+    return this.settings.websocketsProbeOnDisconnect;
   }
   get webComponentsCacheKey(): string | null {
     return this.settings.webComponentsCacheKey;


### PR DESCRIPTION
Opt-in, event-driven solution to allow applications to handle this gracefully without forcing a destructive full-page reload that loses user state.

1. HTTP Probe: When the connection is detected as dead during user interaction, the client performs a lightweight HTTP probe using fetch with `redirect: 'manual'`.
2. Event Emission: If a redirect is detected (indicating session expiry), the framework emits a `mesop:auth-required` CustomEvent on the `window` object, passing the target URL in the details.
3. Proactive Recovery: The framework listens for the `focus` event on the `window`. When the user returns to the tab (presumably after completing the authentication flow in another window or tab), it probes again and automatically reconnects if successful.

fixes #1389 